### PR TITLE
Add API contract test

### DIFF
--- a/tests/unit/api-contract.test.ts
+++ b/tests/unit/api-contract.test.ts
@@ -1,0 +1,44 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it, vi } from 'vitest'
+
+// The three `api.mts` modules import from `lib/classic-facade-manager.mts`,
+// which has real side effects. Mock it so that importing them is safe.
+vi.mock(import('../../lib/classic-facade-manager.mts'), () => ({
+  getClassicBuildings: vi.fn<() => never[]>(),
+  getClassicZones: vi.fn<() => never[]>(),
+}))
+
+const { default: settingsApi } = await import('../../api.mts')
+const { default: ataGroupApi } =
+  await import('../../widgets/ata-group-setting/api.mts')
+const { default: chartsApi } = await import('../../widgets/charts/api.mts')
+
+const readApiKeys = (relativePath: string): string[] => {
+  const url = new URL(relativePath, import.meta.url)
+  const raw = readFileSync(fileURLToPath(url), 'utf8')
+  const parsed = JSON.parse(raw) as { api?: Record<string, unknown> }
+  return Object.keys(parsed.api ?? {}).toSorted()
+}
+
+// Handler config is authoritative in `.homeycompose/app.json` and each
+// `widget.compose.json`; the compiled `app.json` is a build artifact.
+describe('api contract', () => {
+  it.each<[string, string, Record<string, unknown>]>([
+    ['settings', '../../.homeycompose/app.json', settingsApi],
+    [
+      'ata-group-setting widget',
+      '../../widgets/ata-group-setting/widget.compose.json',
+      ataGroupApi,
+    ],
+    ['charts widget', '../../widgets/charts/widget.compose.json', chartsApi],
+  ])(
+    'every %s endpoint declared in config has a matching handler',
+    (_name, configPath, handlers) => {
+      expect(Object.keys(handlers).toSorted()).toStrictEqual(
+        readApiKeys(configPath),
+      )
+    },
+  )
+})

--- a/tests/unit/api-contract.test.ts
+++ b/tests/unit/api-contract.test.ts
@@ -19,7 +19,7 @@ const readApiKeys = (relativePath: string): string[] => {
   const url = new URL(relativePath, import.meta.url)
   const raw = readFileSync(fileURLToPath(url), 'utf8')
   const parsed = JSON.parse(raw) as { api?: Record<string, unknown> }
-  return Object.keys(parsed.api ?? {}).toSorted()
+  return Object.keys(parsed.api ?? {}).toSorted((left, right) => left.localeCompare(right))
 }
 
 // Handler config is authoritative in `.homeycompose/app.json` and each
@@ -36,9 +36,9 @@ describe('api contract', () => {
   ])(
     'every %s endpoint declared in config has a matching handler',
     (_name, configPath, handlers) => {
-      expect(Object.keys(handlers).toSorted()).toStrictEqual(
-        readApiKeys(configPath),
-      )
+      expect(
+        Object.keys(handlers).toSorted((left, right) => left.localeCompare(right)),
+      ).toStrictEqual(readApiKeys(configPath))
     },
   )
 })


### PR DESCRIPTION
## Summary
Lock the JSON↔code consistency for the three API surfaces of the app.

Each handler declared in:
- `.homeycompose/app.json` (settings page API)
- `widgets/ata-group-setting/widget.compose.json` (ATA group widget API)
- `widgets/charts/widget.compose.json` (charts widget API)

must have a matching exported handler in the corresponding `api.mts`. Renaming a handler without updating the JSON (or vice versa) currently compiles, type-checks and unit-tests cleanly — but blows up at runtime on the first request. Three parameterised assertions catch that class of regression at unit-test time.

## Test plan
- [ ] `npm test -- tests/unit/api-contract.test.ts` → 3 tests pass
- [ ] `npm run test:coverage` → 100% maintained
- [ ] `npm run homey:validate` passes at `publish` level
- [ ] Manual regression check: temporarily rename a handler in `api.mts` without touching `.homeycompose/app.json` → contract test fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)