### PR TITLE
ci: harmonize workflows with melcloud-api best practices

### DIFF
--- a/.github/actions/setup-node-and-install/action.yml
+++ b/.github/actions/setup-node-and-install/action.yml
@@ -1,0 +1,32 @@
+description: Set up Node.js for this @olivierzal-scoped GitHub Packages project and (optionally) install dependencies. Caller must run actions/checkout first — composite actions cannot reference local files before the repo is checked out.
+inputs:
+  cache:
+    default: npm
+    description: actions/setup-node cache mode. Set to 'none' to disable (release jobs where cache poisoning is a credential-exfiltration concern).
+    required: false
+  install:
+    default: 'true'
+    description: Whether to run `npm ci --ignore-scripts`. Set to 'false' for jobs that only need a Node/.npmrc setup (audit, publish).
+    required: false
+  node-version:
+    default: '22'
+    description: Node.js version to install. Defaults to the Homey runtime version.
+    required: false
+  npm-token:
+    description: Token forwarded as NODE_AUTH_TOKEN. Required when `install` is true (GitHub Packages requires auth even for read).
+    required: false
+name: Setup Node and install
+runs:
+  steps:
+    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+      with:
+        cache: ${{ inputs.cache == 'none' && '' || inputs.cache }}
+        node-version: ${{ inputs.node-version }}
+        registry-url: https://npm.pkg.github.com
+        scope: '@olivierzal'
+    - env:
+        NODE_AUTH_TOKEN: ${{ inputs.npm-token }}
+      if: inputs.install == 'true'
+      run: npm ci --ignore-scripts
+      shell: bash
+  using: composite

--- a/.github/actions/setup-node-and-install/action.yml
+++ b/.github/actions/setup-node-and-install/action.yml
@@ -18,6 +18,11 @@ inputs:
 name: Setup Node and install
 runs:
   steps:
+    - if: inputs.install == 'true' && inputs.npm-token == ''
+      run: |
+        echo "::error::setup-node-and-install: 'npm-token' input is required when 'install' is 'true' (GitHub Packages auth)."
+        exit 1
+      shell: bash
     - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
       with:
         cache: ${{ inputs.cache == 'none' && '' || inputs.cache }}

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -11,8 +11,10 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/setup-node-and-install
         with:
-          npm-token: ${{ secrets.GITHUB_TOKEN }}
-      - run: npm audit --audit-level=high --omit=dev
+          install: 'false'
+      - env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npm audit --audit-level=high --omit=dev
     timeout-minutes: 15
 name: Audit
 on:

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -4,20 +4,15 @@ jobs:
     permissions:
       contents: read
       packages: read
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+      - uses: ./.github/actions/setup-node-and-install
         with:
-          cache: npm
-          node-version: 22
-          registry-url: https://npm.pkg.github.com
-          scope: '@olivierzal'
-      - env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npm audit --audit-level=high --omit=dev
+          npm-token: ${{ secrets.GITHUB_TOKEN }}
+      - run: npm audit --audit-level=high --omit=dev
     timeout-minutes: 15
 name: Audit
 on:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 concurrency:
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
   group: ci-${{ github.ref }}
 jobs:
   check:
@@ -7,20 +7,14 @@ jobs:
     permissions:
       contents: read
       packages: read
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+      - uses: ./.github/actions/setup-node-and-install
         with:
-          cache: npm
-          node-version: 22
-          registry-url: https://npm.pkg.github.com
-          scope: '@olivierzal'
-      - env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npm ci --ignore-scripts
+          npm-token: ${{ secrets.GITHUB_TOKEN }}
       - run: npm run typecheck
       - run: npm run lint
       - run: npm run format
@@ -30,21 +24,16 @@ jobs:
     permissions:
       contents: read
       packages: read
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+      - uses: ./.github/actions/setup-node-and-install
         with:
-          cache: npm
           node-version: ${{ matrix.node-version }}
-          registry-url: https://npm.pkg.github.com
-          scope: '@olivierzal'
-      - env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npm ci --ignore-scripts
+          npm-token: ${{ secrets.GITHUB_TOKEN }}
       - run: npm test -- --coverage
       - if: matrix.node-version == 22 && (github.event_name == 'push' || (github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository))
         uses: SonarSource/sonarqube-scan-action@7006c4492b2e0ee0f816d36501671557c97f5995

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -13,7 +13,7 @@ jobs:
       id-token: write
       issues: write
       pull-requests: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,7 +1,7 @@
 jobs:
   claude:
     if: |
-      github.actor != 'dependabot[bot]' && (
+      !contains(fromJson('["Copilot","copilot-swe-agent[bot]","dependabot[bot]","github-actions[bot]"]'), github.actor) && (
         (github.event_name == 'issue_comment' &&
           contains(github.event.comment.body, '@claude') &&
           contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,20 +1,22 @@
 jobs:
   claude:
     if: |
-      !contains(fromJson('["Copilot","copilot-swe-agent[bot]","dependabot[bot]","github-actions[bot]"]'), github.actor) && (
-        (github.event_name == 'issue_comment' &&
-          contains(github.event.comment.body, '@claude') &&
-          contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
-        (github.event_name == 'pull_request_review_comment' &&
-          contains(github.event.comment.body, '@claude') &&
-          contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
-        (github.event_name == 'pull_request_review' &&
-          contains(github.event.review.body || '', '@claude') &&
-          contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)) ||
-        (github.event_name == 'issues' &&
-          (contains(github.event.issue.body || '', '@claude') || contains(github.event.issue.title, '@claude')) &&
-          contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association))
-      )
+      (github.event_name == 'issue_comment' &&
+        github.event.comment.user.type != 'Bot' &&
+        contains(github.event.comment.body, '@claude') &&
+        contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review_comment' &&
+        github.event.comment.user.type != 'Bot' &&
+        contains(github.event.comment.body, '@claude') &&
+        contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review' &&
+        github.event.review.user.type != 'Bot' &&
+        contains(github.event.review.body || '', '@claude') &&
+        contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)) ||
+      (github.event_name == 'issues' &&
+        github.event.issue.user.type != 'Bot' &&
+        (contains(github.event.issue.body || '', '@claude') || contains(github.event.issue.title, '@claude')) &&
+        contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association))
     name: Claude
     permissions:
       actions: read

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -22,7 +22,7 @@ jobs:
       id-token: write
       issues: read
       pull-requests: read
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,22 +1,20 @@
 jobs:
   claude:
     if: |
-      (github.event_name == 'issue_comment' &&
-        github.event.comment.user.type != 'Bot' &&
-        contains(github.event.comment.body, '@claude') &&
-        contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
-      (github.event_name == 'pull_request_review_comment' &&
-        github.event.comment.user.type != 'Bot' &&
-        contains(github.event.comment.body, '@claude') &&
-        contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
-      (github.event_name == 'pull_request_review' &&
-        github.event.review.user.type != 'Bot' &&
-        contains(github.event.review.body || '', '@claude') &&
-        contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)) ||
-      (github.event_name == 'issues' &&
-        github.event.issue.user.type != 'Bot' &&
-        (contains(github.event.issue.body || '', '@claude') || contains(github.event.issue.title, '@claude')) &&
-        contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association))
+      github.actor != 'dependabot[bot]' && (
+        (github.event_name == 'issue_comment' &&
+          contains(github.event.comment.body, '@claude') &&
+          contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+        (github.event_name == 'pull_request_review_comment' &&
+          contains(github.event.comment.body, '@claude') &&
+          contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+        (github.event_name == 'pull_request_review' &&
+          contains(github.event.review.body || '', '@claude') &&
+          contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)) ||
+        (github.event_name == 'issues' &&
+          (contains(github.event.issue.body || '', '@claude') || contains(github.event.issue.title, '@claude')) &&
+          contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association))
+      )
     name: Claude
     permissions:
       actions: read

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -5,7 +5,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - id: metadata
         name: Dependabot metadata

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,17 +5,19 @@ jobs:
   publish:
     environment: homey
     name: Publish app on Homey
-    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # zizmor: ignore[cache-poisoning]
+      - uses: ./.github/actions/setup-node-and-install
         with:
-          node-version: '22'
-          registry-url: https://npm.pkg.github.com
-          scope: '@olivierzal'
-      - run: cp $NPM_CONFIG_USERCONFIG ${{ github.workspace }}/.npmrc
+          cache: none
+          install: 'false'
+      - run: cp "$NPM_CONFIG_USERCONFIG" "$GITHUB_WORKSPACE/.npmrc"
       - id: publish
         name: Publish
         uses: athombv/github-action-homey-app-publish@0642b483f1eb66fbceb0c91b73df35d45fd2f3db
@@ -33,6 +35,4 @@ on:
   release:
     types: [published]
   workflow_dispatch: {}
-permissions:
-  contents: read
-  packages: read
+permissions: {}

--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -4,7 +4,9 @@ concurrency:
 jobs:
   update-version:
     name: Update app version
-    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # zizmor: ignore[artipacked]
       - id: update_app_version
@@ -44,5 +46,4 @@ on:
           - patch
         required: true
         type: choice
-permissions:
-  contents: write
+permissions: {}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,5 +1,5 @@
 concurrency:
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
   group: validate-${{ github.ref }}
 jobs:
   validate:
@@ -7,20 +7,14 @@ jobs:
     permissions:
       contents: read
       packages: read
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+      - uses: ./.github/actions/setup-node-and-install
         with:
-          cache: npm
-          node-version: '22'
-          registry-url: https://npm.pkg.github.com
-          scope: '@olivierzal'
-      - env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npm ci --ignore-scripts
+          npm-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Validate app
         uses: athombv/github-action-homey-app-validate@0f3b42c15d26aab79d7c48cde4d2805524da910e
         with:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -8,7 +8,7 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:


### PR DESCRIPTION
## Summary

Ports the workflow patterns established in [`melcloud-api#1516`](https://github.com/OlivierZal/melcloud-api/pull/1516) here, applies a couple of leftover items, and refactors the duplicated setup-node block into a composite action.

### 1. New `setup-node-and-install` composite action

Mirrors the one in melcloud-api but parameterized for this repo:
- `npm-token` input (forwarded as `NODE_AUTH_TOKEN`) — required because every dependency comes from GitHub Packages and even read needs auth.
- `cache` input with a `none` value, so release jobs can disable the npm cache (the cache-poisoning vector that zizmor flagged on `publish.yml`).
- `install` input (`true`/`false`) so audit/publish can reuse setup-node without `npm ci`.

Caller pattern goes from:
\`\`\`yaml
- uses: actions/setup-node@<SHA>
  with:
    cache: npm
    node-version: 22
    registry-url: https://npm.pkg.github.com
    scope: '@olivierzal'
- env:
    NODE_AUTH_TOKEN: \${{ secrets.GITHUB_TOKEN }}
  run: npm ci --ignore-scripts
\`\`\`
…to:
\`\`\`yaml
- uses: ./.github/actions/setup-node-and-install
  with:
    npm-token: \${{ secrets.GITHUB_TOKEN }}
\`\`\`

Applied to `ci.yml` (check + test), `audit.yml`, `validate.yml`, `publish.yml`. One place to bump `actions/setup-node` going forward.

### 2. Default-branch CI/validate no longer self-cancel

`ci.yml` and `validate.yml`: `cancel-in-progress: \${{ github.event_name == 'pull_request' }}` (matches melcloud-api). PRs still cancel superseded runs, but every commit to `main` keeps a complete check history.

### 3. Least-privilege root permissions

- `publish.yml`: root `permissions: contents: read, packages: read` → moved to job-level, with `permissions: {}` at root.
- `update-version.yml`: root `permissions: contents: write` → scoped to the job only.

### 4. Pin runners to `ubuntu-24.04`

All workflows: `ubuntu-latest` → `ubuntu-24.04`. GitHub's own recommendation — avoids surprise behavior shifts when the alias eventually flips to 26.04.

## Validation

- \`prettier --check .github/workflows .github/actions\` ✓
- \`eslint .github/workflows .github/actions\` ✓
- \`zizmor .github/workflows .github/actions\` → No findings to report (1 ignored, 16 suppressed)
- \`npm run typecheck && npm run lint && npm run format\` ✓

## Test plan

- [ ] CI green on this PR (Check + Test matrix + Validate + Zizmor)
- [ ] Audit still runs only on schedule/dispatch/main (unchanged)
- [ ] Next release publishes successfully through the refactored `publish.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)