### PR TITLE
ci(claude-review): enable display_report

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -8,8 +8,8 @@ jobs:
     permissions:
       contents: read
       id-token: write
-      issues: read
-      pull-requests: read
+      issues: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -19,6 +19,7 @@ jobs:
         with:
           claude_args: --model opus
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          display_report: true
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: code-review@claude-code-plugins
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'


### PR DESCRIPTION
## Summary
- Mirror [olivierzal/melcloud-api@8443a17](https://github.com/OlivierZal/melcloud-api/commit/8443a17afc022f9999c56e3beb9222444cd5f5ab) into this repo.
- Bump `issues` and `pull-requests` permissions from `read` to `write` in `.github/workflows/claude-code-review.yml` so the action can post review output.
- Add `display_report: true` to the `anthropics/claude-code-action` step.

## Test plan
- [ ] Open a non-draft PR and verify the Claude Code Review workflow runs and posts its report as a comment.

https://claude.ai/code/session_01QNbKX568csPeRkTx5XPFJx

---
_Generated by [Claude Code](https://claude.ai/code/session_01QNbKX568csPeRkTx5XPFJx)_