### PR TITLE
ci: support GitHub merge queue (merge_group triggers)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ jobs:
     timeout-minutes: 20
 name: CI
 on:
+  merge_group: {}
   pull_request: {}
   push:
     branches: [main]

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -22,6 +22,7 @@ jobs:
     timeout-minutes: 15
 name: Validate
 on:
+  merge_group: {}
   pull_request: {}
   push:
     branches: [main]

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -18,6 +18,7 @@ jobs:
     timeout-minutes: 15
 name: Zizmor
 on:
+  merge_group: {}
   pull_request: {}
   push:
     branches: [main]


### PR DESCRIPTION
## Why

Today `main` requires branches to be **up to date before merging**. With Dependabot auto-merge enabled, that serializes everything: when one PR merges, every other open PR falls behind `main`, must be rebased, and re-runs the full CI matrix before it can merge — quadratic CI load, and grouped Dependabot PRs stall until rebased. (Visible right now on #1329 and #1330, both sitting on the same base commit.)

A **merge queue** solves exactly this: it speculatively tests each queued PR on top of the ones ahead of it against the latest `main`, runs CI once per entry, and merges in order — no manual rebasing, while keeping the same "tested against latest main" guarantee.

## What this PR does

Adds the `merge_group` event to the workflows that produce the deterministic status checks, so they run on the temporary `gh-readonly-queue/*` branches the queue creates:

- `ci.yml` — Check + Test matrix
- `validate.yml` — Homey app validation
- `zizmor.yml` — workflow security scan

**Without these triggers, queued PRs never receive their required checks and stall indefinitely**, so this code change must land *before* the queue is enabled.

`claude-code-review.yml` is intentionally left out — it's advisory, skips Dependabot, and shouldn't run once per queue entry. Sonar is also intentionally left on `pull_request`/`push` only (see step 3).

The existing `concurrency` blocks already behave correctly: on `merge_group`, `github.ref` is the unique queue-branch ref (own concurrency group) and `cancel-in-progress` evaluates to `false`, so queue builds don't cancel each other.

## Manual step required (repo admin — can't be done from this session)

This session's GitHub access has no branch-protection/ruleset capability, so the ruleset must be toggled by hand in **Settings → Rules / Branch protection for `main`**:

1. ✅ Enable **Require merge queue**.
2. Set the queue **merge method** to match today's behavior (the Dependabot workflow uses a merge commit).
3. ☑️ Keep **Require status checks to pass**, and set the required list to **only** checks the queue can produce:
   - ✅ Emitted by this PR's `merge_group` triggers: `Check`, `Test (Node 22)`, `Test (Node latest)`, `Test (Node lts/*)`, `Validate app`, `Zizmor`.
   - ✅ `CodeQL` (`Analyze (actions)` / `Analyze (javascript)`) uses **default setup** (no workflow file), which GitHub runs on merge-queue branches automatically — no change needed.
   - ❌ **Do _not_ require the SonarCloud quality gate.** It's kept advisory and intentionally does not run on `merge_group`; requiring it would hang the queue. It still decorates PRs as before.
4. ⬜️ **Uncheck "Require branches to be up to date before merging"** — the queue supersedes it; leaving both on is redundant and is the source of the current rebase churn.

Dependabot auto-merge needs no change: `gh pr merge --auto` enqueues instead of merging directly once the queue is on.

https://claude.ai/code/session_01LZbwJvb21m1shtBJ4HQ8iM