### PR TITLE
Remove concurrency block from Claude workflows

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,6 +1,3 @@
-concurrency:
-  cancel-in-progress: true
-  group: claude-review-${{ github.event.pull_request.number }}
 jobs:
   review:
     if: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,6 +1,3 @@
-concurrency:
-  cancel-in-progress: true
-  group: claude-${{ github.event.issue.number || github.event.pull_request.number }}
 jobs:
   claude:
     if: |


### PR DESCRIPTION
## Summary

Remove the `concurrency:` block from `claude.yml` and `claude-code-review.yml` to align with the official [anthropics/claude-code-action](https://github.com/anthropics/claude-code-action/tree/main/examples) template, which omits it entirely.

## Why

The shared concurrency group `claude-${pr_number}` covered all triggers (`issue_comment`, `pull_request_review`, `pull_request_review_comment`). When an external bot like Copilot submits a PR review, it creates a Claude workflow run that gets stuck in **"Awaiting approval"** because GitHub treats bot-authored events as outside-collaborator triggers. That stuck run sits in the concurrency queue with `cancel-in-progress: true` and aborts every subsequent user-triggered `@claude` run with:

> Canceling since a higher priority waiting request for claude-1294 exists

That's why the runs at https://github.com/OlivierZal/com.melcloud/actions/runs/25195009901, /25195209375 and /25203163072 were all cancelled even though no new `@claude` comment was posted between them.

Removing the block matches the upstream template and prevents bot-submitted events from polluting the queue.

## Note

This PR doesn't unstick already-pending runs. The "Action required" runs from Copilot/Dependabot on PR #1294 (and other PRs) need to be cancelled manually in **Actions → Claude → Action required** for the queue to be clean immediately.

## Test plan

- [ ] Merge, then post `@claude` on a PR that has a pending Copilot review — the run should no longer be auto-cancelled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mu9QSbu44fetpLozVqtt7y)_