### PR TITLE
docs: improve README badges and structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,15 @@
 # MELCloud for Homey
 
-![GitHub Tag](https://img.shields.io/github/v/tag/OlivierZal/com.melcloud)
-[![CI](https://github.com/OlivierZal/com.melcloud/actions/workflows/ci.yml/badge.svg)](https://github.com/OlivierZal/com.melcloud/actions/workflows/ci.yml)
-[![Validate](https://github.com/OlivierZal/com.melcloud/actions/workflows/validate.yml/badge.svg)](https://github.com/OlivierZal/com.melcloud/actions/workflows/validate.yml)
+A [Homey](https://homey.app/) app for controlling Mitsubishi Electric HVAC devices via [MELCloud](https://app.melcloud.com/) and [MELCloud Home](https://melcloudhome.com/).
+
+[![License](https://img.shields.io/github/license/OlivierZal/com.melcloud)](LICENSE)
+[![GitHub release](https://img.shields.io/github/v/release/OlivierZal/com.melcloud?sort=semver)](https://github.com/OlivierZal/com.melcloud/releases)
+[![CI](https://img.shields.io/github/actions/workflow/status/OlivierZal/com.melcloud/ci.yml?branch=main&label=CI)](https://github.com/OlivierZal/com.melcloud/actions/workflows/ci.yml)
+[![Validate](https://img.shields.io/github/actions/workflow/status/OlivierZal/com.melcloud/validate.yml?branch=main&label=Validate)](https://github.com/OlivierZal/com.melcloud/actions/workflows/validate.yml)
 [![CodeQL](https://github.com/OlivierZal/com.melcloud/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/OlivierZal/com.melcloud/actions/workflows/github-code-scanning/codeql)
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=OlivierZal_com.melcloud&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=OlivierZal_com.melcloud)
+
+[![Quality Gate](https://sonarcloud.io/api/project_badges/measure?project=OlivierZal_com.melcloud&metric=alert_status)](https://sonarcloud.io/dashboard?id=OlivierZal_com.melcloud)
+[![Test coverage](https://sonarcloud.io/api/project_badges/measure?project=OlivierZal_com.melcloud&metric=coverage)](https://sonarcloud.io/component_measures?id=OlivierZal_com.melcloud&metric=coverage)
 
 ## Introduction
 
@@ -33,3 +38,7 @@ Arabic, Danish, Dutch, English, French, German, Italian, Korean, Norwegian, Poli
 ## Disclaimer
 
 This app is not endorsed, verified or approved by Mitsubishi Electric Corporation. Mitsubishi cannot be held liable for any claims or damages that may occur when using this app to control MELCloud devices.
+
+## License
+
+GPL-3.0-only


### PR DESCRIPTION
## Summary
Inspired by [olivierzal/melcloud-api@a84f104](https://github.com/OlivierZal/melcloud-api/commit/a84f104043ba294a26b61c2209a17e00788e0c49), excluding TSDoc-related parts. Each badge re-evaluated case by case to avoid noise — Quality Gate already aggregates Reliability/Maintainability/Security, so those individual SonarCloud rating badges are intentionally not added.

- Add a one-line tagline above the badge block
- Migrate badges to consistent shields.io style and group them: build/release (License, GitHub release, CI, Validate) and SonarCloud quality (Quality Gate, Test coverage)
  - **CodeQL** badge intentionally kept on GitHub's native badge URL: the default-setup CodeQL workflow has no file in `.github/workflows/`, so the shields.io `actions/workflow/status/{repo}/{filename}` form doesn't apply
- Replace the `GitHub Tag` badge with `GitHub release` (`sort=semver`)
- Add a `## License` section (`GPL-3.0-only`, matching `package.json`)

## Test plan
- [ ] Verify all badges render correctly on the rendered README on the PR page

https://claude.ai/code/session_01QNbKX568csPeRkTx5XPFJx