### PR TITLE
Upgrade melcloud-api to 24.0.1

### DIFF
--- a/app.mts
+++ b/app.mts
@@ -484,7 +484,9 @@ export default class MELCloudApp extends App {
     set: (key: string, value: string) => void
   } {
     const prefixKey = (key: string): string =>
-      prefix === '' ? key : `${prefix}${key.charAt(0).toUpperCase()}${key.slice(1)}`
+      prefix === '' ? key : (
+        `${prefix}${key.charAt(0).toUpperCase()}${key.slice(1)}`
+      )
     return {
       get: (key: string): string | null | undefined =>
         // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- Homey settings.get returns unknown

--- a/app.mts
+++ b/app.mts
@@ -479,12 +479,12 @@ export default class MELCloudApp extends App {
     }
   }
 
-  #createSettingManager(prefix: string): {
+  #createSettingManager(prefix = ''): {
     get: (key: string) => string | null | undefined
     set: (key: string, value: string) => void
   } {
     const prefixKey = (key: string): string =>
-      `${prefix}${key.charAt(0).toUpperCase()}${key.slice(1)}`
+      prefix === '' ? key : `${prefix}${key.charAt(0).toUpperCase()}${key.slice(1)}`
     return {
       get: (key: string): string | null | undefined =>
         // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- Homey settings.get returns unknown
@@ -566,7 +566,7 @@ export default class MELCloudApp extends App {
     this.#api = await ClassicAPI.create({
       language,
       logger: this.#createLogger(),
-      settingManager: this.homey.settings,
+      settingManager: this.#createSettingManager(),
       timezone,
       onSync: async (params) => {
         const { ids, type } = params ?? {}

--- a/package-lock.json
+++ b/package-lock.json
@@ -618,9 +618,9 @@
       }
     },
     "node_modules/@olivierzal/melcloud-api": {
-      "version": "24.0.0",
-      "resolved": "https://npm.pkg.github.com/download/@olivierzal/melcloud-api/24.0.0/90ef213bd34932e77a42222b81ff5a4fd5afe941",
-      "integrity": "sha512-f+88NPEjVGaGA0qXyg0CLDjTejezyY1ES/EvQCPzUlAbWkwnqQKlaGRmEK77z34Y00fSDyktOKF6IkKRLmFmtA==",
+      "version": "24.0.1",
+      "resolved": "https://npm.pkg.github.com/download/@olivierzal/melcloud-api/24.0.1/4cf6a23244edb57f59d749a28f264051843bea33",
+      "integrity": "sha512-P1zlE3+pG1f7RFtolpMFLgkjOHi82fvya4K78+0gFeCax3UPhhYSFw+Yxg5TZOQ0G46/0oMa5mi5Ji5GotO2CA==",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.14.0",

--- a/tests/unit/app.test.ts
+++ b/tests/unit/app.test.ts
@@ -842,6 +842,24 @@ describe('melCloudApp', () => {
 
       expect(mockSettingsSet).toHaveBeenCalledWith('homePassword', 'secret')
     })
+
+    it('should create classic setting manager without key prefixing', async () => {
+      await app.onInit()
+
+      const { settingManager } = getMockCallArg<{
+        settingManager: {
+          get: (key: string) => unknown
+          set: (key: string, value: string) => void
+        }
+      }>(mockCreate, 0, 0)
+      settingManager.get('contextKey')
+
+      expect(mockSettingsGet).toHaveBeenCalledWith('contextKey')
+
+      settingManager.set('expiry', '2026-12-31')
+
+      expect(mockSettingsSet).toHaveBeenCalledWith('expiry', '2026-12-31')
+    })
   })
 
   describe('ata value update', () => {

--- a/types/settings.mts
+++ b/types/settings.mts
@@ -45,8 +45,10 @@ export interface FormattedErrorLog extends Omit<
 export interface HomeySettings {
   readonly contextKey?: string | null
   readonly expiry?: string | null
+  readonly homeAccessToken?: string | null
   readonly homeExpiry?: string | null
   readonly homePassword?: string | null
+  readonly homeRefreshToken?: string | null
   readonly homeUsername?: string | null
   readonly notifiedVersion?: string | null
   readonly password?: string | null


### PR DESCRIPTION
## Summary

- Upgrade `@olivierzal/melcloud-api` from 24.0.0 to 24.0.1
- Home API now uses the mobile BFF (`mobile.bff.melcloudhome.com`) with Bearer token auth instead of the cookie-based web BFF (`melcloudhome.com`)
- Settings change: `homeCookies` replaced by `homeAccessToken` + `homeRefreshToken` — existing sessions will require one-time re-authentication

## Test plan

- [ ] `homey app run` and verify Home API devices sync via mobile BFF
- [ ] Verify Classic API devices still work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)