### PR TITLE
Upgrade @olivierzal/melcloud-api to ^40.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "44.1.0",
       "license": "GPL-3.0-only",
       "dependencies": {
-        "@olivierzal/melcloud-api": "^39.0.0",
+        "@olivierzal/melcloud-api": "^40.0.0",
         "homey-lib": "^2.50.5",
         "source-map-support": "^0.5.21",
         "temporal-polyfill": "^1.0.1"
@@ -1058,34 +1058,19 @@
       }
     },
     "node_modules/@olivierzal/melcloud-api": {
-      "version": "39.0.0",
-      "resolved": "https://npm.pkg.github.com/download/@olivierzal/melcloud-api/39.0.0/7eb19d80bc1fbd6e877e636315220cc34336b5a3",
-      "integrity": "sha512-pho/TwW+VnwwNeDuqwx+ryBC44lp1RKj/uZyKC79UJkTTbm7PVQWMF8q9XyPICuVREy9ogxL2ZpTNb5ZJDppLg==",
+      "version": "40.0.0",
+      "resolved": "https://npm.pkg.github.com/download/@olivierzal/melcloud-api/40.0.0/0daadcf562e97ff3ba84fc47573d2dbbc4b310e1",
+      "integrity": "sha512-Dyc99VJFfIWEWVa5TRDoVcC2TGvvvM1rlKvohGqCC3DgDHuyDwugEad38BH4juT305dVLxe7H79P4OVE5gE3Pw==",
       "license": "MIT",
       "dependencies": {
-        "temporal-polyfill": "^0.3.2",
+        "temporal-polyfill": "^1.0.1",
         "tough-cookie": "^6.0.1",
-        "undici": "^8.3.0",
+        "undici": "^8.5.0",
         "zod": "^4.4.3"
       },
       "engines": {
         "node": ">=22.19.0"
       }
-    },
-    "node_modules/@olivierzal/melcloud-api/node_modules/temporal-polyfill": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-0.3.2.tgz",
-      "integrity": "sha512-TzHthD/heRK947GNiSu3Y5gSPpeUDH34+LESnfsq8bqpFhsB79HFBX8+Z834IVX68P3EUyRPZK5bL/1fh437Eg==",
-      "license": "MIT",
-      "dependencies": {
-        "temporal-spec": "0.3.1"
-      }
-    },
-    "node_modules/@olivierzal/melcloud-api/node_modules/temporal-spec": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/temporal-spec/-/temporal-spec-0.3.1.tgz",
-      "integrity": "sha512-B4TUhezh9knfSIMwt7RVggApDRJZo73uZdj8AacL2mZ8RP5KtLianh2MXxL06GN9ESYiIsiuoLQhgVfwe55Yhw==",
-      "license": "ISC"
     },
     "node_modules/@ota-meshi/ast-token-store": {
       "version": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "typecheck": "tsgo --noEmit"
   },
   "dependencies": {
-    "@olivierzal/melcloud-api": "^39.0.0",
+    "@olivierzal/melcloud-api": "^40.0.0",
     "homey-lib": "^2.50.5",
     "source-map-support": "^0.5.21",
     "temporal-polyfill": "^1.0.1"

--- a/tests/unit/classic-device.test.ts
+++ b/tests/unit/classic-device.test.ts
@@ -616,7 +616,7 @@ describe(ClassicMELCloudDevice, () => {
       const errorDevice = new TestDevice()
       setDriver(errorDevice)
       vi.spyOn(errorDevice, 'ensureDevice').mockRejectedValue(
-        new EntityNotFoundError('DeviceLocation', 1),
+        new EntityNotFoundError('DeviceLocation', { entityId: 1 }),
       )
       await errorDevice.syncFromDevice()
 


### PR DESCRIPTION
Brings [melcloud-api v40.0.0](https://github.com/OlivierZal/melcloud-api/releases/tag/v40.0.0) — the Home auth-resilience release that fixes the "settings page shows the Home credentials frame despite valid credentials" bug at its root:

- Schedule entries are validated structurally (power-off entries carry `null` fields; ATW entries use a zone/tank shape — both failed the previous strict schema and read as "unauthenticated").
- `/context` is parsed in two stages: identity slice → strict schema → per-unit salvage, so device-payload drift degrades the registry, never the authentication state.
- The session-reuse probe no longer wipes persisted tokens on transient boot failures.

Breaking-change adaptation: `EntityNotFoundError` now takes an options object (one test call site).

Pairs with #1368 (settings page reflects server auth state) for the complete fix.

Verification: typecheck, lint, format, 432 unit tests, `homey app validate --level=publish` — all green against the published package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)