### PR TITLE
chore(deps): upgrade @olivierzal/melcloud-api to 32.0.0

### DIFF
--- a/drivers/classic-device.mts
+++ b/drivers/classic-device.mts
@@ -75,7 +75,7 @@ export abstract class ClassicMELCloudDevice<
     return this.cachedFacade as Classic.DeviceFacade<T> | undefined
   }
 
-  get #data(): Classic.ListDeviceData<T> | undefined {
+  get #data(): Readonly<Classic.ListDeviceData<T>> | undefined {
     return this.facade?.data
   }
 
@@ -113,7 +113,7 @@ export abstract class ClassicMELCloudDevice<
   }
 
   protected async setCapabilityValues(
-    data: Classic.ListDeviceData<T>,
+    data: Readonly<Classic.ListDeviceData<T>>,
   ): Promise<void> {
     this.homey.api.realtime('deviceupdate', null)
     // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- narrowing shared [string, string][] to typed entries
@@ -134,14 +134,14 @@ export abstract class ClassicMELCloudDevice<
   #convertFromDevice<TKey extends keyof Capabilities<T>>(
     capability: TKey,
     value: Classic.ListDeviceData<T>[keyof Classic.ListDeviceData<T>],
-    data?: Classic.ListDeviceData<T>,
+    data?: Readonly<Classic.ListDeviceData<T>>,
   ): Capabilities<T>[TKey] {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- converter output narrowed to specific capability type
     return (this.deviceToCapability[capability]?.(value, data) ??
       value) as Capabilities<T>[TKey]
   }
 
-  async #getDeviceData(): Promise<Classic.ListDeviceData<T> | null> {
+  async #getDeviceData(): Promise<Readonly<Classic.ListDeviceData<T>> | null> {
     try {
       if (this.#data) {
         return this.#data

--- a/drivers/classic-driver.mts
+++ b/drivers/classic-driver.mts
@@ -20,7 +20,7 @@ export abstract class ClassicMELCloudDriver<
   public abstract override readonly energyCapabilityTagMapping: EnergyCapabilityTagMapping<T>
 
   public abstract override readonly getCapabilitiesOptions: (
-    data: Classic.ListDeviceData<T>,
+    data: Readonly<Classic.ListDeviceData<T>>,
   ) => Partial<CapabilitiesOptions<T>>
 
   public abstract override readonly getCapabilityTagMapping: GetCapabilityTagMapping<T>
@@ -47,11 +47,11 @@ export abstract class ClassicMELCloudDriver<
   }
 
   public abstract override getRequiredCapabilities(
-    data?: Classic.ListDeviceData<T>,
+    data?: Readonly<Classic.ListDeviceData<T>>,
   ): string[]
 
   protected override getDeviceModels(): {
-    data: Classic.ListDeviceData<T>
+    data: Readonly<Classic.ListDeviceData<T>>
     id: number
     name: string
   }[] {
@@ -63,7 +63,7 @@ export abstract class ClassicMELCloudDriver<
     id,
     name,
   }: {
-    data: Classic.ListDeviceData<T>
+    data: Readonly<Classic.ListDeviceData<T>>
     id: number
     name: string
   }): DeviceDetails<T> {

--- a/drivers/melcloud_atw/device.mts
+++ b/drivers/melcloud_atw/device.mts
@@ -103,7 +103,7 @@ export default class ClassicMELCloudDeviceAtw extends ClassicMELCloudDevice<
   protected readonly thermostatMode = null
 
   protected override async setCapabilityValues(
-    data: Classic.ListDeviceData<typeof Classic.DeviceType.Atw>,
+    data: Readonly<Classic.ListDeviceData<typeof Classic.DeviceType.Atw>>,
   ): Promise<void> {
     await super.setCapabilityValues(data)
     await this.#setOperationModeStates()

--- a/drivers/melcloud_atw/driver.mts
+++ b/drivers/melcloud_atw/driver.mts
@@ -66,7 +66,7 @@ export default class ClassicMELCloudDriverAtw extends ClassicMELCloudDriver<
   >)[] = ['target_temperature.flow_cool_zone2']
 
   public override getRequiredCapabilities(
-    data?: Classic.ListDeviceData<typeof Classic.DeviceType.Atw>,
+    data?: Readonly<Classic.ListDeviceData<typeof Classic.DeviceType.Atw>>,
   ): string[] {
     /* v8 ignore next -- data is always provided by callers */
     const { CanCool: canCool, HasZone2: hasClassicZone2 } = data ?? {}

--- a/drivers/melcloud_erv/driver.mts
+++ b/drivers/melcloud_erv/driver.mts
@@ -33,7 +33,9 @@ export default class ClassicMELCloudDriverErv extends ClassicMELCloudDriver<
   public getRequiredCapabilities({
     HasCO2Sensor: hasCO2Sensor,
     HasPM25Sensor: hasPM25Sensor,
-  }: Classic.ListDeviceData<typeof Classic.DeviceType.Erv>): string[] {
+  }: Readonly<
+    Classic.ListDeviceData<typeof Classic.DeviceType.Erv>
+  >): string[] {
     return [
       ...this.manifest.capabilities.filter(
         (capability) => !measureCapabilities.has(capability),

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "44.0.1",
       "license": "GPL-3.0-only",
       "dependencies": {
-        "@olivierzal/melcloud-api": "^31.0.3",
+        "@olivierzal/melcloud-api": "^32.0.0",
         "homey-lib": "^2.49.0",
         "luxon": "^3.7.2"
       },
@@ -618,14 +618,15 @@
       }
     },
     "node_modules/@olivierzal/melcloud-api": {
-      "version": "31.0.3",
-      "resolved": "https://npm.pkg.github.com/download/@olivierzal/melcloud-api/31.0.3/d70be1d5a0b0cfc2a4d2abc5cd441bba3fdb9c32",
-      "integrity": "sha512-Xt3EPMTsq10EFSOByp5uuTM9MhYLDx1/GKZCe5WQ2ZMxNCVrd6swsWfNt6YnNSm59+BPhAePuxHjmuDJ077X/A==",
+      "version": "32.0.0",
+      "resolved": "https://npm.pkg.github.com/download/@olivierzal/melcloud-api/32.0.0/9a4a31bdcab821b0e9e2b6fb7085253808288232",
+      "integrity": "sha512-WKlvRhvGNnDouKGMeoe9tVfO6LB7UQfdWfbPaC0bRmM+VhcQCGbYOCshVT5fVCT4BZR7eVq8m5HDo/vgzCvXMQ==",
       "license": "MIT",
       "dependencies": {
-        "axios": "^1.14.0",
         "luxon": "^3.7.2",
-        "tough-cookie": "^6.0.1"
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "zod": "^4.3.6"
       },
       "engines": {
         "node": ">=22"
@@ -2848,23 +2849,6 @@
         "js-tokens": "^10.0.0"
       }
     },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT"
-    },
-    "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.11",
-        "form-data": "^4.0.5",
-        "proxy-from-env": "^2.1.0"
-      }
-    },
     "node_modules/balanced-match": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
@@ -2992,19 +2976,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/call-bind-apply-helpers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001780",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001780.tgz",
@@ -3102,18 +3073,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
-      }
-    },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/commander": {
@@ -3242,15 +3201,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -3321,20 +3271,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/dunder-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.321",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.321.tgz",
@@ -3356,24 +3292,6 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/es-define-property": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-errors": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/es-html-parser": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/es-html-parser/-/es-html-parser-0.3.1.tgz",
@@ -3387,33 +3305,6 @@
       "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-set-tostringtag": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
-      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.6",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -4090,42 +3981,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/follow-redirects": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
-      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/format": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
@@ -4148,52 +4003,6 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
-    "node_modules/function-bind": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-intrinsic": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "es-define-property": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.1.1",
-        "function-bind": "^1.1.2",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "has-symbols": "^1.1.0",
-        "hasown": "^2.0.2",
-        "math-intrinsics": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "license": "MIT",
-      "dependencies": {
-        "dunder-proto": "^1.0.1",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/get-tsconfig": {
@@ -4252,18 +4061,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/gopd": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -4279,45 +4076,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/has-symbols": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-tostringtag": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "license": "MIT",
-      "dependencies": {
-        "has-symbols": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/homey-apps-sdk-v3-types": {
@@ -5056,15 +4814,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/math-intrinsics": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/mdast-util-find-and-replace": {
@@ -5967,27 +5716,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/minimatch": {
       "version": "10.2.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
@@ -6315,15 +6043,6 @@
         "prettier": {
           "optional": true
         }
-      }
-    },
-    "node_modules/proxy-from-env": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
-      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/punycode": {
@@ -6793,6 +6512,15 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -7312,6 +7040,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zwitch": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@olivierzal/melcloud-api": "^31.0.3",
+    "@olivierzal/melcloud-api": "^32.0.0",
     "homey-lib": "^2.49.0",
     "luxon": "^3.7.2"
   },

--- a/types/ata-erv.mts
+++ b/types/ata-erv.mts
@@ -23,9 +23,9 @@ const getFanSpeedOptions = (
 export const getCapabilitiesOptionsAtaErv = ({
   HasAutomaticFanSpeed: hasAutomaticFanSpeed,
   NumberOfFanSpeeds: numberOfFanSpeeds,
-}:
-  | Classic.ListDeviceDataAta
-  | Classic.ListDeviceDataErv): Partial<CapabilitiesOptionsAtaErv> =>
+}: Readonly<
+  Classic.ListDeviceDataAta | Classic.ListDeviceDataErv
+>): Partial<CapabilitiesOptionsAtaErv> =>
   getFanSpeedOptions(hasAutomaticFanSpeed, numberOfFanSpeeds)
 
 export const homeGetCapabilitiesOptions = ({

--- a/types/capabilities.mts
+++ b/types/capabilities.mts
@@ -49,7 +49,7 @@ export type ConvertFromDevice<T extends Classic.DeviceType> = {
   // eslint-disable-next-line @typescript-eslint/method-signature-style -- method syntax required for bivariant type checking
   bivariant(
     value: Classic.ListDeviceData<T>[keyof Classic.ListDeviceData<T>],
-    data?: Classic.ListDeviceData<T>,
+    data?: Readonly<Classic.ListDeviceData<T>>,
   ): OperationalCapabilities<T>[keyof OperationalCapabilities<T>]
 }['bivariant']
 

--- a/types/classic-atw.mts
+++ b/types/classic-atw.mts
@@ -150,7 +150,7 @@ const thermostatModeValuesAtw = [
 export const getCapabilitiesOptions = ({
   CanCool: canCool,
   HasZone2: hasClassicZone2,
-}: Classic.ListDeviceDataAtw): Partial<CapabilitiesOptions> => {
+}: Readonly<Classic.ListDeviceDataAtw>): Partial<CapabilitiesOptions> => {
   const values =
     canCool ?
       thermostatModeValuesAtw


### PR DESCRIPTION
## Summary
- Bump `@olivierzal/melcloud-api` from `^31.0.3` to `^32.0.0` (PR #1465 upstream — "Refactor: simplify API surface and strengthen immutability")
- Propagate `Readonly<Classic.ListDeviceData<T>>` on consumer signatures that receive device data from `facade.data` / `device.data` — 32.0.0 tightens those getters to `Readonly<>`.
- No import path changes required: `/classic` and `/home` subpaths and their aliased re-exports are preserved.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm test` — 382/382 passing
- [x] `npm run build` — OK (includes `build:constants`)
- [x] `npm run homey:validate` — passes at `publish` level
- [ ] Smoke test on Homey (`npm run homey:start`): auth, sync, one device of each type (ATA, ATW w/ zone2, ERV, home-melcloud), error log, charts widget

🤖 Generated with [Claude Code](https://claude.com/claude-code)