### PR TITLE
chore(deps): squash auto-merges, 7-day npm cooldown, group actions bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,10 +5,16 @@ registries:
     url: https://npm.pkg.github.com
 updates:
   - directory: /
+    groups:
+      actions:
+        patterns:
+          - '*'
     package-ecosystem: github-actions
     schedule:
       interval: weekly
-  - directory: /
+  - cooldown:
+      default-days: 7
+    directory: /
     groups:
       eslint:
         patterns:

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -15,7 +15,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}
-        run: gh pr merge --auto --merge --delete-branch "$PR_URL"
+        run: gh pr merge --auto --squash --delete-branch "$PR_URL"
     timeout-minutes: 10
 name: Dependabot
 on: pull_request


### PR DESCRIPTION
## What

Three Dependabot modernizations agreed in review of the repo's dependency-automation setup:

1. **Squash auto-merges** — `gh pr merge --auto --squash` in the Dependabot workflow: each bump lands as a single `Bump … (#N)` commit on `main` instead of a merge-commit + branch-commit pair. Pairs with the upcoming repo setting change to squash-only (safe to merge before it: squash is already an allowed method).
2. **7-day cooldown on npm updates** — supply-chain protection: compromised releases are almost always yanked within days of publication, so proposing versions only after a week of availability avoids the danger window. Dependabot **security updates bypass the cooldown**, so CVE reactivity is unchanged.
3. **Grouped github-actions bumps** — all action updates arrive in one weekly PR instead of one PR per action.

## Follow-up (repo settings, admin)

After this merges, on Settings → General → Pull Requests: enable **squash-only** (disable merge commits & rebase), set default squash message to *Pull request title*, and enable *Automatically delete head branches*. Or via API:

```bash
gh api -X PATCH repos/OlivierZal/com.melcloud \
  -F allow_squash_merge=true -F allow_merge_commit=false -F allow_rebase_merge=false \
  -F delete_branch_on_merge=true \
  -f squash_merge_commit_title=PR_TITLE -f squash_merge_commit_message=BLANK
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LZbwJvb21m1shtBJ4HQ8iM

---
_Generated by [Claude Code](https://claude.ai/code/session_01LZbwJvb21m1shtBJ4HQ8iM)_