### PR TITLE
Scheduled audit, protected publish, and zizmor workflow hardening

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,9 +1,6 @@
-concurrency:
-  cancel-in-progress: true
-  group: validate-${{ github.ref }}
 jobs:
-  validate:
-    name: Validate app
+  audit:
+    name: Audit
     permissions:
       contents: read
       packages: read
@@ -15,20 +12,18 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           cache: npm
-          node-version: '22'
+          node-version: 22
           registry-url: https://npm.pkg.github.com
           scope: '@olivierzal'
       - env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npm ci --ignore-scripts
-      - name: Validate app
-        uses: athombv/github-action-homey-app-validate@0f3b42c15d26aab79d7c48cde4d2805524da910e
-        with:
-          level: publish
+        run: npm audit --audit-level=high --omit=dev
     timeout-minutes: 15
-name: Validate
+name: Audit
 on:
-  pull_request: {}
   push:
     branches: [main]
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch: {}
 permissions: {}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,24 +2,6 @@ concurrency:
   cancel-in-progress: true
   group: ci-${{ github.ref }}
 jobs:
-  audit:
-    name: Audit
-    permissions:
-      contents: read
-      packages: read
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
-        with:
-          cache: npm
-          node-version: 22
-          registry-url: https://npm.pkg.github.com
-          scope: '@olivierzal'
-      - env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npm audit --audit-level=high --omit=dev
-    timeout-minutes: 15
   check:
     name: Check
     permissions:
@@ -28,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           cache: npm
@@ -51,6 +35,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           cache: npm

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 1
+          persist-credentials: false
       - uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251
         with:
           claude_args: --model opus

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -27,6 +27,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 1
+          persist-credentials: false
       - uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251
         with:
           additional_permissions: |

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,6 +1,6 @@
 jobs:
   dependabot:
-    if: github.actor == 'dependabot[bot]'
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     name: Dependabot
     permissions:
       contents: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,9 +23,9 @@ jobs:
           personal_access_token: ${{ secrets.HOMEY_PAT }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - env:
+      - name: URL
+        env:
           URL: ${{ steps.publish.outputs.url }}
-        name: URL
         run: echo "Manage your app at $URL" >> "$GITHUB_STEP_SUMMARY"
     timeout-minutes: 30
 name: Publish app on Homey

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,13 +3,15 @@ concurrency:
   group: publish
 jobs:
   publish:
+    environment: homey
     name: Publish app on Homey
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
-          cache: npm
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # zizmor: ignore[cache-poisoning]
+        with:
           node-version: '22'
           registry-url: https://npm.pkg.github.com
           scope: '@olivierzal'
@@ -21,8 +23,10 @@ jobs:
           personal_access_token: ${{ secrets.HOMEY_PAT }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: URL
-        run: echo "Manage your app at ${{ steps.publish.outputs.url }}" >> $GITHUB_STEP_SUMMARY
+      - env:
+          URL: ${{ steps.publish.outputs.url }}
+        name: URL
+        run: echo "Manage your app at $URL" >> "$GITHUB_STEP_SUMMARY"
     timeout-minutes: 30
 name: Publish app on Homey
 on:

--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -6,7 +6,7 @@ jobs:
     name: Update app version
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # zizmor: ignore[artipacked]
       - id: update_app_version
         name: Update app version
         uses: athombv/github-action-homey-app-version@3342f092b437550e78074797b52fac6467a456e1
@@ -15,10 +15,10 @@ jobs:
           version: ${{ inputs.version }}
       - env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.update_app_version.outputs.version }}
         name: Commit & push changes
         run: |
-          VERSION=${{ steps.update_app_version.outputs.version }}
-          npm version $VERSION --no-git-tag-version --allow-same-version
+          npm version "$VERSION" --no-git-tag-version --allow-same-version
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add -A

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,24 @@
+concurrency:
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: zizmor-${{ github.ref }}
+jobs:
+  zizmor:
+    name: Zizmor
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+      - uses: zizmorcore/zizmor-action@b572f7b1a1c2d41efaab43d504f68d215c3cd727
+    timeout-minutes: 15
+name: Zizmor
+on:
+  pull_request: {}
+  push:
+    branches: [main]
+permissions: {}


### PR DESCRIPTION
## Summary

Ports the workflow-hardening ideas from `melcloud-api#1516` to this repo, plus adds **zizmor** static analysis.

### 1. `npm audit` → scheduled (`audit.yml`)
Removed the blocking `audit` job from `ci.yml` and moved it to a dedicated `audit.yml` running on push to `main`, a weekly cron (`0 6 * * 1`), and manual dispatch. A CVE published against an unchanged dependency no longer turns unrelated PRs red.
> Note: drop `Audit` from the required-status-checks list when you set up branch protection (it's no longer a PR check).

### 2. Protected publish (`publish.yml`)
Added `environment: homey` to the publish job so you can require manual approval before publishing to the Homey App Store and scope `HOMEY_PAT` to that environment.
> Manual step: create the `homey` environment in *Settings → Environments*, move `HOMEY_PAT` there, and add a required reviewer if you want approval gating.

### 3. zizmor (`zizmor.yml`) + clean all findings
Added `zizmorcore/zizmor-action` (same pinned SHA as melcloud-api) uploading SARIF to code scanning. Resolved every finding zizmor surfaced on the existing workflows:
- `persist-credentials: false` on checkouts that don't push (ci, validate, publish, audit, claude, claude-code-review)
- env indirection for `${{ }}` in `run:` blocks (publish URL, update-version VERSION) — fixes `template-injection`
- non-spoofable Dependabot check: `github.event.pull_request.user.login` instead of `github.actor` — fixes `bot-conditions`
- dropped npm cache from publish; documented `# zizmor: ignore[...]` only where a credential (update-version push) or setup action is genuinely required

Verified locally: `zizmor .github/workflows/` → **No findings to report** (exit 0).

`claude.yml` already had scoped permissions/timeout/author-gating; only `persist-credentials: false` was added.

## Test plan

- [ ] CI green (Check/Test/Validate)
- [ ] New `Zizmor` check passes (SARIF uploaded to Security tab)
- [ ] `Audit` runs on schedule/dispatch, not on PRs
- [ ] After creating the `homey` environment: a release still publishes


---
_Generated by [Claude Code](https://claude.ai/code/session_01CTwDm9ShAGBbC6e8D29PUn)_