### PR TITLE
refactor: code review modernization (6 bundles)

### DIFF
--- a/app.mts
+++ b/app.mts
@@ -473,8 +473,8 @@ export default class MELCloudApp extends App {
   }
 
   /*
-   * ATA capability configuration. `enumType` maps Homey's string capability IDs
-   * to MELCloud's numeric enum values for localization
+   * Sync matching classic devices by pulling their latest state from MELCloud.
+   * Per-device sync failures are logged without aborting the full sync run.
    */
   async #classicSyncDevices(
     filter: { driverId?: string; ids?: (number | string)[] } = {},

--- a/app.mts
+++ b/app.mts
@@ -472,6 +472,23 @@ export default class MELCloudApp extends App {
     })
   }
 
+  /*
+   * ATA capability configuration. `enumType` maps Homey's string capability IDs
+   * to MELCloud's numeric enum values for localization
+   */
+  async #classicSyncDevices(
+    filter: { driverId?: string; ids?: (number | string)[] } = {},
+  ): Promise<void> {
+    const results = await Promise.allSettled(
+      this.#getDevices(filter).map(async (device) => device.syncFromDevice()),
+    )
+    for (const result of results) {
+      if (result.status === 'rejected') {
+        this.error('Device sync failed:', result.reason)
+      }
+    }
+  }
+
   #createLogger(): Logger {
     return {
       error: (...args: unknown[]): void => {
@@ -523,41 +540,6 @@ export default class MELCloudApp extends App {
       set: (key: string, value: string): void => {
         this.homey.settings.set(prefixKey(key), value)
       },
-    }
-  }
-
-  /*
-   * SDK v3 runs `App#onInit` before any `Driver#onInit`, so `onSync`
-   * callbacks fired by the MELCloud API clients during `#initClassicApi`
-   * / `#initHomeApi` find no ready drivers. Awaiting driver readiness
-   * would deadlock: drivers can't init until `App#onInit` returns, which
-   * awaits these API-client constructors. `getDrivers()` only exposes
-   * drivers whose `onInit` has completed, so unready drivers are filtered
-   * out naturally — an initial sync silently becomes a no-op. Each device
-   * runs its own initial sync via `ensureDevice()` in `Device#onInit`,
-   * and post-init `onSync` calls find every driver ready.
-   */
-  #getDrivers(driverId?: string): MELCloudDriver[] {
-    const drivers = Object.values(this.homey.drivers.getDrivers())
-    return driverId === undefined ? drivers : (
-        drivers.filter((driver) => driver.id === driverId)
-      )
-  }
-
-  /*
-   * ATA capability configuration. `enumType` maps Homey's string capability IDs
-   * to MELCloud's numeric enum values for localization
-   */
-  async #classicSyncDevices(
-    filter: { driverId?: string; ids?: (number | string)[] } = {},
-  ): Promise<void> {
-    const results = await Promise.allSettled(
-      this.#getDevices(filter).map(async (device) => device.syncFromDevice()),
-    )
-    for (const result of results) {
-      if (result.status === 'rejected') {
-        this.error('Device sync failed:', result.reason)
-      }
     }
   }
 
@@ -614,6 +596,24 @@ export default class MELCloudApp extends App {
           devices.filter(({ id }) => stringIds.includes(String(id)))
         : devices
     })
+  }
+
+  /*
+   * SDK v3 runs `App#onInit` before any `Driver#onInit`, so `onSync`
+   * callbacks fired by the MELCloud API clients during `#initClassicApi`
+   * / `#initHomeApi` find no ready drivers. Awaiting driver readiness
+   * would deadlock: drivers can't init until `App#onInit` returns, which
+   * awaits these API-client constructors. `getDrivers()` only exposes
+   * drivers whose `onInit` has completed, so unready drivers are filtered
+   * out naturally — an initial sync silently becomes a no-op. Each device
+   * runs its own initial sync via `ensureDevice()` in `Device#onInit`,
+   * and post-init `onSync` calls find every driver ready.
+   */
+  #getDrivers(driverId?: string): MELCloudDriver[] {
+    const drivers = Object.values(this.homey.drivers.getDrivers())
+    return driverId === undefined ? drivers : (
+        drivers.filter((driver) => driver.id === driverId)
+      )
   }
 
   async #initClassicApi(config: {

--- a/drivers/base-device.mts
+++ b/drivers/base-device.mts
@@ -145,12 +145,14 @@ export abstract class BaseMELCloudDevice extends Device {
   public cleanMapping<TMapping extends Readonly<Record<string, unknown>>>(
     capabilityTagMapping: TMapping,
   ): Partial<TMapping> {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- Object.fromEntries widens generic keys; filtered entries retain source value types
-    return Object.fromEntries(
-      Object.entries(capabilityTagMapping).filter(([capability]) =>
-        this.hasCapability(capability),
-      ),
-    ) as Partial<TMapping>
+    const result: Partial<TMapping> = {}
+    for (const capability in capabilityTagMapping) {
+      if (this.hasCapability(capability)) {
+        const { [capability]: tag } = capabilityTagMapping
+        result[capability] = tag
+      }
+    }
+    return result
   }
 
   public async ensureDevice(): Promise<ClassicDeviceFacade | null> {
@@ -253,13 +255,14 @@ export abstract class BaseMELCloudDevice extends Device {
   ): Record<string, unknown> {
     this.log('Requested data:', values)
     const tagMapping = this.#setCapabilityTagMapping
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- Object.fromEntries returns { [k: string]: any }
-    return Object.fromEntries(
-      Object.entries(values).map(([capability, value]) => [
-        tagMapping[capability],
-        this.capabilityToDevice[capability]?.(value) ?? value,
-      ]),
-    ) as Record<string, unknown>
+    const result: Record<string, unknown> = {}
+    for (const [capability, value] of Object.entries(values)) {
+      const { [capability]: tag } = tagMapping
+      if (tag !== undefined) {
+        result[tag] = this.capabilityToDevice[capability]?.(value) ?? value
+      }
+    }
+    return result
   }
 
   protected async scheduleEnergyReports(): Promise<void> {

--- a/drivers/base-device.mts
+++ b/drivers/base-device.mts
@@ -68,19 +68,23 @@ export abstract class BaseMELCloudDevice extends Device {
       ...this.#setCapabilityTagMapping,
       ...this.#getCapabilityTagMapping,
       ...this.#listCapabilityTagMapping,
-    })
+    }).filter(
+      (entry): entry is [string, string] => entry[1] !== undefined,
+    )
   }
 
   #deviceFacade?: ClassicDeviceFacade
 
-  #getCapabilityTagMapping: Record<string, string> = {}
+  #getCapabilityTagMapping: Partial<Readonly<Record<string, string>>> = {}
+
+  #listCapabilityTagMapping: Partial<Readonly<Record<string, string>>> = {}
 
   readonly #reports: {
     regular?: EnergyReportOperation
     total?: EnergyReportOperation
   } = {}
 
-  #setCapabilityTagMapping: Record<string, string> = {}
+  #setCapabilityTagMapping: Partial<Readonly<Record<string, string>>> = {}
 
   public override async onInit(): Promise<void> {
     this.capabilityToDevice = {
@@ -140,22 +144,16 @@ export abstract class BaseMELCloudDevice extends Device {
     }
   }
 
-  public cleanMapping(
-    capabilityTagMapping: Record<string, unknown>,
-  ): Record<string, string> {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- driver tag mappings are Record<string, string> at runtime; unknown comes from BaseMELCloudDriver's broad type
+  public cleanMapping<TMapping extends Readonly<Record<string, unknown>>>(
+    capabilityTagMapping: TMapping,
+  ): Partial<TMapping> {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- Object.fromEntries widens generic keys; filtered entries retain source value types
     return Object.fromEntries(
       Object.entries(capabilityTagMapping).filter(([capability]) =>
         this.hasCapability(capability),
       ),
-    ) as Record<string, string>
+    ) as Partial<TMapping>
   }
-
-  /* v8 ignore start -- trivial override: prepends device name to all error logs */
-  public override error(...args: unknown[]): void {
-    super.error(this.getName(), '-', ...args)
-  }
-  /* v8 ignore stop */
 
   public async ensureDevice(): Promise<ClassicDeviceFacade | null> {
     try {
@@ -170,13 +168,17 @@ export abstract class BaseMELCloudDevice extends Device {
     }
   }
 
+  /* v8 ignore start -- trivial override: prepends device name to all error logs */
+  public override error(...args: unknown[]): void {
+    super.error(this.getName(), '-', ...args)
+  }
+  /* v8 ignore stop */
+
   /* v8 ignore start -- trivial override: prepends device name to all logs */
   public override log(...args: unknown[]): void {
     super.log(this.getName(), '-', ...args)
   }
   /* v8 ignore stop */
-
-  #listCapabilityTagMapping: Record<string, string> = {}
 
   public override async removeCapability(capability: string): Promise<void> {
     if (this.hasCapability(capability)) {

--- a/drivers/base-device.mts
+++ b/drivers/base-device.mts
@@ -68,9 +68,7 @@ export abstract class BaseMELCloudDevice extends Device {
       ...this.#setCapabilityTagMapping,
       ...this.#getCapabilityTagMapping,
       ...this.#listCapabilityTagMapping,
-    }).filter(
-      (entry): entry is [string, string] => entry[1] !== undefined,
-    )
+    }).filter((entry): entry is [string, string] => entry[1] !== undefined)
   }
 
   #deviceFacade?: ClassicDeviceFacade

--- a/drivers/base-driver.mts
+++ b/drivers/base-driver.mts
@@ -28,13 +28,21 @@ export abstract class BaseMELCloudDriver extends Driver {
 
   public abstract readonly type: DeviceType
 
-  public readonly energyCapabilityTagMapping: Record<string, unknown> = {}
+  public readonly energyCapabilityTagMapping: Readonly<
+    Record<string, readonly string[]>
+  > = {}
 
-  public readonly getCapabilityTagMapping: Record<string, unknown> = {}
+  public readonly getCapabilityTagMapping: Readonly<Record<string, string>> = {}
 
-  public readonly listCapabilityTagMapping: Record<string, unknown> = {}
+  public readonly listCapabilityTagMapping: Readonly<Record<string, string>> =
+    {}
 
-  public readonly setCapabilityTagMapping: Record<string, unknown> = {}
+  public readonly setCapabilityTagMapping: Readonly<Record<string, string>> = {}
+
+  public override async onInit(): Promise<void> {
+    this.#registerFlowListeners()
+    await Promise.resolve()
+  }
 
   public override async onPair(session: PairSession): Promise<void> {
     session.setHandler('showView', async (view) => {
@@ -56,11 +64,10 @@ export abstract class BaseMELCloudDriver extends Driver {
     await Promise.resolve()
   }
 
-  #registerLoginHandler(session: PairSession): void {
-    session.setHandler('login', async (data: Classic.LoginCredentials) =>
-      this.api.authenticate(data),
-    )
-  }
+  protected abstract getDeviceModels(): {
+    id: number | string
+    name: string
+  }[]
 
   /* v8 ignore start -- default implementation; always overridden by classic or test mock */
   // eslint-disable-next-line @typescript-eslint/class-methods-use-this -- polymorphic default; overridden by subclasses that use this
@@ -71,16 +78,6 @@ export abstract class BaseMELCloudDriver extends Driver {
     return {}
   }
   /* v8 ignore stop */
-
-  public override async onInit(): Promise<void> {
-    this.#registerFlowListeners()
-    await Promise.resolve()
-  }
-
-  protected abstract getDeviceModels(): {
-    id: number | string
-    name: string
-  }[]
 
   public getRequiredCapabilities(): string[] {
     return [...this.manifest.capabilities]
@@ -146,5 +143,11 @@ export abstract class BaseMELCloudDriver extends Driver {
         })
       }
     }
+  }
+
+  #registerLoginHandler(session: PairSession): void {
+    session.setHandler('login', async (data: Classic.LoginCredentials) =>
+      this.api.authenticate(data),
+    )
   }
 }

--- a/drivers/base-report.mts
+++ b/drivers/base-report.mts
@@ -11,7 +11,6 @@ import type {
   Capabilities,
   EnergyCapabilities,
   EnergyCapabilityTagEntry,
-  EnergyCapabilityTagMapping,
 } from '../types/capabilities.mts'
 import type { EnergyReportMode } from '../types/device.mts'
 import { KILOWATT_TO_WATT } from '../lib/constants.mts'
@@ -50,10 +49,9 @@ export class EnergyReport<T extends Classic.DeviceType> {
   private readonly driver: ClassicMELCloudDriver<T>
 
   get #energyCapabilityTagEntries(): EnergyCapabilityTagEntry<T>[] {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- cleanMapping returns Record<string, string>; energy mapping has typed keys/values at runtime
     const cleaned = this.#device.cleanMapping(
       this.driver.energyCapabilityTagMapping,
-    ) as unknown as Partial<EnergyCapabilityTagMapping<T>>
+    )
     return typedEntries<
       string & keyof EnergyCapabilities<T>,
       readonly (keyof Classic.EnergyData<T>)[]

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -264,6 +264,7 @@ const config = defineConfig([
         'error',
         {
           ignore: [-1, 0, 1, 2],
+          ignoreEnums: true,
           ignoreNumericLiteralTypes: true,
           ignoreReadonlyClassProperties: true,
           ignoreTypeIndexes: true,

--- a/lib/validation.mts
+++ b/lib/validation.mts
@@ -1,0 +1,52 @@
+import type { HourNumbers } from 'luxon'
+
+const HOUR_MIN = 0
+const HOUR_MAX = 23
+
+interface PositiveIntOptions {
+  readonly field?: string
+  readonly max?: number
+}
+
+const fieldPrefix = (field?: string): string =>
+  field === undefined || field === '' ? '' : `${field}: `
+
+/**
+ * Parses `value` as a positive finite integer. Throws if the input cannot be
+ * coerced cleanly (non-numeric string, NaN, non-finite, negative, fractional,
+ * or above the optional `max` bound).
+ */
+export const toPositiveInt = (
+  value: unknown,
+  { field, max }: PositiveIntOptions = {},
+): number => {
+  if (typeof value !== 'number' && typeof value !== 'string') {
+    throw new TypeError(
+      `${fieldPrefix(field)}expected number or numeric string`,
+    )
+  }
+  const parsed = Number(value)
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new RangeError(
+      `${fieldPrefix(field)}expected non-negative integer, got ${String(value)}`,
+    )
+  }
+  if (max !== undefined && parsed > max) {
+    throw new RangeError(
+      `${fieldPrefix(field)}expected value ≤ ${String(max)}, got ${String(parsed)}`,
+    )
+  }
+  return parsed
+}
+
+/**
+ * Parses `value` as a Luxon `HourNumbers` (0-23). Throws on out-of-range or
+ * non-integer input.
+ */
+export const toHourNumbers = (value: unknown, field?: string): HourNumbers => {
+  const parsed = toPositiveInt(value, { field, max: HOUR_MAX })
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- narrowing a [0..23] integer to HourNumbers (Luxon's 0-23 union)
+  return parsed as HourNumbers
+}
+
+export { HOUR_MAX, HOUR_MIN }

--- a/lib/validation.mts
+++ b/lib/validation.mts
@@ -3,7 +3,7 @@ import type { HourNumbers } from 'luxon'
 const HOUR_MIN = 0
 const HOUR_MAX = 23
 
-interface PositiveIntOptions {
+interface NonNegativeIntOptions {
   readonly field?: string
   readonly max?: number
 }
@@ -12,13 +12,13 @@ const fieldPrefix = (field?: string): string =>
   field === undefined || field === '' ? '' : `${field}: `
 
 /**
- * Parses `value` as a positive finite integer. Throws if the input cannot be
- * coerced cleanly (non-numeric string, NaN, non-finite, negative, fractional,
- * or above the optional `max` bound).
+ * Parses `value` as a non-negative finite integer (0 included). Throws if the
+ * input cannot be coerced cleanly (non-numeric string, NaN, non-finite,
+ * negative, fractional, or above the optional `max` bound).
  */
-export const toPositiveInt = (
+export const toNonNegativeInt = (
   value: unknown,
-  { field, max }: PositiveIntOptions = {},
+  { field, max }: NonNegativeIntOptions = {},
 ): number => {
   if (typeof value !== 'number' && typeof value !== 'string') {
     throw new TypeError(
@@ -44,7 +44,7 @@ export const toPositiveInt = (
  * non-integer input.
  */
 export const toHourNumbers = (value: unknown, field?: string): HourNumbers => {
-  const parsed = toPositiveInt(value, { field, max: HOUR_MAX })
+  const parsed = toNonNegativeInt(value, { field, max: HOUR_MAX })
   // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- narrowing a [0..23] integer to HourNumbers (Luxon's 0-23 union)
   return parsed as HourNumbers
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "44.0.1",
       "license": "GPL-3.0-only",
       "dependencies": {
-        "@olivierzal/melcloud-api": "^32.0.0",
+        "@olivierzal/melcloud-api": "^32.0.1",
         "homey-lib": "^2.49.0",
         "luxon": "^3.7.2"
       },
@@ -618,9 +618,9 @@
       }
     },
     "node_modules/@olivierzal/melcloud-api": {
-      "version": "32.0.0",
-      "resolved": "https://npm.pkg.github.com/download/@olivierzal/melcloud-api/32.0.0/9a4a31bdcab821b0e9e2b6fb7085253808288232",
-      "integrity": "sha512-WKlvRhvGNnDouKGMeoe9tVfO6LB7UQfdWfbPaC0bRmM+VhcQCGbYOCshVT5fVCT4BZR7eVq8m5HDo/vgzCvXMQ==",
+      "version": "32.0.1",
+      "resolved": "https://npm.pkg.github.com/download/@olivierzal/melcloud-api/32.0.1/9ad60901a3f0832d00e353e690601629961e8596",
+      "integrity": "sha512-heEgrFtTfAroeZNjak9FcMSmJX7cKzT9QjsW4a+1vMGbkAVlyAztzw3RESu9Af7R17PXfmNCUmm3eBQOXwFI9A==",
       "license": "MIT",
       "dependencies": {
         "luxon": "^3.7.2",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@olivierzal/melcloud-api": "^32.0.0",
+    "@olivierzal/melcloud-api": "^32.0.1",
     "homey-lib": "^2.49.0",
     "luxon": "^3.7.2"
   },

--- a/public/homey-api.mts
+++ b/public/homey-api.mts
@@ -6,10 +6,21 @@ export interface Homey<
   readonly getSettings: () => TSettings
 }
 
-export const fireAndForget = (promise: Promise<unknown>): void => {
-  promise.catch(() => {
-    // Intentional no-op
-  })
+const defaultOnError = (error: unknown): void => {
+  // eslint-disable-next-line no-console -- intentional fallback: surfaces otherwise-swallowed rejections in widget dev tools
+  console.error(error)
+}
+
+/**
+ * Runs an async operation that shouldn't block. Rejections go to `onError`
+ * (default: console.error). Pass a homey.alert handler for user-visible
+ * failures, or a no-op when a miss is acceptable.
+ */
+export const fireAndForget = (
+  promise: Promise<unknown>,
+  onError: (error: unknown) => void = defaultOnError,
+): void => {
+  promise.catch(onError)
 }
 
 export const homeyApiGet = async <T,>(

--- a/settings/index.mts
+++ b/settings/index.mts
@@ -842,7 +842,7 @@ class DeviceSettingsManager {
   }
 }
 
-// ── DeviceSettingsManager ──
+// ── ErrorLogManager ──
 class ErrorLogManager {
   #errorCount = 0
 

--- a/settings/index.mts
+++ b/settings/index.mts
@@ -83,10 +83,16 @@ const getZoneName = (name: string, level: number): string =>
 
 // ── Helpers ──
 
-const fireAndForget = (promise: Promise<unknown>): void => {
-  promise.catch(() => {
-    // Intentional no-op
-  })
+const defaultOnError = (error: unknown): void => {
+  // eslint-disable-next-line no-console -- intentional fallback: surfaces otherwise-swallowed rejections in settings dev tools
+  console.error(error)
+}
+
+const fireAndForget = (
+  promise: Promise<unknown>,
+  onError: (error: unknown) => void = defaultOnError,
+): void => {
+  promise.catch(onError)
 }
 
 const getErrorMessage = (error: unknown): string => {

--- a/settings/index.mts
+++ b/settings/index.mts
@@ -465,139 +465,6 @@ class AuthManager {
 }
 
 // ── ErrorLogManager ──
-
-class ErrorLogManager {
-  #errorCount = 0
-
-  readonly #errorCountLabel: HTMLLabelElement
-
-  readonly #errorLog: HTMLDivElement
-
-  #errorLogTBody: HTMLTableSectionElement | null = null
-
-  #from = ''
-
-  readonly #homey: Homey
-
-  readonly #periodLabel: HTMLLabelElement
-
-  readonly #seeButton: HTMLButtonElement
-
-  readonly #sinceInput: HTMLInputElement
-
-  #to = ''
-
-  public constructor(homey: Homey) {
-    this.#homey = homey
-    this.#errorLog = getDiv('error_log')
-    this.#errorCountLabel = getLabel('error_count')
-    this.#periodLabel = getLabel('period')
-    this.#sinceInput = getInput('since')
-    this.#seeButton = getButton('see')
-  }
-
-  public addEventListeners(): void {
-    this.#sinceInput.addEventListener('change', () => {
-      if (
-        this.#to &&
-        this.#sinceInput.value &&
-        Date.parse(this.#sinceInput.value) > Date.parse(this.#to)
-      ) {
-        this.#sinceInput.value = this.#to
-        fireAndForget(
-          this.#homey.alert(
-            this.#homey.__('settings.errorLog.error', { from: this.#from }),
-          ),
-        )
-      }
-    })
-    this.#seeButton.addEventListener('click', () => {
-      fireAndForget(this.fetchErrorLog())
-    })
-  }
-
-  public disable(): void {
-    disableButton(this.#seeButton.id)
-  }
-
-  /** @alerts Displays fetch errors to the user. */
-  public async fetchErrorLog(): Promise<void> {
-    await withDisablingButton(this.#seeButton.id, async () => {
-      try {
-        const data = await homeyApiGet<FormattedErrorLog>(
-          this.#homey,
-          `/classic/logs/errors?${new URLSearchParams({
-            from: this.#sinceInput.value,
-            limit: '29',
-            offset: '0',
-            to: this.#to,
-          } satisfies Classic.ErrorLogQuery)}`,
-        )
-        this.#updateErrorLogElements(data)
-        this.#appendErrorLogRows(data.errors)
-      } catch (error) {
-        await this.#homey.alert(getErrorMessage(error))
-      }
-    })
-  }
-
-  #appendErrorLogRows(errors: readonly FormattedErrorDetails[]): void {
-    for (const error of errors) {
-      this.#errorLogTBody ??= this.#createErrorLogTable(Object.keys(error))
-      const row = this.#errorLogTBody.insertRow()
-      for (const value of Object.values(error)) {
-        const cell = row.insertCell()
-        cell.textContent = String(value)
-      }
-    }
-  }
-
-  #createErrorLogTable(keys: string[]): HTMLTableSectionElement {
-    const table = document.createElement('table')
-    table.classList.add('bordered')
-    const thead = table.createTHead()
-    const row = thead.insertRow()
-    for (const key of keys) {
-      const th = document.createElement('th')
-      th.textContent = this.#homey.__(`settings.errorLog.columns.${key}`)
-      row.append(th)
-    }
-    this.#errorLog.append(table)
-    return table.createTBody()
-  }
-
-  #getErrorCountText(count: number): string {
-    if (count < PLURAL_THRESHOLD) {
-      return this.#homey.__(`settings.errorLog.errorCount.${String(count)}`)
-    }
-    if (
-      numberEndsWithTwoThreeFour.has(count % Modulo.base10) &&
-      !pluralExceptions.has(count % Modulo.base100)
-    ) {
-      return this.#homey.__('settings.errorLog.errorCount.234')
-    }
-    return this.#homey.__('settings.errorLog.errorCount.plural')
-  }
-
-  #updateErrorLogElements({
-    errors,
-    fromDateHuman,
-    nextFromDate,
-    nextToDate,
-  }: FormattedErrorLog): void {
-    this.#errorCount += errors.length
-    this.#from = fromDateHuman
-    this.#to = nextToDate
-    this.#errorCountLabel.textContent = `${String(this.#errorCount)} ${this.#getErrorCountText(this.#errorCount)}`
-    this.#periodLabel.textContent = this.#homey.__('settings.errorLog.period', {
-      from: this.#from,
-    })
-    this.#sinceInput.value = nextFromDate
-  }
-}
-
-// ── DeviceSettingsManager ──
-
 class DeviceSettingsManager {
   public get deviceSettings(): Partial<DeviceSettings> {
     return this.#deviceSettings
@@ -969,8 +836,138 @@ class DeviceSettingsManager {
   }
 }
 
-// ── ZoneSettingsManager ──
+// ── DeviceSettingsManager ──
+class ErrorLogManager {
+  #errorCount = 0
 
+  readonly #errorCountLabel: HTMLLabelElement
+
+  readonly #errorLog: HTMLDivElement
+
+  #errorLogTBody: HTMLTableSectionElement | null = null
+
+  #from = ''
+
+  readonly #homey: Homey
+
+  readonly #periodLabel: HTMLLabelElement
+
+  readonly #seeButton: HTMLButtonElement
+
+  readonly #sinceInput: HTMLInputElement
+
+  #to = ''
+
+  public constructor(homey: Homey) {
+    this.#homey = homey
+    this.#errorLog = getDiv('error_log')
+    this.#errorCountLabel = getLabel('error_count')
+    this.#periodLabel = getLabel('period')
+    this.#sinceInput = getInput('since')
+    this.#seeButton = getButton('see')
+  }
+
+  public addEventListeners(): void {
+    this.#sinceInput.addEventListener('change', () => {
+      if (
+        this.#to &&
+        this.#sinceInput.value &&
+        Date.parse(this.#sinceInput.value) > Date.parse(this.#to)
+      ) {
+        this.#sinceInput.value = this.#to
+        fireAndForget(
+          this.#homey.alert(
+            this.#homey.__('settings.errorLog.error', { from: this.#from }),
+          ),
+        )
+      }
+    })
+    this.#seeButton.addEventListener('click', () => {
+      fireAndForget(this.fetchErrorLog())
+    })
+  }
+
+  public disable(): void {
+    disableButton(this.#seeButton.id)
+  }
+
+  /** @alerts Displays fetch errors to the user. */
+  public async fetchErrorLog(): Promise<void> {
+    await withDisablingButton(this.#seeButton.id, async () => {
+      try {
+        const data = await homeyApiGet<FormattedErrorLog>(
+          this.#homey,
+          `/classic/logs/errors?${new URLSearchParams({
+            from: this.#sinceInput.value,
+            limit: '29',
+            offset: '0',
+            to: this.#to,
+          } satisfies Classic.ErrorLogQuery)}`,
+        )
+        this.#updateErrorLogElements(data)
+        this.#appendErrorLogRows(data.errors)
+      } catch (error) {
+        await this.#homey.alert(getErrorMessage(error))
+      }
+    })
+  }
+
+  #appendErrorLogRows(errors: readonly FormattedErrorDetails[]): void {
+    for (const error of errors) {
+      this.#errorLogTBody ??= this.#createErrorLogTable(Object.keys(error))
+      const row = this.#errorLogTBody.insertRow()
+      for (const value of Object.values(error)) {
+        const cell = row.insertCell()
+        cell.textContent = String(value)
+      }
+    }
+  }
+
+  #createErrorLogTable(keys: string[]): HTMLTableSectionElement {
+    const table = document.createElement('table')
+    table.classList.add('bordered')
+    const thead = table.createTHead()
+    const row = thead.insertRow()
+    for (const key of keys) {
+      const th = document.createElement('th')
+      th.textContent = this.#homey.__(`settings.errorLog.columns.${key}`)
+      row.append(th)
+    }
+    this.#errorLog.append(table)
+    return table.createTBody()
+  }
+
+  #getErrorCountText(count: number): string {
+    if (count < PLURAL_THRESHOLD) {
+      return this.#homey.__(`settings.errorLog.errorCount.${String(count)}`)
+    }
+    if (
+      numberEndsWithTwoThreeFour.has(count % Modulo.base10) &&
+      !pluralExceptions.has(count % Modulo.base100)
+    ) {
+      return this.#homey.__('settings.errorLog.errorCount.234')
+    }
+    return this.#homey.__('settings.errorLog.errorCount.plural')
+  }
+
+  #updateErrorLogElements({
+    errors,
+    fromDateHuman,
+    nextFromDate,
+    nextToDate,
+  }: FormattedErrorLog): void {
+    this.#errorCount += errors.length
+    this.#from = fromDateHuman
+    this.#to = nextToDate
+    this.#errorCountLabel.textContent = `${String(this.#errorCount)} ${this.#getErrorCountText(this.#errorCount)}`
+    this.#periodLabel.textContent = this.#homey.__('settings.errorLog.period', {
+      from: this.#from,
+    })
+    this.#sinceInput.value = nextFromDate
+  }
+}
+
+// ── ZoneSettingsManager ──
 class ZoneSettingsManager {
   readonly #frostProtectionEnabled: HTMLSelectElement
 
@@ -1010,22 +1007,6 @@ class ZoneSettingsManager {
   }
 
   /** @silent Falls back to default values on error. */
-  public async fetchFrostProtectionData(): Promise<void> {
-    await withDisablingButtonPair('frost_protection', async () => {
-      try {
-        const data = await homeyApiGet<Classic.FrostProtectionData>(
-          this.#homey,
-          `/classic/zones/${this.#getZonePath()}/settings/frost-protection`,
-        )
-        this.#updateZoneMapping(data)
-        this.displayFrostProtectionData()
-      } catch {
-        // Non-critical: UI falls back to default values
-      }
-    })
-  }
-
-  /** @silent Falls back to default values on error. */
   public displayFrostProtectionData(): void {
     const { [this.#zone.value]: data } = this.#zoneMapping
     if (data) {
@@ -1052,6 +1033,22 @@ class ZoneSettingsManager {
       this.#holidayModeStartDate.value = isEnabled ? (startDate ?? '') : ''
       this.#holidayModeEndDate.value = isEnabled ? (endDate ?? '') : ''
     }
+  }
+
+  /** @silent Falls back to default values on error. */
+  public async fetchFrostProtectionData(): Promise<void> {
+    await withDisablingButtonPair('frost_protection', async () => {
+      try {
+        const data = await homeyApiGet<Classic.FrostProtectionData>(
+          this.#homey,
+          `/classic/zones/${this.#getZonePath()}/settings/frost-protection`,
+        )
+        this.#updateZoneMapping(data)
+        this.displayFrostProtectionData()
+      } catch {
+        // Non-critical: UI falls back to default values
+      }
+    })
   }
 
   public async fetchHolidayModeData(): Promise<void> {
@@ -1259,7 +1256,6 @@ class ZoneSettingsManager {
 }
 
 // ── SettingsApp ──
-
 class SettingsApp {
   readonly #authManager: AuthManager
 

--- a/tests/mock-device-class.ts
+++ b/tests/mock-device-class.ts
@@ -27,7 +27,9 @@ export const createMockDeviceClass = (
 
     public error = vi.fn<(...args: readonly unknown[]) => void>()
 
-    public getCapabilities = vi.fn<() => readonly string[]>().mockReturnValue([])
+    public getCapabilities = vi
+      .fn<() => readonly string[]>()
+      .mockReturnValue([])
 
     public getCapabilityOptions =
       vi.fn<(capability: string) => Record<string, unknown>>()
@@ -44,8 +46,9 @@ export const createMockDeviceClass = (
       .fn<() => Record<string, unknown>>()
       .mockReturnValue({})
 
-    public hasCapability =
-      vi.fn<(capability: string) => boolean>().mockReturnValue(true)
+    public hasCapability = vi
+      .fn<(capability: string) => boolean>()
+      .mockReturnValue(true)
 
     public homey = {
       __: vi.fn<(key: string) => string>(),
@@ -55,8 +58,7 @@ export const createMockDeviceClass = (
       clearTimeout: vi.fn<(timer: NodeJS.Timeout | null) => void>(),
       setInterval:
         vi.fn<(callback: () => void, ms: number) => NodeJS.Timeout>(),
-      setTimeout:
-        vi.fn<(callback: () => void, ms: number) => NodeJS.Timeout>(),
+      setTimeout: vi.fn<(callback: () => void, ms: number) => NodeJS.Timeout>(),
     }
 
     public log = vi.fn<(...args: readonly unknown[]) => void>()

--- a/tests/mock-device-class.ts
+++ b/tests/mock-device-class.ts
@@ -21,76 +21,97 @@ export const createMockDeviceClass = (
   const { overrides, superMocks } = options
 
   class MockDevice {
-    public addCapability = vi.fn()
+    public addCapability = vi.fn<(capability: string) => Promise<void>>()
 
     public driver = {}
 
-    public error = vi.fn()
+    public error = vi.fn<(...args: readonly unknown[]) => void>()
 
-    public getCapabilities = vi.fn().mockReturnValue([])
+    public getCapabilities = vi.fn<() => readonly string[]>().mockReturnValue([])
 
-    public getCapabilityOptions = vi.fn()
+    public getCapabilityOptions =
+      vi.fn<(capability: string) => Record<string, unknown>>()
 
-    public getCapabilityValue = vi.fn()
+    public getCapabilityValue = vi.fn<(capability: string) => unknown>()
 
-    public getData = vi.fn().mockReturnValue({ id: 1 })
+    public getData = vi
+      .fn<() => { id: number | string }>()
+      .mockReturnValue({ id: 1 })
 
-    public getSetting = vi.fn()
+    public getSetting = vi.fn<(key: string) => unknown>()
 
-    public getSettings = vi.fn().mockReturnValue({})
+    public getSettings = vi
+      .fn<() => Record<string, unknown>>()
+      .mockReturnValue({})
 
-    public hasCapability = vi.fn().mockReturnValue(true)
+    public hasCapability =
+      vi.fn<(capability: string) => boolean>().mockReturnValue(true)
 
     public homey = {
-      __: vi.fn(),
-      api: { realtime: vi.fn() },
-      app: { getClassicFacade: vi.fn() },
-      clearInterval: vi.fn(),
-      clearTimeout: vi.fn(),
-      setInterval: vi.fn(),
-      setTimeout: vi.fn(),
+      __: vi.fn<(key: string) => string>(),
+      api: { realtime: vi.fn<(event: string, data: unknown) => void>() },
+      app: { getClassicFacade: vi.fn<(kind: string, id: number) => unknown>() },
+      clearInterval: vi.fn<(timer: NodeJS.Timeout | undefined) => void>(),
+      clearTimeout: vi.fn<(timer: NodeJS.Timeout | null) => void>(),
+      setInterval:
+        vi.fn<(callback: () => void, ms: number) => NodeJS.Timeout>(),
+      setTimeout:
+        vi.fn<(callback: () => void, ms: number) => NodeJS.Timeout>(),
     }
 
-    public log = vi.fn()
+    public log = vi.fn<(...args: readonly unknown[]) => void>()
 
-    public registerMultipleCapabilityListener = vi.fn()
+    public registerMultipleCapabilityListener =
+      vi.fn<
+        (
+          capabilities: readonly string[],
+          listener: (values: Record<string, unknown>) => Promise<void>,
+          delay?: number,
+        ) => void
+      >()
 
-    public removeCapability = vi.fn()
+    public removeCapability = vi.fn<(capability: string) => Promise<void>>()
 
-    public setCapabilityOptions = vi.fn()
+    public setCapabilityOptions =
+      vi.fn<
+        (capability: string, options: Record<string, unknown>) => Promise<void>
+      >()
 
-    public setCapabilityValue = vi.fn()
+    public setCapabilityValue =
+      vi.fn<(capability: string, value: unknown) => Promise<void>>()
 
-    public setSettings = vi.fn()
+    public setSettings =
+      vi.fn<(settings: Record<string, unknown>) => Promise<void>>()
 
-    public setWarning = vi.fn()
+    public setWarning = vi.fn<(message: unknown) => Promise<void>>()
 
-    public triggerCapabilityListener = vi.fn()
+    public triggerCapabilityListener =
+      vi.fn<(capability: string, value: unknown) => Promise<void>>()
 
     public constructor() {
       if (overrides) {
         Object.assign(this, overrides)
       }
       if (superMocks) {
-        // Delete shadowing instance props so prototype super-delegates win
+        // Strip shadowing instance props so the prototype super-delegates win
+        const instance = this as Record<string, unknown>
         for (const methodName of Object.keys(superMocks)) {
-          delete (this as Record<string, unknown>)[methodName]
+          // eslint-disable-next-line @typescript-eslint/no-dynamic-delete -- methodName is a known key from superMocks; dynamic delete required to shadow instance vi.fn() props with prototype super-delegates
+          delete instance[methodName]
         }
       }
     }
   }
 
   if (superMocks) {
-    for (const [methodName, mockFn] of Object.entries(superMocks)) {
+    for (const [methodName, mockFunction] of Object.entries(superMocks)) {
       Object.defineProperty(MockDevice.prototype, methodName, {
         configurable: true,
-        value: async function superDelegate(
-          ...args: readonly unknown[]
-        ): Promise<void> {
-          mockFn(...args)
+        writable: true,
+        async value(...args: readonly unknown[]): Promise<void> {
+          mockFunction(...args)
           await Promise.resolve()
         },
-        writable: true,
       })
     }
   }

--- a/tests/mock-device-class.ts
+++ b/tests/mock-device-class.ts
@@ -1,8 +1,25 @@
 import { vi } from 'vitest'
 
+/*
+ * Options for createMockDeviceClass.
+ * - `overrides`: instance-level props assigned in the constructor (shallow merge).
+ * - `superMocks`: prototype-level async methods that delegate to the provided vi.fn.
+ *   Required when BaseMELCloudDevice calls super.X() (e.g. addCapability,
+ *   removeCapability, setWarning) — instance vi.fn properties can't be invoked
+ *   through super in a subclass.
+ */
+export interface MockDeviceClassOptions {
+  readonly overrides?: Readonly<Record<string, unknown>>
+  readonly superMocks?: Readonly<
+    Record<string, (...args: readonly unknown[]) => unknown>
+  >
+}
+
 export const createMockDeviceClass = (
-  overrides?: Record<string, unknown>,
+  options: MockDeviceClassOptions = {},
 ): new () => Record<string, unknown> => {
+  const { overrides, superMocks } = options
+
   class MockDevice {
     public addCapability = vi.fn()
 
@@ -54,7 +71,29 @@ export const createMockDeviceClass = (
       if (overrides) {
         Object.assign(this, overrides)
       }
+      if (superMocks) {
+        // Delete shadowing instance props so prototype super-delegates win
+        for (const methodName of Object.keys(superMocks)) {
+          delete (this as Record<string, unknown>)[methodName]
+        }
+      }
     }
   }
+
+  if (superMocks) {
+    for (const [methodName, mockFn] of Object.entries(superMocks)) {
+      Object.defineProperty(MockDevice.prototype, methodName, {
+        configurable: true,
+        value: async function superDelegate(
+          ...args: readonly unknown[]
+        ): Promise<void> {
+          mockFn(...args)
+          await Promise.resolve()
+        },
+        writable: true,
+      })
+    }
+  }
+
   return MockDevice as unknown as new () => Record<string, unknown>
 }

--- a/tests/mock-driver-class.ts
+++ b/tests/mock-driver-class.ts
@@ -20,24 +20,48 @@ export const createMockDriverClass = (
   overrides?: Record<string, unknown>,
 ): new () => MockDriverInstance => {
   class MockDriver implements MockDriverInstance {
-    public getDevices = vi.fn().mockReturnValue([])
+    public getDevices = vi.fn<() => readonly unknown[]>().mockReturnValue([])
 
     public homey = {
       app: {
-        api: { authenticate: vi.fn() },
-        getDevicesByType: vi.fn().mockReturnValue([]),
+        api: { authenticate: vi.fn<(data: unknown) => Promise<boolean>>() },
+        getDevicesByType: vi
+          .fn<(type: number) => readonly unknown[]>()
+          .mockReturnValue([]),
       },
       flow: {
-        getActionCard: vi.fn().mockReturnValue({
-          registerRunListener: vi.fn(),
-        }),
-        getConditionCard: vi.fn().mockReturnValue({
-          registerRunListener: vi.fn(),
-        }),
+        getActionCard: vi
+          .fn<
+            (id: string) => {
+              registerRunListener: (
+                listener: (args: Record<string, unknown>) => unknown,
+              ) => void
+            }
+          >()
+          .mockReturnValue({
+            registerRunListener:
+              vi.fn<
+                (listener: (args: Record<string, unknown>) => unknown) => void
+              >(),
+          }),
+        getConditionCard: vi
+          .fn<
+            (id: string) => {
+              registerRunListener: (
+                listener: (args: Record<string, unknown>) => unknown,
+              ) => void
+            }
+          >()
+          .mockReturnValue({
+            registerRunListener:
+              vi.fn<
+                (listener: (args: Record<string, unknown>) => unknown) => void
+              >(),
+          }),
       },
     }
 
-    public log = vi.fn()
+    public log = vi.fn<(...args: readonly unknown[]) => void>()
 
     public manifest = { capabilities: [] }
 

--- a/tests/unit/base-report.test.ts
+++ b/tests/unit/base-report.test.ts
@@ -1,6 +1,13 @@
 import type * as Classic from '@olivierzal/melcloud-api/classic'
-import { DateTime, Settings } from 'luxon'
-import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest'
 
 import type { ClassicMELCloudDevice } from '../../drivers/classic-device.mts'
 import type { ClassicMELCloudDriver } from '../../drivers/classic-driver.mts'
@@ -14,7 +21,7 @@ import { getMockCallArg, mock } from '../helpers.ts'
 
 type TestDeviceType = typeof Classic.DeviceType.Ata
 
-const FAKE_NOW_MILLIS = DateTime.fromISO('2026-03-18T12:00:00.000').toMillis()
+const FAKE_NOW = new Date('2026-03-18T12:00:00.000')
 
 const setCapabilityValueMock = vi.fn()
 const ensureDeviceMock = vi.fn()
@@ -110,7 +117,11 @@ const createCopMocks = (): ClassicMELCloudDevice<TestDeviceType> => {
 
 describe(EnergyReport, () => {
   beforeAll(() => {
-    Settings.now = (): number => FAKE_NOW_MILLIS
+    vi.useFakeTimers({ now: FAKE_NOW, toFake: ['Date'] })
+  })
+
+  afterAll(() => {
+    vi.useRealTimers()
   })
 
   beforeEach(() => {

--- a/tests/unit/classic-device.test.ts
+++ b/tests/unit/classic-device.test.ts
@@ -56,69 +56,34 @@ const mockDeviceData = {
 }
 
 // eslint-disable-next-line vitest/prefer-import-in-mock -- Stub class is not assignable to the full homey module type (40+ exports)
-vi.mock('homey', () => {
-  class MockDevice {
-    public driver = {}
-
-    public error = vi.fn()
-
-    public getCapabilities = vi.fn().mockReturnValue([])
-
-    public getCapabilityOptions = vi.fn()
-
-    public getCapabilityValue = vi.fn()
-
-    public getData = vi.fn().mockReturnValue({ id: 1 })
-
-    public getSetting = getSettingMock
-
-    public getSettings = vi.fn().mockReturnValue({})
-
-    public hasCapability = vi.fn().mockReturnValue(true)
-
-    public homey = {
-      __: vi.fn().mockImplementation((key: string) => key),
-      api: { realtime: realtimeMock },
-      app: { getClassicFacade: getFacadeMock },
-      clearInterval: vi.fn(),
-      clearTimeout: vi.fn(),
-      setInterval: vi.fn(),
-      setTimeout: vi.fn(),
-    }
-
-    public log = vi.fn()
-
-    public registerMultipleCapabilityListener =
-      registerMultipleCapabilityListenerMock
-
-    public setCapabilityOptions = vi.fn()
-
-    public setCapabilityValue = vi.fn()
-
-    public setSettings = vi.fn()
-
-    public triggerCapabilityListener = triggerCapabilityListenerMock
-
-    // eslint-disable-next-line @typescript-eslint/class-methods-use-this -- Prototype method required for super.addCapability() resolution in BaseMELCloudDevice
-    public async addCapability(...args: unknown[]): Promise<void> {
-      superAddCapabilityMock(...args)
-      await Promise.resolve()
-    }
-
-    // eslint-disable-next-line @typescript-eslint/class-methods-use-this -- Prototype method required for super.removeCapability() resolution in BaseMELCloudDevice
-    public async removeCapability(...args: unknown[]): Promise<void> {
-      superRemoveCapabilityMock(...args)
-      await Promise.resolve()
-    }
-
-    // eslint-disable-next-line @typescript-eslint/class-methods-use-this -- Prototype method required for super.setWarning() resolution in BaseMELCloudDevice
-    public async setWarning(...args: unknown[]): Promise<void> {
-      superSetWarningMock(...args)
-      await Promise.resolve()
-    }
+vi.mock('homey', async () => {
+  const { createMockDeviceClass } = await import('../helpers.ts')
+  return {
+    default: {
+      Device: createMockDeviceClass({
+        overrides: {
+          getSetting: getSettingMock,
+          homey: {
+            __: vi.fn().mockImplementation((key: string) => key),
+            api: { realtime: realtimeMock },
+            app: { getClassicFacade: getFacadeMock },
+            clearInterval: vi.fn(),
+            clearTimeout: vi.fn(),
+            setInterval: vi.fn(),
+            setTimeout: vi.fn(),
+          },
+          registerMultipleCapabilityListener:
+            registerMultipleCapabilityListenerMock,
+          triggerCapabilityListener: triggerCapabilityListenerMock,
+        },
+        superMocks: {
+          addCapability: superAddCapabilityMock,
+          removeCapability: superRemoveCapabilityMock,
+          setWarning: superSetWarningMock,
+        },
+      }),
+    },
   }
-
-  return { default: { Device: MockDevice } }
 })
 
 const getCapabilityListenerCallback = createCapabilityListenerCallbackGetter(

--- a/tests/unit/home-base-device.test.ts
+++ b/tests/unit/home-base-device.test.ts
@@ -54,81 +54,56 @@ const createMockFacade = (): Home.DeviceAtaFacade =>
   }) as unknown as Home.DeviceAtaFacade
 
 // eslint-disable-next-line vitest/prefer-import-in-mock -- Stub class is not assignable to the full homey module type (40+ exports)
-vi.mock('homey', () => {
-  class MockDevice {
-    public driver = {
-      energyCapabilityTagMapping: {},
-      getCapabilityTagMapping: {},
-      listCapabilityTagMapping: {},
-      manifest: {
-        capabilities: [
-          'measure_temperature',
-          'onoff',
-          'target_temperature',
-          'thermostat_mode',
-        ],
-      },
-      setCapabilityTagMapping: {
-        fan_speed: 'setFanSpeed',
-        horizontal: 'vaneHorizontalDirection',
-        onoff: 'power',
-        target_temperature: 'setTemperature',
-        thermostat_mode: 'operationMode',
-        vertical: 'vaneVerticalDirection',
-      },
-      getCapabilitiesOptions: (): Record<string, unknown> => ({}),
-      getRequiredCapabilities: (): string[] =>
-        this.driver.manifest.capabilities,
-    }
-
-    public error = vi.fn()
-
-    public getCapabilities = vi.fn().mockReturnValue([])
-
-    public getCapabilityOptions = vi.fn()
-
-    public getCapabilityValue = vi.fn()
-
-    public getData = vi.fn().mockReturnValue({ id: 'device-1' })
-
-    public getSetting = getSettingMock
-
-    public getSettings = vi.fn().mockReturnValue({})
-
-    public hasCapability = vi.fn().mockReturnValue(true)
-
-    public homey = {
-      api: { realtime: realtimeMock },
-      app: {
-        getHomeFacade: getHomeFacadeMock,
-      },
-      clearInterval: vi.fn(),
-      clearTimeout: vi.fn(),
-      setInterval: vi.fn(),
-      setTimeout: vi.fn(),
-    }
-
-    public log = vi.fn()
-
-    public registerMultipleCapabilityListener =
-      registerMultipleCapabilityListenerMock
-
-    public setCapabilityOptions = vi.fn()
-
-    public setCapabilityValue = vi.fn()
-
-    public setSettings = vi.fn()
-
-    public triggerCapabilityListener = vi.fn()
-
-    // eslint-disable-next-line @typescript-eslint/class-methods-use-this -- Prototype method required for super.setWarning() resolution in BaseMELCloudDevice
-    public async setWarning(...args: unknown[]): Promise<void> {
-      superSetWarningMock(...args)
-      await Promise.resolve()
-    }
+vi.mock('homey', async () => {
+  const { createMockDeviceClass } = await import('../helpers.ts')
+  return {
+    default: {
+      Device: createMockDeviceClass({
+        overrides: {
+          driver: {
+            energyCapabilityTagMapping: {},
+            getCapabilityTagMapping: {},
+            listCapabilityTagMapping: {},
+            manifest: {
+              capabilities: [
+                'measure_temperature',
+                'onoff',
+                'target_temperature',
+                'thermostat_mode',
+              ],
+            },
+            setCapabilityTagMapping: {
+              fan_speed: 'setFanSpeed',
+              horizontal: 'vaneHorizontalDirection',
+              onoff: 'power',
+              target_temperature: 'setTemperature',
+              thermostat_mode: 'operationMode',
+              vertical: 'vaneVerticalDirection',
+            },
+            getCapabilitiesOptions: (): Record<string, unknown> => ({}),
+            getRequiredCapabilities(
+              this: { manifest: { capabilities: string[] } },
+            ): string[] {
+              return this.manifest.capabilities
+            },
+          },
+          getData: vi.fn().mockReturnValue({ id: 'device-1' }),
+          getSetting: getSettingMock,
+          homey: {
+            api: { realtime: realtimeMock },
+            app: { getHomeFacade: getHomeFacadeMock },
+            clearInterval: vi.fn(),
+            clearTimeout: vi.fn(),
+            setInterval: vi.fn(),
+            setTimeout: vi.fn(),
+          },
+          registerMultipleCapabilityListener:
+            registerMultipleCapabilityListenerMock,
+        },
+        superMocks: { setWarning: superSetWarningMock },
+      }),
+    },
   }
-
-  return { default: { Device: MockDevice } }
 })
 
 const getCapabilityListenerCallback = createCapabilityListenerCallbackGetter(

--- a/tests/unit/home-base-device.test.ts
+++ b/tests/unit/home-base-device.test.ts
@@ -81,9 +81,9 @@ vi.mock('homey', async () => {
               vertical: 'vaneVerticalDirection',
             },
             getCapabilitiesOptions: (): Record<string, unknown> => ({}),
-            getRequiredCapabilities(
-              this: { manifest: { capabilities: string[] } },
-            ): string[] {
+            getRequiredCapabilities(this: {
+              manifest: { capabilities: string[] }
+            }): string[] {
               return this.manifest.capabilities
             },
           },

--- a/tests/unit/melcloud-atw-device.test.ts
+++ b/tests/unit/melcloud-atw-device.test.ts
@@ -34,9 +34,11 @@ vi.mock('homey', async () => {
   return {
     default: {
       Device: createMockDeviceClass({
-        getCapabilityOptions: getCapabilityOptionsMock,
-        hasCapability: hasCapabilityMock,
-        setCapabilityValue: setCapabilityValueMock,
+        overrides: {
+          getCapabilityOptions: getCapabilityOptionsMock,
+          hasCapability: hasCapabilityMock,
+          setCapabilityValue: setCapabilityValueMock,
+        },
       }),
     },
   }

--- a/tests/unit/melcloud-erv-driver.test.ts
+++ b/tests/unit/melcloud-erv-driver.test.ts
@@ -101,5 +101,12 @@ describe(ClassicMELCloudDriverErv, () => {
       expect(capabilities).toContain('measure_co2')
       expect(capabilities).toContain('measure_pm25')
     })
+
+    it('should exclude measure sensors when called without data', () => {
+      const capabilities = driver.getRequiredCapabilities()
+
+      expect(capabilities).not.toContain('measure_co2')
+      expect(capabilities).not.toContain('measure_pm25')
+    })
   })
 })

--- a/tests/unit/validation.test.ts
+++ b/tests/unit/validation.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+
+import { toHourNumbers, toPositiveInt } from '../../lib/validation.mts'
+
+describe(toPositiveInt, () => {
+  it.each([
+    [0, 0],
+    [23, 23],
+    ['7', 7],
+    ['0', 0],
+  ])('accepts %s and returns %d', (input, expected) => {
+    expect(toPositiveInt(input)).toBe(expected)
+  })
+
+  it('enforces the optional max', () => {
+    expect(toPositiveInt(10, { max: 10 })).toBe(10)
+    expect(() => toPositiveInt(11, { field: 'days', max: 10 })).toThrow(
+      /days: expected value ≤ 10/u,
+    )
+  })
+
+  it.each([
+    ['abc', /non-negative integer/u],
+    [-1, /non-negative integer/u],
+    [1.5, /non-negative integer/u],
+    [Number.NaN, /non-negative integer/u],
+    [Number.POSITIVE_INFINITY, /non-negative integer/u],
+  ])('rejects %p', (input, pattern) => {
+    expect(() => toPositiveInt(input)).toThrow(pattern)
+  })
+
+  it('rejects non-numeric types', () => {
+    expect(() => toPositiveInt(null)).toThrow(
+      /expected number or numeric string/u,
+    )
+    expect(() => toPositiveInt({ field: 'x' })).toThrow(
+      /expected number or numeric string/u,
+    )
+  })
+
+  it('includes the field name in error messages when provided', () => {
+    expect(() => toPositiveInt('bad', { field: 'days' })).toThrow(
+      /^days: /u,
+    )
+  })
+})
+
+describe(toHourNumbers, () => {
+  it.each([0, 12, 23])('accepts %d', (input) => {
+    expect(toHourNumbers(input)).toBe(input)
+  })
+
+  it('accepts numeric strings', () => {
+    expect(toHourNumbers('5')).toBe(5)
+  })
+
+  it.each([24, -1, 1.5, 'abc'])('rejects %p', (input) => {
+    expect(() => toHourNumbers(input, 'hour')).toThrow(/^hour: /u)
+  })
+})

--- a/tests/unit/validation.test.ts
+++ b/tests/unit/validation.test.ts
@@ -1,20 +1,20 @@
 import { describe, expect, it } from 'vitest'
 
-import { toHourNumbers, toPositiveInt } from '../../lib/validation.mts'
+import { toHourNumbers, toNonNegativeInt } from '../../lib/validation.mts'
 
-describe(toPositiveInt, () => {
+describe(toNonNegativeInt, () => {
   it.each([
     [0, 0],
     [23, 23],
     ['7', 7],
     ['0', 0],
   ])('accepts %s and returns %d', (input, expected) => {
-    expect(toPositiveInt(input)).toBe(expected)
+    expect(toNonNegativeInt(input)).toBe(expected)
   })
 
   it('enforces the optional max', () => {
-    expect(toPositiveInt(10, { max: 10 })).toBe(10)
-    expect(() => toPositiveInt(11, { field: 'days', max: 10 })).toThrow(
+    expect(toNonNegativeInt(10, { max: 10 })).toBe(10)
+    expect(() => toNonNegativeInt(11, { field: 'days', max: 10 })).toThrow(
       /days: expected value ≤ 10/u,
     )
   })
@@ -26,20 +26,20 @@ describe(toPositiveInt, () => {
     [Number.NaN, /non-negative integer/u],
     [Number.POSITIVE_INFINITY, /non-negative integer/u],
   ])('rejects %p', (input, pattern) => {
-    expect(() => toPositiveInt(input)).toThrow(pattern)
+    expect(() => toNonNegativeInt(input)).toThrow(pattern)
   })
 
   it('rejects non-numeric types', () => {
-    expect(() => toPositiveInt(null)).toThrow(
+    expect(() => toNonNegativeInt(null)).toThrow(
       /expected number or numeric string/u,
     )
-    expect(() => toPositiveInt({ field: 'x' })).toThrow(
+    expect(() => toNonNegativeInt({ field: 'x' })).toThrow(
       /expected number or numeric string/u,
     )
   })
 
   it('includes the field name in error messages when provided', () => {
-    expect(() => toPositiveInt('bad', { field: 'days' })).toThrow(/^days: /u)
+    expect(() => toNonNegativeInt('bad', { field: 'days' })).toThrow(/^days: /u)
   })
 })
 

--- a/tests/unit/validation.test.ts
+++ b/tests/unit/validation.test.ts
@@ -39,9 +39,7 @@ describe(toPositiveInt, () => {
   })
 
   it('includes the field name in error messages when provided', () => {
-    expect(() => toPositiveInt('bad', { field: 'days' })).toThrow(
-      /^days: /u,
-    )
+    expect(() => toPositiveInt('bad', { field: 'days' })).toThrow(/^days: /u)
   })
 })
 

--- a/types/capabilities.mts
+++ b/types/capabilities.mts
@@ -83,12 +83,12 @@ export type EnergyCapabilityTagMapping<T extends Classic.DeviceType> = Record<
 
 export type GetCapabilityTagMapping<T extends Classic.DeviceType> = Record<
   keyof GetCapabilities<T>,
-  keyof Classic.GetDeviceData<T>
+  string & keyof Classic.GetDeviceData<T>
 >
 
 export type ListCapabilityTagMapping<T extends Classic.DeviceType> = Record<
   keyof ListCapabilities<T>,
-  keyof Classic.ListDeviceData<T>
+  string & keyof Classic.ListDeviceData<T>
 >
 
 export type OperationalCapabilities<T extends Classic.DeviceType> =
@@ -107,5 +107,5 @@ export type SetCapabilities<T extends Classic.DeviceType> =
 
 export type SetCapabilityTagMapping<T extends Classic.DeviceType> = Record<
   keyof SetCapabilities<T>,
-  keyof Classic.UpdateDeviceData<T>
+  string & keyof Classic.UpdateDeviceData<T>
 >

--- a/types/home-ata.mts
+++ b/types/home-ata.mts
@@ -11,18 +11,6 @@ export type HomeCapabilitiesAta = HomeGetCapabilitiesAta &
   HomeListCapabilitiesAta &
   HomeSetCapabilitiesAta
 
-export type HomeGetCapabilitiesAta = BaseGetCapabilities
-
-export type HomeListCapabilitiesAta = BaseListCapabilities
-
-export interface HomeSetCapabilitiesAta extends BaseSetCapabilities {
-  readonly fan_speed: number
-  readonly horizontal: string
-  readonly target_temperature: number
-  readonly thermostat_mode: keyof typeof ThermostatModeAta
-  readonly vertical: string
-}
-
 /*
  * Uses method signature syntax (bivariant) to allow converter functions
  * to accept narrower parameter types from the facade getters.
@@ -48,6 +36,18 @@ export type HomeConvertToDevice = {
     value: HomeSetCapabilitiesAta[keyof HomeSetCapabilitiesAta],
   ): Home.AtaValues[keyof Home.AtaValues]
 }['bivariant']
+
+export type HomeGetCapabilitiesAta = BaseGetCapabilities
+
+export type HomeListCapabilitiesAta = BaseListCapabilities
+
+export interface HomeSetCapabilitiesAta extends BaseSetCapabilities {
+  readonly fan_speed: number
+  readonly horizontal: string
+  readonly target_temperature: number
+  readonly thermostat_mode: keyof typeof ThermostatModeAta
+  readonly vertical: string
+}
 
 export const homeSetCapabilityTagMappingAta: Record<
   keyof HomeSetCapabilitiesAta,

--- a/widgets/ata-group-setting/public/homey-api.mts
+++ b/widgets/ata-group-setting/public/homey-api.mts
@@ -6,10 +6,21 @@ export interface Homey<
   readonly getSettings: () => TSettings
 }
 
-export const fireAndForget = (promise: Promise<unknown>): void => {
-  promise.catch(() => {
-    // Intentional no-op
-  })
+const defaultOnError = (error: unknown): void => {
+  // eslint-disable-next-line no-console -- intentional fallback: surfaces otherwise-swallowed rejections in widget dev tools
+  console.error(error)
+}
+
+/**
+ * Runs an async operation that shouldn't block. Rejections go to `onError`
+ * (default: console.error). Pass a homey.alert handler for user-visible
+ * failures, or a no-op when a miss is acceptable.
+ */
+export const fireAndForget = (
+  promise: Promise<unknown>,
+  onError: (error: unknown) => void = defaultOnError,
+): void => {
+  promise.catch(onError)
 }
 
 export const homeyApiGet = async <T,>(

--- a/widgets/ata-group-setting/public/styles/dist.css
+++ b/widgets/ata-group-setting/public/styles/dist.css
@@ -1122,6 +1122,38 @@
     }
   }
 }
+.alert {
+  border-width: var(--border);
+  border-color: var(--alert-border-color, var(--color-base-200));
+  @layer daisyui.l1.l2.l3 {
+    border-style: solid;
+    --alert-border-color: var(--color-base-200);
+    display: grid;
+    align-items: center;
+    gap: calc(0.25rem * 4);
+    border-radius: var(--radius-box);
+    padding-inline: calc(0.25rem * 4);
+    padding-block: calc(0.25rem * 3);
+    color: var(--color-base-content);
+    background-color: var(--alert-color, var(--color-base-200));
+    justify-content: start;
+    justify-items: start;
+    grid-auto-flow: column;
+    grid-template-columns: auto;
+    text-align: start;
+    font-size: 0.875rem;
+    line-height: 1.25rem;
+    background-size: auto, calc(var(--noise) * 100%);
+    background-image: none, var(--fx-noise);
+    box-shadow: 0 3px 0 -2px oklch(100% 0 0 / calc(var(--depth) * 0.08)) inset, 0 1px #000, 0 4px 3px -2px oklch(0% 0 0 / calc(var(--depth) * 0.08));
+    @supports (color: color-mix(in lab, red, red)) {
+      box-shadow: 0 3px 0 -2px oklch(100% 0 0 / calc(var(--depth) * 0.08)) inset, 0 1px color-mix( in oklab, color-mix(in oklab, #000 20%, var(--alert-color, var(--color-base-200))) calc(var(--depth) * 20%), #0000 ), 0 4px 3px -2px oklch(0% 0 0 / calc(var(--depth) * 0.08));
+    }
+    &:has(:nth-child(2)) {
+      grid-template-columns: auto minmax(auto, 1fr);
+    }
+  }
+}
 .fieldset {
   @layer daisyui.l1.l2.l3 {
     display: grid;

--- a/widgets/charts/api.mts
+++ b/widgets/charts/api.mts
@@ -8,7 +8,7 @@ import type { Homey } from 'homey/lib/Homey'
 import type { DaysQuery, HourQuery } from '../../types/widgets.mts'
 import { getClassicZones } from '../../lib/classic-facade-manager.mts'
 import { toDeviceType } from '../../lib/to-device-type.mts'
-import { toHourNumbers, toPositiveInt } from '../../lib/validation.mts'
+import { toHourNumbers, toNonNegativeInt } from '../../lib/validation.mts'
 
 const DAYS_MAX = 366
 
@@ -46,7 +46,7 @@ const api = {
     query: DaysQuery
   }): Promise<ReportChartPieOptions> {
     return app.getClassicOperationModes({
-      days: toPositiveInt(days, { field: 'days', max: DAYS_MAX }),
+      days: toNonNegativeInt(days, { field: 'days', max: DAYS_MAX }),
       deviceId,
     })
   },
@@ -74,7 +74,7 @@ const api = {
     query: DaysQuery
   }): Promise<ReportChartLineOptions> {
     return app.getClassicTemperatures({
-      days: toPositiveInt(days, { field: 'days', max: DAYS_MAX }),
+      days: toNonNegativeInt(days, { field: 'days', max: DAYS_MAX }),
       deviceId,
     })
   },

--- a/widgets/charts/api.mts
+++ b/widgets/charts/api.mts
@@ -4,11 +4,13 @@ import type {
 } from '@olivierzal/melcloud-api'
 import type * as Classic from '@olivierzal/melcloud-api/classic'
 import type { Homey } from 'homey/lib/Homey'
-import type { HourNumbers } from 'luxon'
 
 import type { DaysQuery, HourQuery } from '../../types/widgets.mts'
 import { getClassicZones } from '../../lib/classic-facade-manager.mts'
 import { toDeviceType } from '../../lib/to-device-type.mts'
+import { toHourNumbers, toPositiveInt } from '../../lib/validation.mts'
+
+const DAYS_MAX = 366
 
 const api = {
   getClassicDevices({
@@ -31,8 +33,7 @@ const api = {
   }): Promise<ReportChartLineOptions> {
     return app.getClassicHourlyTemperatures({
       deviceId,
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- narrowing Number to HourNumbers (0-23)
-      hour: hour === undefined ? undefined : (Number(hour) as HourNumbers),
+      hour: hour === undefined ? undefined : toHourNumbers(hour, 'hour'),
     })
   },
   async getClassicOperationModes({
@@ -44,7 +45,10 @@ const api = {
     params: { deviceId: string }
     query: DaysQuery
   }): Promise<ReportChartPieOptions> {
-    return app.getClassicOperationModes({ days: Number(days), deviceId })
+    return app.getClassicOperationModes({
+      days: toPositiveInt(days, { field: 'days', max: DAYS_MAX }),
+      deviceId,
+    })
   },
   async getClassicSignal({
     homey: { app },
@@ -57,8 +61,7 @@ const api = {
   }): Promise<ReportChartLineOptions> {
     return app.getClassicSignal({
       deviceId,
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- narrowing Number to HourNumbers (0-23)
-      hour: hour === undefined ? undefined : (Number(hour) as HourNumbers),
+      hour: hour === undefined ? undefined : toHourNumbers(hour, 'hour'),
     })
   },
   async getClassicTemperatures({
@@ -70,7 +73,10 @@ const api = {
     params: { deviceId: string }
     query: DaysQuery
   }): Promise<ReportChartLineOptions> {
-    return app.getClassicTemperatures({ days: Number(days), deviceId })
+    return app.getClassicTemperatures({
+      days: toPositiveInt(days, { field: 'days', max: DAYS_MAX }),
+      deviceId,
+    })
   },
   getLanguage({ homey: { i18n } }: { homey: Homey }): string {
     return i18n.getLanguage()

--- a/widgets/charts/public/homey-api.mts
+++ b/widgets/charts/public/homey-api.mts
@@ -6,10 +6,21 @@ export interface Homey<
   readonly getSettings: () => TSettings
 }
 
-export const fireAndForget = (promise: Promise<unknown>): void => {
-  promise.catch(() => {
-    // Intentional no-op
-  })
+const defaultOnError = (error: unknown): void => {
+  // eslint-disable-next-line no-console -- intentional fallback: surfaces otherwise-swallowed rejections in widget dev tools
+  console.error(error)
+}
+
+/**
+ * Runs an async operation that shouldn't block. Rejections go to `onError`
+ * (default: console.error). Pass a homey.alert handler for user-visible
+ * failures, or a no-op when a miss is acceptable.
+ */
+export const fireAndForget = (
+  promise: Promise<unknown>,
+  onError: (error: unknown) => void = defaultOnError,
+): void => {
+  promise.catch(onError)
 }
 
 export const homeyApiGet = async <T,>(

--- a/widgets/charts/public/index.mts
+++ b/widgets/charts/public/index.mts
@@ -218,7 +218,6 @@ interface DrawConfig {
 }
 
 // ── ChartWidget class ──
-
 class ChartWidget {
   #chart: ApexCharts | null = null
 

--- a/widgets/charts/public/styles/dist.css
+++ b/widgets/charts/public/styles/dist.css
@@ -1122,6 +1122,38 @@
     }
   }
 }
+.alert {
+  border-width: var(--border);
+  border-color: var(--alert-border-color, var(--color-base-200));
+  @layer daisyui.l1.l2.l3 {
+    border-style: solid;
+    --alert-border-color: var(--color-base-200);
+    display: grid;
+    align-items: center;
+    gap: calc(0.25rem * 4);
+    border-radius: var(--radius-box);
+    padding-inline: calc(0.25rem * 4);
+    padding-block: calc(0.25rem * 3);
+    color: var(--color-base-content);
+    background-color: var(--alert-color, var(--color-base-200));
+    justify-content: start;
+    justify-items: start;
+    grid-auto-flow: column;
+    grid-template-columns: auto;
+    text-align: start;
+    font-size: 0.875rem;
+    line-height: 1.25rem;
+    background-size: auto, calc(var(--noise) * 100%);
+    background-image: none, var(--fx-noise);
+    box-shadow: 0 3px 0 -2px oklch(100% 0 0 / calc(var(--depth) * 0.08)) inset, 0 1px #000, 0 4px 3px -2px oklch(0% 0 0 / calc(var(--depth) * 0.08));
+    @supports (color: color-mix(in lab, red, red)) {
+      box-shadow: 0 3px 0 -2px oklch(100% 0 0 / calc(var(--depth) * 0.08)) inset, 0 1px color-mix( in oklab, color-mix(in oklab, #000 20%, var(--alert-color, var(--color-base-200))) calc(var(--depth) * 20%), #0000 ), 0 4px 3px -2px oklch(0% 0 0 / calc(var(--depth) * 0.08));
+    }
+    &:has(:nth-child(2)) {
+      grid-template-columns: auto minmax(auto, 1fr);
+    }
+  }
+}
 .fieldset {
   @layer daisyui.l1.l2.l3 {
     display: grid;


### PR DESCRIPTION
## Summary

Review honnête TS / UI / tests menée sur la branche, filtrée pour éliminer les faux positifs (build artifacts `widgets/*/public/{dom,homey-api,zones,constants}.mts` sont copiés par `build:public` → pas de la duplication source ; `text-default text-color` sont deux utilités Tailwind distinctes ; dark mode géré par Homey via CSS vars).

6 bundles, un commit par bundle pour faciliter la review séquentielle.

### Bundle D — Resserrer les `Record<string, unknown>` (tag mappings)
`ef71954` — les mappings de tags dans `BaseMELCloudDriver` passent à leurs vraies formes (`Record<string, string>` pour get/list/set, `Record<string, readonly string[]>` pour energy). `cleanMapping<TMapping>()` devient générique et retourne `Partial<TMapping>`, supprimant le double-cast `as unknown as Partial<EnergyCapabilityTagMapping<T>>` dans `EnergyReport`. Les types classic intersectent `& string` sur les valeurs pour rester assignables à la base.

### Bundle A — Factorisation des mocks Homey Device
`d39824f` — `createMockDeviceClass` reçoit une API d'options typée (`overrides` + `superMocks`). `superMocks` installe des délégués async sur le prototype (requis pour les `super.addCapability`/`super.removeCapability`/`super.setWarning` de `BaseMELCloudDevice`) et supprime les props d'instance qui shadowaient. `classic-device.test.ts` et `home-base-device.test.ts` migrent vers la factory (−62 et −44 LoC inline).

### Bundle B — Typer les `vi.fn()` dans les factories partagées
`733709d` — signatures explicites `vi.fn<Sig>()` dans `mock-device-class` et `mock-driver-class`. 32/162 warnings `vitest/require-mock-type-parameters` nettoyés dans le hot path.

### Bundle C — `vi.useFakeTimers` au lieu de `Settings.now`
`0dd61ba` — `base-report.test.ts` remplace l'override luxon `Settings.now = () => FAKE_NOW_MILLIS` par `vi.useFakeTimers({ now, toFake: ['Date'] })` idiomatique, avec restoration en `afterAll`.

### Bundle E — Validation d'inputs API (chart widget)
`1981168` — nouveau `lib/validation.mts` avec `toPositiveInt` / `toHourNumbers` qui throw `TypeError`/`RangeError` explicites. Remplace les `Number(hour) as HourNumbers` silencieux dans `widgets/charts/api.mts`. +20 tests unitaires.

### Bundle F — `fireAndForget` ne swallow plus silencieusement
`a7efabb` — `fireAndForget(promise, onError?)` dans `public/homey-api.mts` (copié dans les widgets par `build:public`) et dans `settings/index.mts`. Le handler par défaut `console.error` fait surface les rejections au lieu de les noop.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors, 131 warnings pré-existants (`vitest/require-mock-type-parameters` — style preference)
- [x] `npm test` — 402/402 (20 nouveaux tests pour `lib/validation`)
- [x] `npm run build` — OK
- [x] `npm run homey:validate` — passes at `publish` level
- [ ] Smoke test manuel Homey optionnel : login, sync, widget ata-group-setting (zone change, refresh/apply), widget charts (hour/days input), settings UI (fetchErrorLog, fetchZoneSettings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)