### PR TITLE
fix(ci): actually disable setup-node caching when cache is 'none'

### DIFF
--- a/.github/actions/setup-node-and-install/action.yml
+++ b/.github/actions/setup-node-and-install/action.yml
@@ -25,7 +25,10 @@ runs:
       shell: bash
     - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
       with:
-        cache: ${{ inputs.cache == 'none' && '' || inputs.cache }}
+        # `''` is falsy in expressions, so `cond && '' || x` can never
+        # yield the empty string — the condition must be inverted so
+        # the falsy branch sits after `||`.
+        cache: ${{ inputs.cache != 'none' && inputs.cache || '' }}
         node-version: ${{ inputs.node-version }}
         registry-url: https://npm.pkg.github.com
         scope: '@olivierzal'


### PR DESCRIPTION
The v44.1.0 publish run failed with `Caching for 'none' is not supported`: in `setup-node-and-install`, `${{ inputs.cache == 'none' && '' || inputs.cache }}` can never yield the empty string because `''` is falsy in Actions expressions — the `||` fallback returned `none` verbatim to `actions/setup-node`. Inverting the condition (`inputs.cache != 'none' && inputs.cache || ''`) puts the falsy value in the `||` branch, which is safe since real cache values (`npm`) are always truthy.

First exercised now because no release had run since the pipeline modernization; will re-dispatch the publish workflow once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)