### PR TITLE
feat: upgrade @olivierzal/melcloud-api to v39 + migrate Luxon → Temporal

### DIFF
--- a/app.mts
+++ b/app.mts
@@ -9,7 +9,7 @@ import type {
   SettingManager,
   SyncCallback,
 } from '@olivierzal/melcloud-api'
-import { DateTime, Settings as LuxonSettings } from 'luxon'
+import { Temporal } from 'temporal-polyfill'
 import * as Classic from '@olivierzal/melcloud-api/classic'
 import * as Home from '@olivierzal/melcloud-api/home'
 
@@ -53,11 +53,14 @@ const DRIVER_IDS_BY_TYPE: Partial<Record<DeviceType, string>> = {
   [Home.DeviceType.Ata]: 'home-melcloud',
 }
 
-const createDateRange = (days: number): { from: string; to: string } => {
-  const now = DateTime.now()
+const createDateRange = (
+  days: number,
+  timezone: string,
+): { from: string; to: string } => {
+  const now = Temporal.Now.plainDateTimeISO(timezone)
   return {
-    from: now.minus({ days }).toISO({ includeOffset: false }),
-    to: now.toISO({ includeOffset: false }),
+    from: now.subtract({ days }).toString(),
+    to: now.toString(),
   }
 }
 
@@ -175,9 +178,7 @@ export default class MELCloudApp extends App {
   public override async onInit(): Promise<void> {
     const language = this.homey.i18n.getLanguage()
     const timezone = this.homey.clock.getTimezone()
-    LuxonSettings.defaultLocale = language
-    LuxonSettings.defaultZone = timezone
-    await this.#initClassicApi({ language, timezone })
+    await this.#initClassicApi({ language, locale: language, timezone })
     await this.#initHomeApi()
     this.#createNotification(language)
     this.#registerWidgetListeners()
@@ -342,7 +343,7 @@ export default class MELCloudApp extends App {
   }): Promise<ReportChartPieOptions> {
     return unwrapResult(
       await this.getClassicFacade('devices', deviceId).getOperationModes(
-        createDateRange(days),
+        createDateRange(days, this.homey.clock.getTimezone()),
       ),
     )
   }
@@ -368,7 +369,7 @@ export default class MELCloudApp extends App {
   }): Promise<ReportChartLineOptions> {
     return unwrapResult(
       await this.getClassicFacade('devices', deviceId).getTemperatures(
-        createDateRange(days),
+        createDateRange(days, this.homey.clock.getTimezone()),
       ),
     )
   }
@@ -416,7 +417,7 @@ export default class MELCloudApp extends App {
 
   public getHomeFacade(deviceId: string): Home.DeviceAtaFacade {
     const model = this.#homeRegistry.getById(deviceId)
-    if (!model) {
+    if (model?.isAta() !== true) {
       throw new Error(this.homey.__('errors.deviceNotFound'))
     }
     return this.#homeFacadeManager.get(model)
@@ -636,6 +637,7 @@ export default class MELCloudApp extends App {
 
   async #initClassicApi(config: {
     language: string
+    locale: string
     timezone: string
   }): Promise<void> {
     this.#classicApi = await Classic.API.create({

--- a/app.mts
+++ b/app.mts
@@ -159,10 +159,6 @@ export default class MELCloudApp extends App {
     return this.#homeApi
   }
 
-  public get timezone(): string {
-    return this.homey.clock.getTimezone()
-  }
-
   #classicApi!: Classic.API
 
   #facadeManager!: Classic.FacadeManager
@@ -184,7 +180,7 @@ export default class MELCloudApp extends App {
     await this.#initClassicApi({
       language,
       locale: language,
-      timezone: this.timezone,
+      timezone: this.getTimeZone(),
     })
     await this.#initHomeApi()
     this.#createNotification(language)
@@ -259,7 +255,7 @@ export default class MELCloudApp extends App {
       await this.#classicApi.getErrorLog(query),
     )
     const locale = this.homey.i18n.getLanguage()
-    const { timezone: timeZone } = this
+    const timeZone = this.getTimeZone()
     // Reused across all entries instead of rebuilding a DateTime + formatter per call.
     const dateTimeMedFormat = new Intl.DateTimeFormat(locale, {
       day: 'numeric',
@@ -350,7 +346,7 @@ export default class MELCloudApp extends App {
   }): Promise<ReportChartPieOptions> {
     return unwrapResult(
       await this.getClassicFacade('devices', deviceId).getOperationModes(
-        createDateRange(days, this.timezone),
+        createDateRange(days, this.getTimeZone()),
       ),
     )
   }
@@ -376,7 +372,7 @@ export default class MELCloudApp extends App {
   }): Promise<ReportChartLineOptions> {
     return unwrapResult(
       await this.getClassicFacade('devices', deviceId).getTemperatures(
-        createDateRange(days, this.timezone),
+        createDateRange(days, this.getTimeZone()),
       ),
     )
   }
@@ -424,13 +420,17 @@ export default class MELCloudApp extends App {
 
   public getHomeFacade(deviceId: string): Home.DeviceAtaFacade {
     const model = this.#homeRegistry.getById(deviceId)
-    if (model === undefined) {
-      throw new Error(this.homey.__('errors.deviceNotFound'))
-    }
-    if (!model.isAta()) {
+    // `!model?.isAta()` would be flagged by strict-boolean-expressions
+    // (rule wants undefined-vs-false distinction explicit). `=== true` makes
+    // the intent unambiguous: throw on missing OR non-ATA.
+    if (model?.isAta() !== true) {
       throw new Error(this.homey.__('errors.deviceNotFound'))
     }
     return this.#homeFacadeManager.get(model)
+  }
+
+  public getTimeZone(): string {
+    return this.homey.clock.getTimezone()
   }
 
   public async updateClassicAtaState({

--- a/app.mts
+++ b/app.mts
@@ -159,6 +159,10 @@ export default class MELCloudApp extends App {
     return this.#homeApi
   }
 
+  public get timezone(): string {
+    return this.homey.clock.getTimezone()
+  }
+
   #classicApi!: Classic.API
 
   #facadeManager!: Classic.FacadeManager
@@ -177,8 +181,11 @@ export default class MELCloudApp extends App {
 
   public override async onInit(): Promise<void> {
     const language = this.homey.i18n.getLanguage()
-    const timezone = this.homey.clock.getTimezone()
-    await this.#initClassicApi({ language, locale: language, timezone })
+    await this.#initClassicApi({
+      language,
+      locale: language,
+      timezone: this.timezone,
+    })
     await this.#initHomeApi()
     this.#createNotification(language)
     this.#registerWidgetListeners()
@@ -252,7 +259,7 @@ export default class MELCloudApp extends App {
       await this.#classicApi.getErrorLog(query),
     )
     const locale = this.homey.i18n.getLanguage()
-    const timeZone = this.homey.clock.getTimezone()
+    const { timezone: timeZone } = this
     // Reused across all entries instead of rebuilding a DateTime + formatter per call.
     const dateTimeMedFormat = new Intl.DateTimeFormat(locale, {
       day: 'numeric',
@@ -343,7 +350,7 @@ export default class MELCloudApp extends App {
   }): Promise<ReportChartPieOptions> {
     return unwrapResult(
       await this.getClassicFacade('devices', deviceId).getOperationModes(
-        createDateRange(days, this.homey.clock.getTimezone()),
+        createDateRange(days, this.timezone),
       ),
     )
   }
@@ -369,7 +376,7 @@ export default class MELCloudApp extends App {
   }): Promise<ReportChartLineOptions> {
     return unwrapResult(
       await this.getClassicFacade('devices', deviceId).getTemperatures(
-        createDateRange(days, this.homey.clock.getTimezone()),
+        createDateRange(days, this.timezone),
       ),
     )
   }
@@ -417,7 +424,10 @@ export default class MELCloudApp extends App {
 
   public getHomeFacade(deviceId: string): Home.DeviceAtaFacade {
     const model = this.#homeRegistry.getById(deviceId)
-    if (model?.isAta() !== true) {
+    if (model === undefined) {
+      throw new Error(this.homey.__('errors.deviceNotFound'))
+    }
+    if (!model.isAta()) {
       throw new Error(this.homey.__('errors.deviceNotFound'))
     }
     return this.#homeFacadeManager.get(model)

--- a/app.mts
+++ b/app.mts
@@ -40,6 +40,7 @@ import {
 } from './files.mts'
 import { setClassicFacadeManager } from './lib/classic-facade-manager.mts'
 import { type Homey, App } from './lib/homey.mts'
+import { getTimeZone } from './lib/temporal.mts'
 import { typedFromEntries } from './lib/typed-object.mts'
 import { unwrapResult } from './lib/unwrap-result.mts'
 import { fanSpeedValues } from './types/ata-erv.mts'
@@ -180,7 +181,7 @@ export default class MELCloudApp extends App {
     await this.#initClassicApi({
       language,
       locale: language,
-      timezone: this.getTimeZone(),
+      timezone: getTimeZone(this.homey),
     })
     await this.#initHomeApi()
     this.#createNotification(language)
@@ -255,7 +256,7 @@ export default class MELCloudApp extends App {
       await this.#classicApi.getErrorLog(query),
     )
     const locale = this.homey.i18n.getLanguage()
-    const timeZone = this.getTimeZone()
+    const timeZone = getTimeZone(this.homey)
     // Reused across all entries instead of rebuilding a DateTime + formatter per call.
     const dateTimeMedFormat = new Intl.DateTimeFormat(locale, {
       day: 'numeric',
@@ -346,7 +347,7 @@ export default class MELCloudApp extends App {
   }): Promise<ReportChartPieOptions> {
     return unwrapResult(
       await this.getClassicFacade('devices', deviceId).getOperationModes(
-        createDateRange(days, this.getTimeZone()),
+        createDateRange(days, getTimeZone(this.homey)),
       ),
     )
   }
@@ -372,7 +373,7 @@ export default class MELCloudApp extends App {
   }): Promise<ReportChartLineOptions> {
     return unwrapResult(
       await this.getClassicFacade('devices', deviceId).getTemperatures(
-        createDateRange(days, this.getTimeZone()),
+        createDateRange(days, getTimeZone(this.homey)),
       ),
     )
   }
@@ -424,10 +425,6 @@ export default class MELCloudApp extends App {
       throw new Error(this.homey.__('errors.deviceNotFound'))
     }
     return this.#homeFacadeManager.get(model)
-  }
-
-  public getTimeZone(): string {
-    return this.homey.clock.getTimezone()
   }
 
   public async updateClassicAtaState({

--- a/app.mts
+++ b/app.mts
@@ -420,9 +420,6 @@ export default class MELCloudApp extends App {
 
   public getHomeFacade(deviceId: string): Home.DeviceAtaFacade {
     const model = this.#homeRegistry.getById(deviceId)
-    // `!model?.isAta()` would be flagged by strict-boolean-expressions
-    // (rule wants undefined-vs-false distinction explicit). `=== true` makes
-    // the intent unambiguous: throw on missing OR non-ATA.
     if (model?.isAta() !== true) {
       throw new Error(this.homey.__('errors.deviceNotFound'))
     }

--- a/drivers/base-device.mts
+++ b/drivers/base-device.mts
@@ -1,5 +1,5 @@
 import { NoChangesError } from '@olivierzal/melcloud-api'
-import { type DurationLike, DateTime, Duration } from 'luxon'
+import { Temporal } from 'temporal-polyfill'
 
 import type { CapabilityConverter } from '../types/capabilities.mts'
 import type {
@@ -188,7 +188,7 @@ export abstract class BaseMELCloudDevice extends Device {
 
   public setInterval(
     callback: () => Promise<void>,
-    interval: DurationLike,
+    interval: Temporal.DurationLike,
     actionType: string,
   ): NodeJS.Timeout {
     return this.#setTimer(callback, interval, {
@@ -200,7 +200,7 @@ export abstract class BaseMELCloudDevice extends Device {
 
   public setTimeout(
     callback: () => Promise<void>,
-    interval: DurationLike,
+    interval: Temporal.DurationLike,
     actionType: string,
   ): NodeJS.Timeout {
     return this.#setTimer(callback, interval, {
@@ -361,22 +361,30 @@ export abstract class BaseMELCloudDevice extends Device {
 
   #setTimer(
     callback: () => Promise<void>,
-    interval: DurationLike,
+    interval: Temporal.DurationLike,
     { actionType, timerType, timerWords }: TimerOptions,
   ): NodeJS.Timeout {
-    const duration = Duration.fromDurationLike(interval)
+    const duration = Temporal.Duration.from(interval)
+    const locale = this.homey.i18n.getLanguage()
+    const timezone = this.homey.clock.getTimezone()
     this.log(
       capitalize(actionType),
       'will run',
       timerWords.timeSpecifier,
-      duration.rescale().toHuman(),
+      duration.round({ largestUnit: 'days' }).toLocaleString(locale),
       timerWords.dateSpecifier,
-      DateTime.now()
-        .plus(duration)
-        .toLocaleString(DateTime.DATETIME_HUGE_WITH_SECONDS),
+      Temporal.Now.zonedDateTimeISO(timezone)
+        .add(duration)
+        .toLocaleString(locale, {
+          dateStyle: 'full',
+          timeStyle: 'full',
+        }),
     )
 
-    return this.homey[timerType](callback, duration.as('milliseconds'))
+    return this.homey[timerType](
+      callback,
+      duration.total({ unit: 'milliseconds' }),
+    )
   }
 
   async #syncOptionalCapabilities(

--- a/drivers/base-device.mts
+++ b/drivers/base-device.mts
@@ -10,6 +10,7 @@ import type {
 import { getErrorMessage } from '../lib/get-error-message.mts'
 import { type Homey, Device } from '../lib/homey.mts'
 import { isTotalEnergyKey } from '../lib/is-total-energy-key.mts'
+import { getLocale, getNow } from '../lib/temporal.mts'
 import type { BaseMELCloudDriver } from './base-driver.mts'
 import type { EnergyReportConfig } from './base-report.mts'
 
@@ -365,20 +366,17 @@ export abstract class BaseMELCloudDevice extends Device {
     { actionType, timerType, timerWords }: TimerOptions,
   ): NodeJS.Timeout {
     const duration = Temporal.Duration.from(interval)
-    const locale = this.homey.i18n.getLanguage()
-    const timezone = this.homey.clock.getTimezone()
+    const locale = getLocale(this.homey)
     this.log(
       capitalize(actionType),
       'will run',
       timerWords.timeSpecifier,
       duration.round({ largestUnit: 'days' }).toLocaleString(locale),
       timerWords.dateSpecifier,
-      Temporal.Now.zonedDateTimeISO(timezone)
-        .add(duration)
-        .toLocaleString(locale, {
-          dateStyle: 'full',
-          timeStyle: 'full',
-        }),
+      getNow(this.homey).add(duration).toLocaleString(locale, {
+        dateStyle: 'full',
+        timeStyle: 'full',
+      }),
     )
 
     return this.homey[timerType](

--- a/drivers/base-report.mts
+++ b/drivers/base-report.mts
@@ -1,4 +1,3 @@
-import type { Hour } from '@olivierzal/melcloud-api'
 import type * as Classic from '@olivierzal/melcloud-api/classic'
 import type Homey from 'homey/lib/Homey'
 import { Temporal } from 'temporal-polyfill'
@@ -110,7 +109,7 @@ export class EnergyReport<T extends Classic.DeviceType> {
   #calculatePowerValue(
     data: Classic.EnergyData<T>,
     tags: readonly (keyof Classic.EnergyData<T>)[],
-    hour: Hour,
+    hour: number,
   ): number {
     let total = 0
     for (const tag of tags) {
@@ -145,8 +144,7 @@ export class EnergyReport<T extends Classic.DeviceType> {
           to,
         }),
       )
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- ZonedDateTime.hour is structurally 0-23, matches the Hour literal union
-      await this.#set(data, toDateTime.hour as Hour)
+      await this.#set(data, toDateTime.hour)
     } catch (error) {
       this.#device.error('Energy report fetch failed:', error)
     }
@@ -171,7 +169,7 @@ export class EnergyReport<T extends Classic.DeviceType> {
     )
   }
 
-  async #set(data: Classic.EnergyData<T>, hour: Hour): Promise<void> {
+  async #set(data: Classic.EnergyData<T>, hour: number): Promise<void> {
     if ('UsageDisclaimerPercentages' in data) {
       ;({ length: this.#linkedDeviceCount } =
         data.UsageDisclaimerPercentages.split(','))

--- a/drivers/base-report.mts
+++ b/drivers/base-report.mts
@@ -1,7 +1,7 @@
 import type { Hour } from '@olivierzal/melcloud-api'
 import type * as Classic from '@olivierzal/melcloud-api/classic'
 import type Homey from 'homey/lib/Homey'
-import { type DateObjectUnits, type DurationLike, DateTime } from 'luxon'
+import { Temporal } from 'temporal-polyfill'
 
 import type {
   Capabilities,
@@ -23,11 +23,11 @@ const sumTags = <T extends Classic.DeviceType>(
   tags.reduce((accumulator, tag) => accumulator + Number(data[tag]), 0)
 
 export interface EnergyReportConfig {
-  readonly duration: DurationLike
-  readonly interval: DurationLike
-  readonly minus: DurationLike
+  readonly duration: Temporal.DurationLike
+  readonly interval: Temporal.DurationLike
+  readonly minus: Temporal.DurationLike
   readonly mode: EnergyReportMode
-  readonly values: DateObjectUnits
+  readonly values: Temporal.PlainTimeLike
 }
 
 export class EnergyReport<T extends Classic.DeviceType> {
@@ -123,11 +123,9 @@ export class EnergyReport<T extends Classic.DeviceType> {
     return total / this.#linkedDeviceCount
   }
 
-  #computeNextFireDelay(): DurationLike {
-    return DateTime.now()
-      .plus(this.#config.duration)
-      .set(this.#config.values)
-      .diffNow()
+  #computeNextFireDelay(): Temporal.Duration {
+    const now = Temporal.Now.zonedDateTimeISO(this.#homey.clock.getTimezone())
+    return now.add(this.#config.duration).with(this.#config.values).since(now)
   }
 
   async #get(): Promise<void> {
@@ -136,8 +134,10 @@ export class EnergyReport<T extends Classic.DeviceType> {
       return
     }
     // Fetch energy data from the previous period (offset by config.minus)
-    const toDateTime = DateTime.now().minus(this.#config.minus)
-    const to = toDateTime.toISODate()
+    const toDateTime = Temporal.Now.zonedDateTimeISO(
+      this.#homey.clock.getTimezone(),
+    ).subtract(this.#config.minus)
+    const to = toDateTime.toPlainDate().toString()
     try {
       const data = unwrapResult(
         await device.getEnergy({
@@ -145,7 +145,8 @@ export class EnergyReport<T extends Classic.DeviceType> {
           to,
         }),
       )
-      await this.#set(data, toDateTime.hour)
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- ZonedDateTime.hour is structurally 0-23, matches the Hour literal union
+      await this.#set(data, toDateTime.hour as Hour)
     } catch (error) {
       this.#device.error('Energy report fetch failed:', error)
     }

--- a/drivers/base-report.mts
+++ b/drivers/base-report.mts
@@ -1,6 +1,6 @@
 import type * as Classic from '@olivierzal/melcloud-api/classic'
 import type Homey from 'homey/lib/Homey'
-import { Temporal } from 'temporal-polyfill'
+import type { Temporal } from 'temporal-polyfill'
 
 import type {
   Capabilities,
@@ -10,6 +10,7 @@ import type {
 import type { EnergyReportMode } from '../types/device.mts'
 import { KILOWATT_TO_WATT } from '../lib/constants.mts'
 import { isTotalEnergyKey } from '../lib/is-total-energy-key.mts'
+import { getNow } from '../lib/temporal.mts'
 import { typedEntries } from '../lib/typed-object.mts'
 import { unwrapResult } from '../lib/unwrap-result.mts'
 import type { ClassicMELCloudDevice } from './classic-device.mts'
@@ -123,7 +124,7 @@ export class EnergyReport<T extends Classic.DeviceType> {
   }
 
   #computeNextFireDelay(): Temporal.Duration {
-    const now = Temporal.Now.zonedDateTimeISO(this.#homey.clock.getTimezone())
+    const now = getNow(this.#homey)
     return now.add(this.#config.duration).with(this.#config.values).since(now)
   }
 
@@ -133,9 +134,7 @@ export class EnergyReport<T extends Classic.DeviceType> {
       return
     }
     // Fetch energy data from the previous period (offset by config.minus)
-    const toDateTime = Temporal.Now.zonedDateTimeISO(
-      this.#homey.clock.getTimezone(),
-    ).subtract(this.#config.minus)
+    const toDateTime = getNow(this.#homey).subtract(this.#config.minus)
     const to = toDateTime.toPlainDate().toString()
     try {
       const data = unwrapResult(

--- a/drivers/melcloud_atw/device.mts
+++ b/drivers/melcloud_atw/device.mts
@@ -1,5 +1,5 @@
 import { hasClassicZone2, isClassicAtwFacade } from '@olivierzal/melcloud-api'
-import { DateTime } from 'luxon'
+import { Temporal } from 'temporal-polyfill'
 import * as Classic from '@olivierzal/melcloud-api/classic'
 
 import type {
@@ -73,11 +73,14 @@ export default class ClassicMELCloudDeviceAtw extends ClassicMELCloudDevice<
     hot_water_mode: (isForced: boolean) =>
       isForced ? HotWaterMode.forced : HotWaterMode.auto,
     legionella: (value: string) =>
-      DateTime.fromISO(value).toLocaleString({
-        day: 'numeric',
-        month: 'short',
-        weekday: 'short',
-      }),
+      Temporal.PlainDate.from(value).toLocaleString(
+        this.homey.i18n.getLanguage(),
+        {
+          day: 'numeric',
+          month: 'short',
+          weekday: 'short',
+        },
+      ),
     operational_state: (value: Classic.OperationModeState) =>
       operationModeStateFromDevice[value],
   }

--- a/drivers/melcloud_atw/device.mts
+++ b/drivers/melcloud_atw/device.mts
@@ -10,6 +10,7 @@ import type {
 } from '../../types/capabilities.mts'
 import type { EnergyReportConfig } from '../base-report.mts'
 import { KILOWATT_TO_WATT } from '../../lib/constants.mts'
+import { getLocale } from '../../lib/temporal.mts'
 import {
   type TargetTemperatureFlowCapabilities,
   HotWaterMode,
@@ -73,14 +74,11 @@ export default class ClassicMELCloudDeviceAtw extends ClassicMELCloudDevice<
     hot_water_mode: (isForced: boolean) =>
       isForced ? HotWaterMode.forced : HotWaterMode.auto,
     legionella: (value: string) =>
-      Temporal.PlainDate.from(value).toLocaleString(
-        this.homey.i18n.getLanguage(),
-        {
-          day: 'numeric',
-          month: 'short',
-          weekday: 'short',
-        },
-      ),
+      Temporal.PlainDate.from(value).toLocaleString(getLocale(this.homey), {
+        day: 'numeric',
+        month: 'short',
+        weekday: 'short',
+      }),
     operational_state: (value: Classic.OperationModeState) =>
       operationModeStateFromDevice[value],
   }

--- a/lib/temporal.mts
+++ b/lib/temporal.mts
@@ -1,0 +1,14 @@
+import type Homey from 'homey/lib/Homey'
+import { Temporal } from 'temporal-polyfill'
+
+/** IANA timezone identifier from Homey's clock manager (e.g. `'Europe/Paris'`). */
+export const getTimeZone = (homey: Homey.Homey): string =>
+  homey.clock.getTimezone()
+
+/** Current Temporal moment in the user's Homey-configured timezone. */
+export const getNow = (homey: Homey.Homey): Temporal.ZonedDateTime =>
+  Temporal.Now.zonedDateTimeISO(getTimeZone(homey))
+
+/** BCP-47 locale tag from Homey's i18n manager (e.g. `'en'`, `'fr'`). */
+export const getLocale = (homey: Homey.Homey): string =>
+  homey.i18n.getLanguage()

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
       "version": "44.1.0",
       "license": "GPL-3.0-only",
       "dependencies": {
-        "@olivierzal/melcloud-api": "^38.0.2",
+        "@olivierzal/melcloud-api": "^39.0.0",
         "homey-lib": "^2.50.2",
-        "luxon": "^3.7.2",
-        "source-map-support": "^0.5.21"
+        "source-map-support": "^0.5.21",
+        "temporal-polyfill": "^0.3.2"
       },
       "devDependencies": {
         "@eslint/css": "^1.2.0",
@@ -25,7 +25,6 @@
         "@swc/core": "^1.15.33",
         "@tailwindcss/cli": "^4.3.0",
         "@types/homey": "npm:homey-apps-sdk-v3-types@^0.3.12",
-        "@types/luxon": "^3.7.1",
         "@types/node": "^25.9.1",
         "@typescript/native-preview": "^7.0.0-dev.20260522.1",
         "@vitest/coverage-v8": "^4.1.7",
@@ -648,18 +647,18 @@
       }
     },
     "node_modules/@olivierzal/melcloud-api": {
-      "version": "38.0.2",
-      "resolved": "https://npm.pkg.github.com/download/@olivierzal/melcloud-api/38.0.2/342ed0a3b0e181e7da6577dfb0352d3e0524c12e",
-      "integrity": "sha512-kHUy/4ZkpldoDcvDQmmaHgEyxikZHn8TitmprlEZUv0+KD+9CdWrwUt3MNXV1tJRJB1BqB5K8ac/JDfB40Y8jA==",
+      "version": "39.0.0",
+      "resolved": "https://npm.pkg.github.com/download/@olivierzal/melcloud-api/39.0.0/7eb19d80bc1fbd6e877e636315220cc34336b5a3",
+      "integrity": "sha512-pho/TwW+VnwwNeDuqwx+ryBC44lp1RKj/uZyKC79UJkTTbm7PVQWMF8q9XyPICuVREy9ogxL2ZpTNb5ZJDppLg==",
       "license": "MIT",
       "dependencies": {
-        "luxon": "^3.7.2",
+        "temporal-polyfill": "^0.3.2",
         "tough-cookie": "^6.0.1",
-        "undici": "^8.2.0",
-        "zod": "^4.4.2"
+        "undici": "^8.3.0",
+        "zod": "^4.4.3"
       },
       "engines": {
-        "node": ">=22"
+        "node": ">=22.19.0"
       }
     },
     "node_modules/@ota-meshi/ast-token-store": {
@@ -2065,13 +2064,6 @@
       "version": "0.16.8",
       "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.8.tgz",
       "integrity": "sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/luxon": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.7.1.tgz",
-      "integrity": "sha512-H3iskjFIAn5SlJU7OuxUmTEpebK6TKB8rxZShDslBMZJ5u9S//KM1sbdAisiSrqwLQncVjnpi2OK2J51h+4lsg==",
       "dev": true,
       "license": "MIT"
     },
@@ -4972,15 +4964,6 @@
         "node": "20 || >=22"
       }
     },
-    "node_modules/luxon": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
-      "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -6605,6 +6588,21 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/temporal-polyfill": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-0.3.2.tgz",
+      "integrity": "sha512-TzHthD/heRK947GNiSu3Y5gSPpeUDH34+LESnfsq8bqpFhsB79HFBX8+Z834IVX68P3EUyRPZK5bL/1fh437Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "temporal-spec": "0.3.1"
+      }
+    },
+    "node_modules/temporal-spec": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/temporal-spec/-/temporal-spec-0.3.1.tgz",
+      "integrity": "sha512-B4TUhezh9knfSIMwt7RVggApDRJZo73uZdj8AacL2mZ8RP5KtLianh2MXxL06GN9ESYiIsiuoLQhgVfwe55Yhw==",
+      "license": "ISC"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -6775,9 +6773,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.2.0.tgz",
-      "integrity": "sha512-Z+4Hx9GE26Lh9Upwfnc8C7SsrpBPGaM/Gm6kMFtiG7c+5IvQKlXi/t+9x9DrrCh29cww5TSP9YdVaBcnLDs5fQ==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.3.0.tgz",
+      "integrity": "sha512-TkUDgb6tl7KOGZ+7e8E3d2FYgUQgF6z5YypqjWmixVQSQERFcVrVg0ySADm2LVLRh5ljAaHTCR5Fmz3Q34rB7Q==",
       "license": "MIT",
       "engines": {
         "node": ">=22.19.0"

--- a/package.json
+++ b/package.json
@@ -35,10 +35,10 @@
     "typecheck": "tsgo --noEmit"
   },
   "dependencies": {
-    "@olivierzal/melcloud-api": "^38.0.2",
+    "@olivierzal/melcloud-api": "^39.0.0",
     "homey-lib": "^2.50.2",
-    "luxon": "^3.7.2",
-    "source-map-support": "^0.5.21"
+    "source-map-support": "^0.5.21",
+    "temporal-polyfill": "^0.3.2"
   },
   "devDependencies": {
     "@eslint/css": "^1.2.0",
@@ -51,7 +51,6 @@
     "@swc/core": "^1.15.33",
     "@tailwindcss/cli": "^4.3.0",
     "@types/homey": "npm:homey-apps-sdk-v3-types@^0.3.12",
-    "@types/luxon": "^3.7.1",
     "@types/node": "^25.9.1",
     "@typescript/native-preview": "^7.0.0-dev.20260522.1",
     "@vitest/coverage-v8": "^4.1.7",
@@ -80,6 +79,6 @@
     "vitest": "^4.1.2"
   },
   "engines": {
-    "node": ">=22"
+    "node": ">=22.19.0"
   }
 }

--- a/tests/mock-device-class.ts
+++ b/tests/mock-device-class.ts
@@ -54,6 +54,8 @@ export const createMockDeviceClass = (
       app: { getClassicFacade: vi.fn<(kind: string, id: number) => unknown>() },
       clearInterval: vi.fn<(timer: NodeJS.Timeout | undefined) => void>(),
       clearTimeout: vi.fn<(timer: NodeJS.Timeout | null) => void>(),
+      clock: { getTimezone: vi.fn<() => string>(() => 'Europe/Paris') },
+      i18n: { getLanguage: vi.fn<() => string>(() => 'en') },
       setInterval:
         vi.fn<(callback: () => void, ms: number) => NodeJS.Timeout>(),
       setTimeout: vi.fn<(callback: () => void, ms: number) => NodeJS.Timeout>(),

--- a/tests/unit/app.test.ts
+++ b/tests/unit/app.test.ts
@@ -6,7 +6,6 @@ import {
   type SyncCallback,
   ok,
 } from '@olivierzal/melcloud-api'
-import { Settings as LuxonSettings } from 'luxon'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import * as Classic from '@olivierzal/melcloud-api/classic'
 import * as Home from '@olivierzal/melcloud-api/home'
@@ -352,6 +351,7 @@ describe('melCloudApp', () => {
       expect(mockCreate).toHaveBeenCalledWith(
         expect.objectContaining({
           language: 'en',
+          locale: 'en',
           timezone: 'Europe/Paris',
         }),
       )
@@ -392,15 +392,6 @@ describe('melCloudApp', () => {
 
       expect(logMock).toHaveBeenCalledWith('test log')
       expect(errorMock).toHaveBeenCalledWith('test error')
-    })
-
-    it('should set luxon defaults', async () => {
-      await app.onInit()
-
-      expect(LuxonSettings.defaultLocale).toBe('en')
-      expect(LuxonSettings.defaultZone).toStrictEqual(
-        expect.objectContaining({ zoneName: 'Europe/Paris' }),
-      )
     })
 
     it('should create notification when version differs', async () => {
@@ -739,7 +730,11 @@ describe('melCloudApp', () => {
   })
 
   describe('home facade retrieval', () => {
-    const mockModel = { id: 'device-1', name: 'Living Room' }
+    const mockModel = {
+      id: 'device-1',
+      name: 'Living Room',
+      isAta: (): boolean => true,
+    }
 
     it('should return a facade for a matching device', async () => {
       mockHomeApiInstance.list.mockResolvedValue([])

--- a/tests/unit/app.test.ts
+++ b/tests/unit/app.test.ts
@@ -757,6 +757,21 @@ describe('melCloudApp', () => {
       )
       expect(mockTranslate).toHaveBeenCalledWith('errors.deviceNotFound')
     })
+
+    it('should throw when device is found but is not ATA', async () => {
+      const atwModel = {
+        id: 'device-1',
+        name: 'Heat Pump',
+        isAta: (): boolean => false,
+      }
+      mockHomeApiInstance.list.mockResolvedValue([])
+      mockHomeRegistry.getById.mockReturnValue(atwModel)
+      await app.onInit()
+
+      expect(() => app.getHomeFacade('device-1')).toThrow(
+        'errors.deviceNotFound',
+      )
+    })
   })
 
   describe('frost protection settings retrieval', () => {

--- a/tests/unit/base-report.test.ts
+++ b/tests/unit/base-report.test.ts
@@ -22,9 +22,6 @@ import { getMockCallArg, mock } from '../helpers.ts'
 
 type TestDeviceType = typeof Classic.DeviceType.Ata
 
-// Explicit offset so the same instant resolves identically regardless of
-// the host's local timezone (CI runs UTC; dev machines often run CET/CEST).
-// 12:00 Europe/Paris in mid-March (pre-DST) → 11:00 UTC.
 const FAKE_NOW = new Date('2026-03-18T12:00:00.000+01:00')
 
 const setCapabilityValueMock =

--- a/tests/unit/base-report.test.ts
+++ b/tests/unit/base-report.test.ts
@@ -22,7 +22,10 @@ import { getMockCallArg, mock } from '../helpers.ts'
 
 type TestDeviceType = typeof Classic.DeviceType.Ata
 
-const FAKE_NOW = new Date('2026-03-18T12:00:00.000')
+// Explicit offset so the same instant resolves identically regardless of
+// the host's local timezone (CI runs UTC; dev machines often run CET/CEST).
+// 12:00 Europe/Paris in mid-March (pre-DST) → 11:00 UTC.
+const FAKE_NOW = new Date('2026-03-18T12:00:00.000+01:00')
 
 const setCapabilityValueMock =
   vi.fn<(capability: string, value: unknown) => Promise<void>>()

--- a/tests/unit/base-report.test.ts
+++ b/tests/unit/base-report.test.ts
@@ -89,6 +89,9 @@ const mockDevice = mock<ClassicMELCloudDevice<TestDeviceType>>({
   homey: mock<Homey.Homey>({
     clearInterval: clearIntervalMock,
     clearTimeout: clearTimeoutMock,
+    clock: mock<Homey.Homey['clock']>({
+      getTimezone: vi.fn<() => string>(() => 'Europe/Paris'),
+    }),
   }),
   log: logMock,
   setCapabilityValue: setCapabilityValueMock,
@@ -130,6 +133,9 @@ const createCopMocks = (): ClassicMELCloudDevice<TestDeviceType> => {
     homey: mock<Homey.Homey>({
       clearInterval: clearIntervalMock,
       clearTimeout: clearTimeoutMock,
+      clock: mock<Homey.Homey['clock']>({
+        getTimezone: vi.fn<() => string>(() => 'Europe/Paris'),
+      }),
     }),
     log: logMock,
     setCapabilityValue: setCapabilityValueMock,

--- a/tests/unit/capabilities-options.test.ts
+++ b/tests/unit/capabilities-options.test.ts
@@ -53,7 +53,7 @@ describe(getCapabilitiesOptionsAtaErv, () => {
 
 describe(homeGetCapabilitiesOptions, () => {
   it('should return fan_speed options from Home device capabilities', () => {
-    const capabilities = mock<Home.DeviceCapabilities>({
+    const capabilities = mock<Home.AtaDeviceCapabilities>({
       hasAutomaticFanSpeed: true,
       numberOfFanSpeeds: 4,
     })
@@ -65,7 +65,7 @@ describe(homeGetCapabilitiesOptions, () => {
   })
 
   it('should return min 1 when hasAutomaticFanSpeed is false', () => {
-    const capabilities = mock<Home.DeviceCapabilities>({
+    const capabilities = mock<Home.AtaDeviceCapabilities>({
       hasAutomaticFanSpeed: false,
       numberOfFanSpeeds: 5,
     })

--- a/tests/unit/classic-device.test.ts
+++ b/tests/unit/classic-device.test.ts
@@ -79,6 +79,8 @@ vi.mock('homey', async () => {
             app: { getClassicFacade: getFacadeMock },
             clearInterval: vi.fn<(timer: NodeJS.Timeout | undefined) => void>(),
             clearTimeout: vi.fn<(timer: NodeJS.Timeout | null) => void>(),
+            clock: { getTimezone: vi.fn<() => string>(() => 'Europe/Paris') },
+            i18n: { getLanguage: vi.fn<() => string>(() => 'en') },
             setInterval:
               vi.fn<(callback: () => void, ms: number) => NodeJS.Timeout>(),
             setTimeout:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,7 @@
     "skipLibCheck": true,
     "sourceMap": true,
     "target": "es2025",
-    "types": ["node", "luxon"],
+    "types": ["node"],
     "verbatimModuleSyntax": true
   },
   "exclude": ["*.config.ts"]

--- a/types/ata-erv.mts
+++ b/types/ata-erv.mts
@@ -31,7 +31,7 @@ export const getCapabilitiesOptionsAtaErv = ({
 export const homeGetCapabilitiesOptions = ({
   hasAutomaticFanSpeed,
   numberOfFanSpeeds,
-}: Home.DeviceCapabilities): Partial<CapabilitiesOptionsAtaErv> =>
+}: Home.AtaDeviceCapabilities): Partial<CapabilitiesOptionsAtaErv> =>
   getFanSpeedOptions(hasAutomaticFanSpeed, numberOfFanSpeeds)
 
 const addPrefixToTitle = (

--- a/widgets/ata-group-setting/public/styles/dist.css
+++ b/widgets/ata-group-setting/public/styles/dist.css
@@ -27,7 +27,7 @@
       z-index: 999;
       @media (prefers-reduced-motion: no-preference) {
         animation: dropdown 0.2s;
-        transition-property: opacity, scale, display;
+        transition-property: opacity, scale, display, overlay;
         transition-behavior: allow-discrete;
         transition-duration: 0.2s;
         transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
@@ -1309,28 +1309,17 @@
   text-align-last: center;
 }
 @layer base {
-  :root {
-    --fx-noise: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 200 200'%3E%3Cfilter id='a'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='1.34' numOctaves='4' stitchTiles='stitch'%3E%3C/feTurbulence%3E%3C/filter%3E%3Crect width='200' height='200' filter='url(%23a)' opacity='0.2'%3E%3C/rect%3E%3C/svg%3E");
-  }
-}
-@layer base {
-  :root {
-    scrollbar-color: currentColor #0000;
-    @supports (color: color-mix(in lab, red, red)) {
-      scrollbar-color: color-mix(in oklch, currentColor 35%, #0000) #0000;
-    }
-  }
-}
-@layer base {
-  @property --radialprogress {
-    syntax: "<percentage>";
-    inherits: true;
-    initial-value: 0%;
-  }
-}
-@layer base {
   :root:not(span) {
     overflow: var(--page-overflow);
+  }
+}
+@layer base {
+  :root, [data-theme] {
+    background: var(--page-scroll-bg, var(--root-bg));
+    color: var(--color-base-content);
+  }
+  :where(:root, [data-theme]) {
+    --root-bg: var(--color-base-100);
   }
 }
 @layer base {
@@ -1354,12 +1343,41 @@
   }
 }
 @layer base {
-  :root, [data-theme] {
-    background: var(--page-scroll-bg, var(--root-bg));
-    color: var(--color-base-content);
+  :root {
+    --fx-noise: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 200 200'%3E%3Cfilter id='a'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='1.34' numOctaves='4' stitchTiles='stitch'%3E%3C/feTurbulence%3E%3C/filter%3E%3Crect width='200' height='200' filter='url(%23a)' opacity='0.2'%3E%3C/rect%3E%3C/svg%3E");
   }
-  :where(:root, [data-theme]) {
-    --root-bg: var(--color-base-100);
+}
+@layer base {
+  :root {
+    scrollbar-color: currentColor #0000;
+    @supports (color: color-mix(in lab, red, red)) {
+      scrollbar-color: color-mix(in oklch, currentColor 35%, #0000) #0000;
+    }
+  }
+}
+@layer base {
+  @property --radialprogress {
+    syntax: "<percentage>";
+    inherits: true;
+    initial-value: 0%;
+  }
+}
+@keyframes menu {
+  0% {
+    opacity: 0;
+  }
+}
+@keyframes dropdown {
+  0% {
+    opacity: 0;
+  }
+}
+@keyframes skeleton {
+  0% {
+    background-position: 150%;
+  }
+  100% {
+    background-position: -50%;
   }
 }
 @keyframes rating {
@@ -1368,17 +1386,9 @@
     filter: brightness(1.05) contrast(1.05);
   }
 }
-@keyframes dropdown {
-  0% {
-    opacity: 0;
-  }
-}
-@keyframes radio {
-  0% {
-    padding: 5px;
-  }
+@keyframes progress {
   50% {
-    padding: 3px;
+    background-position-x: -115%;
   }
 }
 @keyframes toast {
@@ -1402,22 +1412,12 @@
     translate: 0 -100%;
   }
 }
-@keyframes skeleton {
+@keyframes radio {
   0% {
-    background-position: 150%;
+    padding: 5px;
   }
-  100% {
-    background-position: -50%;
-  }
-}
-@keyframes menu {
-  0% {
-    opacity: 0;
-  }
-}
-@keyframes progress {
   50% {
-    background-position-x: -115%;
+    padding: 3px;
   }
 }
 @property --tw-rotate-x {

--- a/widgets/charts/public/styles/dist.css
+++ b/widgets/charts/public/styles/dist.css
@@ -27,7 +27,7 @@
       z-index: 999;
       @media (prefers-reduced-motion: no-preference) {
         animation: dropdown 0.2s;
-        transition-property: opacity, scale, display;
+        transition-property: opacity, scale, display, overlay;
         transition-behavior: allow-discrete;
         transition-duration: 0.2s;
         transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
@@ -1309,28 +1309,17 @@
   text-align-last: center;
 }
 @layer base {
-  :root {
-    --fx-noise: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 200 200'%3E%3Cfilter id='a'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='1.34' numOctaves='4' stitchTiles='stitch'%3E%3C/feTurbulence%3E%3C/filter%3E%3Crect width='200' height='200' filter='url(%23a)' opacity='0.2'%3E%3C/rect%3E%3C/svg%3E");
-  }
-}
-@layer base {
-  :root {
-    scrollbar-color: currentColor #0000;
-    @supports (color: color-mix(in lab, red, red)) {
-      scrollbar-color: color-mix(in oklch, currentColor 35%, #0000) #0000;
-    }
-  }
-}
-@layer base {
-  @property --radialprogress {
-    syntax: "<percentage>";
-    inherits: true;
-    initial-value: 0%;
-  }
-}
-@layer base {
   :root:not(span) {
     overflow: var(--page-overflow);
+  }
+}
+@layer base {
+  :root, [data-theme] {
+    background: var(--page-scroll-bg, var(--root-bg));
+    color: var(--color-base-content);
+  }
+  :where(:root, [data-theme]) {
+    --root-bg: var(--color-base-100);
   }
 }
 @layer base {
@@ -1354,12 +1343,41 @@
   }
 }
 @layer base {
-  :root, [data-theme] {
-    background: var(--page-scroll-bg, var(--root-bg));
-    color: var(--color-base-content);
+  :root {
+    --fx-noise: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 200 200'%3E%3Cfilter id='a'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='1.34' numOctaves='4' stitchTiles='stitch'%3E%3C/feTurbulence%3E%3C/filter%3E%3Crect width='200' height='200' filter='url(%23a)' opacity='0.2'%3E%3C/rect%3E%3C/svg%3E");
   }
-  :where(:root, [data-theme]) {
-    --root-bg: var(--color-base-100);
+}
+@layer base {
+  :root {
+    scrollbar-color: currentColor #0000;
+    @supports (color: color-mix(in lab, red, red)) {
+      scrollbar-color: color-mix(in oklch, currentColor 35%, #0000) #0000;
+    }
+  }
+}
+@layer base {
+  @property --radialprogress {
+    syntax: "<percentage>";
+    inherits: true;
+    initial-value: 0%;
+  }
+}
+@keyframes menu {
+  0% {
+    opacity: 0;
+  }
+}
+@keyframes dropdown {
+  0% {
+    opacity: 0;
+  }
+}
+@keyframes skeleton {
+  0% {
+    background-position: 150%;
+  }
+  100% {
+    background-position: -50%;
   }
 }
 @keyframes rating {
@@ -1368,17 +1386,9 @@
     filter: brightness(1.05) contrast(1.05);
   }
 }
-@keyframes dropdown {
-  0% {
-    opacity: 0;
-  }
-}
-@keyframes radio {
-  0% {
-    padding: 5px;
-  }
+@keyframes progress {
   50% {
-    padding: 3px;
+    background-position-x: -115%;
   }
 }
 @keyframes toast {
@@ -1402,22 +1412,12 @@
     translate: 0 -100%;
   }
 }
-@keyframes skeleton {
+@keyframes radio {
   0% {
-    background-position: 150%;
+    padding: 5px;
   }
-  100% {
-    background-position: -50%;
-  }
-}
-@keyframes menu {
-  0% {
-    opacity: 0;
-  }
-}
-@keyframes progress {
   50% {
-    background-position-x: -115%;
+    padding: 3px;
   }
 }
 @property --tw-rotate-x {


### PR DESCRIPTION
## Why

[`@olivierzal/melcloud-api@39.0.0`](https://github.com/OlivierZal/melcloud-api/releases/tag/v39.0.0) (released today) replaced Luxon with the Stage-4 Temporal proposal in its public surface. This PR bumps the dep, migrates com.melcloud's own Luxon usage to Temporal in the same pass, and adapts to v39's tightened type narrowing.

## Changes

### Dependency surface
- `@olivierzal/melcloud-api`: `^38.0.2` → `^39.0.0`
- Drop `luxon` + `@types/luxon` (no longer used anywhere)
- Add `temporal-polyfill` (~30 KB; defers to native `globalThis.Temporal` once V8 14 / Node 26+ ships it unflagged)
- `engines.node`: `>=22` → `>=22.19.0` (matches v39's floor, transitively required by `undici@8.3.0`)

### Luxon → Temporal migration (5 production files)
- **`app.mts`** — drop `LuxonSettings.defaultLocale/defaultZone` global mutation (latent bug; v39 no longer reads from those globals anyway). `locale` is now passed explicitly to `Classic.API.create({ language, locale, timezone })`. `createDateRange` takes timezone as a parameter and uses `Temporal.Now.plainDateTimeISO(tz)`.
- **`drivers/base-device.mts`** (`#setTimer`) — `Duration.fromDurationLike` → `Temporal.Duration.from`. The duration's human label uses `Temporal.Duration.prototype.toLocaleString(locale)` (backed by `Intl.DurationFormat` on Node 22+). The "next fire at …" timestamp uses `ZonedDateTime.toLocaleString(locale, { dateStyle: 'full', timeStyle: 'full' })` — matches Luxon's `DATETIME_HUGE_WITH_SECONDS` shape.
- **`drivers/base-report.mts`** — `EnergyReportConfig` retyped to `Temporal.DurationLike` / `Temporal.PlainTimeLike` (structurally the same `{ hours, days, hour, minute, … }`). `#computeNextFireDelay` rewritten with `ZonedDateTime.add().with().since(now)`. Timezone read per-call from `this.#homey.clock.getTimezone()` instead of via a Luxon global.
- **`drivers/melcloud_atw/device.mts`** — legionella date formatting uses `Temporal.PlainDate.from(iso).toLocaleString(language, …)`.
- **`tsconfig.json`** — drop `"luxon"` from `compilerOptions.types`.

### v39 type adaptations (separate from Temporal — fallout from melcloud-api#1504)
- **`app.mts#getHomeFacade`** — narrow with `model?.isAta()` (FacadeManager.get now requires a discriminated `HomeDevice<HomeAta…|HomeAtw…>`).
- **`types/ata-erv.mts#homeGetCapabilitiesOptions`** — parameter type narrowed from `Home.DeviceCapabilities` (union) to `Home.AtaDeviceCapabilities` (where `hasAutomaticFanSpeed` / `numberOfFanSpeeds` live now).
- Test mocks updated to match.

### Test mock infrastructure
- `tests/mock-device-class.ts` — add `clock.getTimezone()` and `i18n.getLanguage()` defaults on the shared homey mock so device-driver tests that go through the new Temporal code paths don't have to re-declare them per file.
- `tests/unit/app.test.ts` — drop the obsolete *"should set luxon defaults"* test (the global-mutation behavior it asserted no longer exists). The existing `mockCreate` assertion is extended to also check `locale`.

### Side-effect noise
- `widgets/*/styles/dist.css` — regenerated by `npx homey app validate` (the validate step runs Tailwind). Minor CSS-property order changes.

## Polyfill choice rationale

Default for Temporal: `import { Temporal } from 'temporal-polyfill'` directly (not re-exported via `@olivierzal/melcloud-api`). Reasons:
- Explicit dep relationship — com.melcloud's polyfill choice is decoupled from melcloud-api's.
- Standard pattern in the ecosystem (no magic globals).
- The polyfill itself defers to native `globalThis.Temporal` when available, so when Node 26+ ships native Temporal we get it transparently — no migration needed.

## Validation

- `typecheck` ✓
- `lint` ✓
- `format` ✓
- `test` — **418/418 passing**
- `homey app validate --level publish` ✓

## Test plan

- [ ] CI green (Check, Test Node 22/latest/lts/*, Validate app, Zizmor)
- [ ] Smoke-check after deploy: confirm energy reports schedule correctly (`Temporal.Now.zonedDateTimeISO(tz)` returns the Homey timezone), legionella formatted dates look right, timer "next fire at …" log lines render

🤖 Generated with [Claude Code](https://claude.com/claude-code)