### PR TITLE
Fix main CI and run CI on Dependabot PRs

### DIFF
--- a/widgets/charts/public/index.mts
+++ b/widgets/charts/public/index.mts
@@ -123,7 +123,7 @@ const getChartLineOptions = (
     },
     xaxis: {
       ...axisStyle,
-      categories,
+      categories: [...categories],
       labels: { rotate: 0, style },
       tickAmount: 3,
     },


### PR DESCRIPTION
## Summary

Two related changes: fix the red `main`, and prevent the class of regression that caused it.

### 1. Fix the failing `typecheck` on `main`

```
widgets/charts/public/index.mts(126,7): error TS2322:
Type 'readonly string[]' is not assignable to type
'(string | number)[][] | (string | number)[] | undefined'.
```

`ReportChartLineOptions.labels` (from `@olivierzal/melcloud-api`) is `readonly string[]`, but ApexCharts' `xaxis.categories` wants a mutable `(string | number)[]`. A recent bump (`apexcharts` 5.13.0 and/or the `@typescript/native-preview` compiler) tightened this. Fixed by spreading into a fresh mutable array (`[...categories]`).

### 2. Run CI on Dependabot PRs + workflow hardening

Root cause this slipped onto `main`: every CI job was guarded by `if: github.actor != 'dependabot[bot]'`, and non-major bumps are auto-merged — so breaking bumps merged unverified.

- **`ci.yml` / `validate.yml`**: removed the Dependabot exclusions so CI runs on Dependabot PRs. Only the **SonarQube step** stays gated (`SONAR_TOKEN` isn't in Dependabot's secret store; npm auth uses `GITHUB_TOKEN`, which Dependabot does have).
- **`timeout-minutes`** added to every job (avoids runaway 6h runners).
- **`permissions: {}`** default-deny added to workflows that lacked a top-level block.
- **`concurrency`** added to `claude-code-review` (cancel stale reviews on new pushes) and to `publish` / `update-version` (serialize, never cancel a release).

`claude.yml` was already hardened (scoped permissions, timeout, author gating) — left as-is.

## ⚠️ One manual step required

For CI to actually *block* a bad bump's auto-merge, enable **branch protection on `main`** with these checks marked **required**: `Audit`, `Check`, `Test (Node 22)`, `Validate app`. Do **not** mark the SonarQube check required (it's intentionally skipped on Dependabot PRs).

## Test plan

- [ ] CI green on this PR (typecheck now passes)
- [ ] After merge: open/rerun a Dependabot PR and confirm CI runs on it
- [ ] Charts widget line chart still renders correct x-axis labels
