### PR TITLE
Erase pre-refactor legacy and resolve 24 inline disables by code

### DIFF
--- a/app.mts
+++ b/app.mts
@@ -9,7 +9,7 @@ import type {
   SettingManager,
   SyncCallback,
 } from '@olivierzal/melcloud-api'
-import { Temporal } from 'temporal-polyfill'
+import { Intl, Temporal } from 'temporal-polyfill'
 import * as Classic from '@olivierzal/melcloud-api/classic'
 import * as Home from '@olivierzal/melcloud-api/home'
 
@@ -59,16 +59,9 @@ const DRIVER_IDS_BY_TYPE: Partial<Record<DeviceType, string>> = {
   [Home.DeviceType.Ata]: 'home-melcloud',
 }
 
-const createDateRange = (
-  days: number,
-  timezone: string,
-): { from: string; to: string } => {
-  const now = Temporal.Now.plainDateTimeISO(timezone)
-  return {
-    from: now.subtract({ days }).toString(),
-    to: now.toString(),
-  }
-}
+// The report `to` bound defaults to now in the API timezone lib-side.
+const daysAgo = (days: number, timezone: string): string =>
+  Temporal.Now.plainDateTimeISO(timezone).subtract({ days }).toString()
 
 const formatErrors = (errors: Record<string, readonly string[]>): string =>
   Object.entries(errors)
@@ -176,12 +169,13 @@ const getLocalizedCapabilitiesOptions = (
 
 // MELCloud reports error timestamps either as UTC instants (Z or offset
 // suffix) or as wall-clock times in the building's timezone.
-const parseErrorDate = (date: string, timeZone: string): number => {
+const parseErrorDate = (date: string, timeZone: string): Temporal.Instant => {
   try {
-    return Temporal.Instant.from(date).epochMilliseconds
+    return Temporal.Instant.from(date)
   } catch {
-    return Temporal.PlainDateTime.from(date).toZonedDateTime(timeZone)
-      .epochMilliseconds
+    return Temporal.PlainDateTime.from(date)
+      .toZonedDateTime(timeZone)
+      .toInstant()
   }
 }
 
@@ -258,7 +252,10 @@ export default class MELCloudApp extends App {
     zoneId,
     zoneType,
   }: GetAtaOptions & ZoneData): GroupAtaStates {
-    const { devices } = this.getClassicFacade(zoneType, zoneId)
+    // Annotated to collapse the BuildingFacade | ZoneFacade `devices` union
+    // into one array type, so the `.filter` type guard below can narrow.
+    const { devices }: { devices: readonly Classic.DeviceAny[] } =
+      this.getClassicFacade(zoneType, zoneId)
     if (devices.length === 0) {
       throw new NotFoundError(this.homey.__('errors.deviceNotFound'))
     }
@@ -267,9 +264,10 @@ export default class MELCloudApp extends App {
       this.getClassicAtaCapabilities().map(([key]) => [
         key,
         devices
-          .filter((device) => device.type === Classic.DeviceType.Ata)
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- narrowing generic DeviceModel data to ATA-specific type
-          .map(({ data }) => data as Classic.ListDeviceDataAta)
+          .filter((device) =>
+            Classic.isDeviceOfType(device, Classic.DeviceType.Ata),
+          )
+          .map(({ data }) => data)
           .filter((data) => status !== 'on' || data.Power)
           .map((data) => data[key]),
       ]),
@@ -302,12 +300,6 @@ export default class MELCloudApp extends App {
       timeZone,
       year: 'numeric',
     })
-    const dateFullFormat = new Intl.DateTimeFormat(locale, {
-      day: 'numeric',
-      month: 'long',
-      timeZone,
-      year: 'numeric',
-    })
     return {
       ...rest,
       errors: errors.map(({ date, deviceId, ...errorRest }) => ({
@@ -315,10 +307,11 @@ export default class MELCloudApp extends App {
         date: dateTimeMedFormat.format(parseErrorDate(date, timeZone)),
         device: this.#classicRegistry.devices.getById(deviceId)?.name ?? '',
       })),
-      fromDateHuman: dateFullFormat.format(
-        Temporal.PlainDate.from(fromDate).toZonedDateTime(timeZone)
-          .epochMilliseconds,
-      ),
+      fromDateHuman: Temporal.PlainDate.from(fromDate).toLocaleString(locale, {
+        day: 'numeric',
+        month: 'long',
+        year: 'numeric',
+      }),
     }
   }
 
@@ -388,11 +381,11 @@ export default class MELCloudApp extends App {
     days: number
     deviceId: string
   }): Promise<ReportChartPieOptions> {
-    const dateRange = createDateRange(days, getTimeZone(this.homey))
+    const from = daysAgo(days, getTimeZone(this.homey))
     return unwrapResult(
-      await this.getClassicFacade('devices', deviceId).getOperationModes(
-        dateRange,
-      ),
+      await this.getClassicFacade('devices', deviceId).getOperationModes({
+        from,
+      }),
     )
   }
 
@@ -415,11 +408,11 @@ export default class MELCloudApp extends App {
     days: number
     deviceId: string
   }): Promise<ReportChartLineOptions> {
-    const dateRange = createDateRange(days, getTimeZone(this.homey))
+    const from = daysAgo(days, getTimeZone(this.homey))
     return unwrapResult(
-      await this.getClassicFacade('devices', deviceId).getTemperatures(
-        dateRange,
-      ),
+      await this.getClassicFacade('devices', deviceId).getTemperatures({
+        from,
+      }),
     )
   }
 
@@ -602,9 +595,10 @@ export default class MELCloudApp extends App {
         `${api}${key.charAt(0).toUpperCase()}${key.slice(1)}`
       )
     return {
-      get: (key: string): string | null | undefined =>
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- Homey settings.get returns unknown
-        this.homey.settings.get(prefixKey(key)) as string | null | undefined,
+      get: (key: string): string | null | undefined => {
+        const value: unknown = this.homey.settings.get(prefixKey(key))
+        return typeof value === 'string' || value === null ? value : undefined
+      },
       set: (key: string, value: string): void => {
         this.homey.settings.set(prefixKey(key), value)
       },

--- a/drivers/base-device.mts
+++ b/drivers/base-device.mts
@@ -30,7 +30,9 @@ const capitalize = ([first = '', ...rest] = ''): string =>
 const DEBOUNCE_DELAY = 1000
 const modes: EnergyReportMode[] = ['regular', 'total']
 
-export abstract class BaseMELCloudDevice extends Device {
+export abstract class BaseMELCloudDevice<
+  TFacade extends ClassicDeviceFacade = ClassicDeviceFacade,
+> extends Device {
   declare public readonly driver: BaseMELCloudDriver
 
   declare public readonly getData: () => { id: number | string }
@@ -57,7 +59,7 @@ export abstract class BaseMELCloudDevice extends Device {
     return this.getData().id
   }
 
-  protected get cachedFacade(): ClassicDeviceFacade | undefined {
+  protected get cachedFacade(): TFacade | undefined {
     return this.#deviceFacade
   }
 
@@ -73,7 +75,7 @@ export abstract class BaseMELCloudDevice extends Device {
     }).filter((entry): entry is [string, string] => entry[1] !== undefined)
   }
 
-  #deviceFacade?: ClassicDeviceFacade
+  #deviceFacade?: TFacade
 
   #getCapabilityTagMapping: Partial<Readonly<Record<string, string>>> = {}
 
@@ -136,7 +138,7 @@ export abstract class BaseMELCloudDevice extends Device {
     config: EnergyReportConfig,
   ): EnergyReportOperation
 
-  protected abstract getFacade(): ClassicDeviceFacade
+  protected abstract getFacade(): TFacade
 
   public abstract syncFromDevice(): Promise<void>
 
@@ -157,7 +159,7 @@ export abstract class BaseMELCloudDevice extends Device {
     ) as Partial<TMapping>
   }
 
-  public async ensureDevice(): Promise<ClassicDeviceFacade | null> {
+  public async ensureDevice(): Promise<TFacade | null> {
     try {
       return await this.#ensureDeviceFacade()
     } catch (error) {
@@ -229,14 +231,10 @@ export abstract class BaseMELCloudDevice extends Device {
   protected async applyCapabilitiesOptions(data?: unknown): Promise<void> {
     const capabilitiesOptions = this.driver.getCapabilitiesOptions(data)
     for (const [capability, options] of Object.entries(capabilitiesOptions)) {
-      /* v8 ignore next -- options is always defined in practice; Partial type is defensive */
-      if (options !== undefined) {
+      /* v8 ignore next -- options is always an object in practice; Partial type is defensive */
+      if (typeof options === 'object' && options !== null) {
         // eslint-disable-next-line no-await-in-loop -- Sequential: Homey SDK does not support concurrent capability mutations
-        await this.setCapabilityOptions(
-          capability,
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- narrowing options from unknown
-          options as Record<string, unknown>,
-        )
+        await this.setCapabilityOptions(capability, options)
       }
     }
   }
@@ -306,7 +304,7 @@ export abstract class BaseMELCloudDevice extends Device {
     this.#scheduleSyncFromDevice()
   }
 
-  async #ensureDeviceFacade(): Promise<ClassicDeviceFacade> {
+  async #ensureDeviceFacade(): Promise<TFacade> {
     if (this.#deviceFacade === undefined) {
       this.#deviceFacade = this.getFacade()
       await this.#init()

--- a/drivers/classic-device.mts
+++ b/drivers/classic-device.mts
@@ -18,7 +18,7 @@ import { type EnergyReportConfig, EnergyReport } from './base-report.mts'
 
 export abstract class ClassicMELCloudDevice<
   T extends Classic.DeviceType,
-> extends BaseMELCloudDevice {
+> extends BaseMELCloudDevice<Classic.DeviceFacade<T>> {
   declare public readonly driver: ClassicMELCloudDriver<T>
 
   declare public readonly getCapabilityOptions: <
@@ -71,17 +71,11 @@ export abstract class ClassicMELCloudDevice<
   > | null
 
   protected get facade(): Classic.DeviceFacade<T> | undefined {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- narrowing from generic base FacadeWithSetValues
-    return this.cachedFacade as Classic.DeviceFacade<T> | undefined
+    return this.cachedFacade
   }
 
   get #data(): Readonly<Classic.ListDeviceData<T>> | undefined {
     return this.facade?.data
-  }
-
-  public override async ensureDevice(): Promise<Classic.DeviceFacade<T> | null> {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- narrowing from base FacadeWithSetValues after super call
-    return (await super.ensureDevice()) as Classic.DeviceFacade<T> | null
   }
 
   public override async syncFromDevice(): Promise<void> {

--- a/drivers/home-melcloud/device.mts
+++ b/drivers/home-melcloud/device.mts
@@ -11,7 +11,6 @@ import {
 } from '@olivierzal/melcloud-api'
 import * as Classic from '@olivierzal/melcloud-api/classic'
 
-import type { ClassicDeviceFacade } from '../../types/device.mts'
 import type {
   HomeCapabilitiesAta,
   HomeConvertFromDevice,
@@ -26,7 +25,7 @@ import {
 } from '../../types/ata.mts'
 import { BaseMELCloudDevice } from '../base-device.mts'
 
-export default class HomeMELCloudDeviceAta extends BaseMELCloudDevice {
+export default class HomeMELCloudDeviceAta extends BaseMELCloudDevice<Home.DeviceAtaFacade> {
   declare public readonly getData: () => { id: string }
 
   public override get id(): string {
@@ -102,19 +101,16 @@ export default class HomeMELCloudDeviceAta extends BaseMELCloudDevice {
     return this.homey.app.getHomeFacade(this.id)
   }
 
-  async #setCapabilityValues(device: ClassicDeviceFacade): Promise<void> {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- converters accept ClassicDeviceFacade at runtime; concrete HomeConvertFromDevice type is narrower for bivariance
-    const converters = Object.entries(this.deviceToCapability) as [
-      string,
-      (device: ClassicDeviceFacade) => unknown,
-    ][]
+  async #setCapabilityValues(device: Home.DeviceAtaFacade): Promise<void> {
     await Promise.all(
-      converters.map(async ([capability, convert]) => {
-        /* v8 ignore next -- hasCapability always true in tests */
-        if (this.hasCapability(capability)) {
-          await this.setCapabilityValue(capability, convert(device))
-        }
-      }),
+      Object.entries(this.deviceToCapability).map(
+        async ([capability, convert]) => {
+          /* v8 ignore next -- hasCapability always true in tests */
+          if (this.hasCapability(capability)) {
+            await this.setCapabilityValue(capability, convert(device))
+          }
+        },
+      ),
     )
   }
 }

--- a/lib/typed-object.mts
+++ b/lib/typed-object.mts
@@ -7,8 +7,3 @@ export const typedFromEntries = <TKey extends string, TValue>(
   entries: Iterable<readonly [TKey, TValue]>,
   // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- Object.entries/fromEntries/keys lose key types; cast restores them
 ): Record<TKey, TValue> => Object.fromEntries(entries) as Record<TKey, TValue>
-
-export const typedKeys = <TKey extends string>(
-  object: Partial<Record<TKey, unknown>>,
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- Object.entries/fromEntries/keys lose key types; cast restores them
-): TKey[] => Object.keys(object) as TKey[]

--- a/public/dom.mts
+++ b/public/dom.mts
@@ -5,7 +5,7 @@ export const booleanStrings: string[] = [
   'true',
 ] satisfies `${boolean}`[]
 
-export const getElement = <T extends HTMLElement>(
+const getElement = <T extends HTMLElement>(
   id: string,
   elementConstructor: new () => T,
   elementType: string,

--- a/settings/index.mts
+++ b/settings/index.mts
@@ -19,6 +19,7 @@ import type {
   FormattedErrorDetails,
   FormattedErrorLog,
 } from '../types/error-log.mts'
+import { getErrorMessage } from '../lib/get-error-message.mts'
 import {
   type HTMLValueElement,
   booleanStrings,
@@ -31,29 +32,10 @@ import {
   getSpan,
   translateAriaLabels,
 } from '../public/dom.mts'
+import { fireAndForget } from '../public/homey-api.mts'
 import { getZoneId, getZoneName } from '../public/zones.mts'
 
 // ── Helpers ──
-
-const defaultOnError = (error: unknown): void => {
-  // eslint-disable-next-line no-console -- intentional fallback: surfaces otherwise-swallowed rejections in settings dev tools
-  console.error(error)
-}
-
-const fireAndForget = (
-  promise: Promise<unknown>,
-  onError: (error: unknown) => void = defaultOnError,
-): void => {
-  // eslint-disable-next-line unicorn/prefer-await -- fire-and-forget: rejections route to onError without blocking the caller
-  promise.catch(onError)
-}
-
-const getErrorMessage = (error: unknown): string => {
-  if (error instanceof Error) {
-    return error.message
-  }
-  return typeof error === 'string' ? error : JSON.stringify(error)
-}
 
 // Wraps Homey's callback-based settings API in a Promise for async/await usage
 const createCallback =
@@ -655,10 +637,9 @@ class DeviceSettingsManager {
       appendFormControl(this.#settingsCommon, { formControl, title })
       this.#updateCommonSetting(formControl)
     }
-    this.#addSettingsEventListeners(
-      // eslint-disable-next-line unicorn/prefer-spread -- NodeListOf not iterable without DOM.Iterable lib
-      Array.from(this.#settingsCommon.querySelectorAll('select')),
-    )
+    this.#addSettingsEventListeners([
+      ...this.#settingsCommon.querySelectorAll('select'),
+    ])
   }
 
   #createDriverSettingControls(
@@ -700,8 +681,7 @@ class DeviceSettingsManager {
         this.#createDriverSettingControls(driverSetting, fieldSet)
         settingsContainer.append(fieldSet)
         this.#addSettingsEventListeners(
-          // eslint-disable-next-line unicorn/prefer-spread -- NodeListOf not iterable without DOM.Iterable lib
-          Array.from(fieldSet.querySelectorAll('input')),
+          [...fieldSet.querySelectorAll('input')],
           driverId,
         )
         hide(getDiv(`has_devices_${driverId}`), false)
@@ -1110,7 +1090,7 @@ class ZoneSettingsManager {
     await this.fetchHolidayModeData()
   }
 
-  public async populateZoneOptions(zones: Classic.Zone[] = []): Promise<void> {
+  public populateZoneOptions(zones: Classic.Zone[] = []): void {
     if (zones.length > 0) {
       for (const zone of zones) {
         const { id, level, model, name } = zone
@@ -1118,8 +1098,7 @@ class ZoneSettingsManager {
           id: getZoneId(id, model),
           label: getZoneName(name, level),
         })
-        // eslint-disable-next-line no-await-in-loop -- Sequential: parent-child order required for tree rendering
-        await this.populateZoneOptions(getSubzones(zone))
+        this.populateZoneOptions(getSubzones(zone))
       }
     }
   }
@@ -1424,7 +1403,7 @@ class SettingsApp {
     if (buildings.length === 0) {
       throw new NoClassicDeviceError(this.#homey)
     }
-    await this.#zoneSettingsManager.populateZoneOptions(buildings)
+    this.#zoneSettingsManager.populateZoneOptions(buildings)
     await Promise.all([
       this.#errorLogManager.fetchErrorLog(),
       this.#zoneSettingsManager.fetchZoneSettings(),

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -1,7 +1,10 @@
 import { expect, vi } from 'vitest'
 
-// eslint-disable-next-line func-style -- TS requires function declaration for asserts predicates
-export function assertDefined<T>(value: T | undefined): asserts value is T {
+// TS requires an explicit type annotation on the called identifier for
+// asserts predicates; an annotated arrow satisfies that.
+export const assertDefined: <T>(value: T | undefined) => asserts value is T = (
+  value,
+) => {
   expect(value).toBeDefined()
 }
 

--- a/tests/unit/app.test.ts
+++ b/tests/unit/app.test.ts
@@ -130,7 +130,9 @@ const { default: MelCloudApp } = await import('../../app.mts')
 
 const mockGetLanguage = vi.fn<() => string>().mockReturnValue('en')
 const mockGetTimezone = vi.fn<() => string>().mockReturnValue('Europe/Paris')
-const mockSettingsGet = vi.fn<(key: string) => string | null>()
+// Homey's settings.get is untyped (`any`): the manager must survive
+// non-string values, so the mock mirrors that width.
+const mockSettingsGet = vi.fn<(key: string) => unknown>()
 const mockSettingsSet = vi.fn<(key: string, value: string) => void>()
 const mockSetTimeout =
   vi.fn<(callback: () => Promise<void> | void, ms: number) => void>()
@@ -949,6 +951,25 @@ describe('melCloudApp', () => {
       settingManager.set('expiry', '2026-12-31')
 
       expect(mockSettingsSet).toHaveBeenCalledWith('expiry', '2026-12-31')
+    })
+
+    it('should pass through string and null settings and coerce the rest to undefined', async () => {
+      await app.onInit()
+
+      const { settingManager } = getMockCallArg<{
+        settingManager: {
+          get: (key: string) => unknown
+          set: (key: string, value: string) => void
+        }
+      }>(mockCreate, 0, 0)
+      mockSettingsGet
+        .mockReturnValueOnce('stored')
+        .mockReturnValueOnce(null)
+        .mockReturnValueOnce(42)
+
+      expect(settingManager.get('contextKey')).toBe('stored')
+      expect(settingManager.get('contextKey')).toBeNull()
+      expect(settingManager.get('contextKey')).toBeUndefined()
     })
   })
 

--- a/tests/unit/classic-driver.test.ts
+++ b/tests/unit/classic-driver.test.ts
@@ -1,3 +1,6 @@
+import type * as Classic from '@olivierzal/melcloud-api/classic'
+import type FlowCardAction from 'homey/lib/FlowCardAction'
+import type FlowCardCondition from 'homey/lib/FlowCardCondition'
 import type PairSession from 'homey/lib/PairSession'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -123,8 +126,11 @@ describe(ClassicMELCloudDriver, () => {
         showView: showViewMock,
       })
       vi.spyOn(driver.homey.app, 'getDevicesByType').mockReturnValue([
-        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- partial mock data cannot satisfy the full ClassicDevice<T> generic type
-        { data: { Power: true }, id: 1, name: 'Device 1' } as never,
+        mock<Classic.Device<TestDriverType>>({
+          data: { Power: true },
+          id: 1,
+          name: 'Device 1',
+        }),
       ])
       await driver.onPair(session)
       const devices = await listHandler()
@@ -177,14 +183,13 @@ describe(ClassicMELCloudDriver, () => {
       > = {}
       vi.spyOn(driver.homey.flow, 'getActionCard').mockImplementation(
         (cardName: string) =>
-          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- partial mock: only registerRunListener is needed from FlowCardAction
-          ({
+          mock<FlowCardAction>({
             registerRunListener: (
               listener: (args: Record<string, unknown>) => Promise<void>,
             ): void => {
               actionListeners[cardName] = listener
             },
-          }) as never,
+          }),
       )
       await driver.onInit()
 
@@ -215,14 +220,13 @@ describe(ClassicMELCloudDriver, () => {
       > = {}
       vi.spyOn(driver.homey.flow, 'getConditionCard').mockImplementation(
         (cardName: string) =>
-          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- partial mock: only registerRunListener is needed from FlowCardCondition
-          ({
+          mock<FlowCardCondition>({
             registerRunListener: (
               listener: (args: Record<string, unknown>) => unknown,
             ): void => {
               conditionListeners[cardName] = listener
             },
-          }) as never,
+          }),
       )
       await driver.onInit()
 
@@ -247,14 +251,13 @@ describe(ClassicMELCloudDriver, () => {
       > = {}
       vi.spyOn(driver.homey.flow, 'getConditionCard').mockImplementation(
         (cardName: string) =>
-          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- partial mock: only registerRunListener is needed from FlowCardCondition
-          ({
+          mock<FlowCardCondition>({
             registerRunListener: (
               listener: (args: Record<string, unknown>) => unknown,
             ): void => {
               conditionListeners[cardName] = listener
             },
-          }) as never,
+          }),
       )
       await driver.onInit()
 

--- a/tests/unit/home-melcloud-device.test.ts
+++ b/tests/unit/home-melcloud-device.test.ts
@@ -14,10 +14,7 @@ import { createInstance } from './create-test-instance.ts'
 
 // eslint-disable-next-line vitest/prefer-import-in-mock -- Mock class is not assignable to typeof DeviceAtaFacade (lacks prototype members)
 vi.mock('@olivierzal/melcloud-api/home', async (importOriginal) => ({
-  ...(await importOriginal<
-    // eslint-disable-next-line @typescript-eslint/consistent-type-imports -- typeof import() required by vitest importOriginal generic
-    typeof import('@olivierzal/melcloud-api/home')
-  >()),
+  ...(await importOriginal<typeof Home>()),
   DeviceAtaFacade: vi.fn<new (...args: unknown[]) => unknown>(),
 }))
 

--- a/tests/unit/typed-object.test.ts
+++ b/tests/unit/typed-object.test.ts
@@ -1,10 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import {
-  typedEntries,
-  typedFromEntries,
-  typedKeys,
-} from '../../lib/typed-object.mts'
+import { typedEntries, typedFromEntries } from '../../lib/typed-object.mts'
 
 describe('typed-object', () => {
   const testObject = { bar: 2, foo: 1 }
@@ -28,14 +24,6 @@ describe('typed-object', () => {
       ])
 
       expect(result).toStrictEqual(testObject)
-    })
-  })
-
-  describe(typedKeys, () => {
-    it('should return typed keys', () => {
-      const keys = typedKeys(testObject)
-
-      expect(keys).toStrictEqual(['bar', 'foo'])
     })
   })
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "declaration": true,
     "erasableSyntaxOnly": true,
     "isolatedDeclarations": true,
-    "lib": ["DOM", "ESNext"],
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "libReplacement": false,
     "module": "preserve",
     "noFallthroughCasesInSwitch": true,

--- a/types/driver-settings.mts
+++ b/types/driver-settings.mts
@@ -1,5 +1,10 @@
 import type { LoginCredentials } from '@olivierzal/melcloud-api'
 
+interface DriverSettingValue {
+  readonly id: string
+  readonly label: string
+}
+
 export interface DriverCapabilitiesOptions {
   readonly title: string
   readonly type: string
@@ -18,11 +23,6 @@ export interface DriverSetting {
   readonly placeholder?: string
   readonly units?: string
   readonly values?: readonly DriverSettingValue[]
-}
-
-export interface DriverSettingValue {
-  readonly id: string
-  readonly label: string
 }
 
 export interface LoginDriverSetting extends DriverSetting {

--- a/types/home-ata.mts
+++ b/types/home-ata.mts
@@ -7,6 +7,10 @@ import type {
   BaseSetCapabilities,
 } from './bases.mts'
 
+type HomeGetCapabilitiesAta = BaseGetCapabilities
+
+type HomeListCapabilitiesAta = BaseListCapabilities
+
 export type HomeCapabilitiesAta = HomeGetCapabilitiesAta &
   HomeListCapabilitiesAta &
   HomeSetCapabilitiesAta
@@ -35,10 +39,6 @@ export type HomeConvertToDevice = {
     value: HomeSetCapabilitiesAta[keyof HomeSetCapabilitiesAta],
   ): Home.AtaValues[keyof Home.AtaValues]
 }['bivariant']
-
-export type HomeGetCapabilitiesAta = BaseGetCapabilities
-
-export type HomeListCapabilitiesAta = BaseListCapabilities
 
 export interface HomeSetCapabilitiesAta extends BaseSetCapabilities {
   readonly fan_speed: number

--- a/types/manifest.mts
+++ b/types/manifest.mts
@@ -1,5 +1,28 @@
 import type { CapabilitiesOptionsValues, LocalizedStrings } from './bases.mts'
 
+interface ManifestDriverSetting {
+  readonly label: LocalizedStrings
+  readonly children?: readonly ManifestDriverSettingData[]
+  readonly id?: string
+}
+
+interface ManifestDriverSettingData {
+  readonly id: string
+  readonly label: LocalizedStrings
+  readonly type: string
+  readonly max?: number
+  readonly min?: number
+  readonly units?: string
+  readonly values?: readonly {
+    readonly id: string
+    readonly label: LocalizedStrings
+  }[]
+}
+
+interface PairSetting {
+  readonly id: string
+}
+
 export interface LoginSetting extends PairSetting {
   readonly id: 'login'
   readonly options: {
@@ -30,27 +53,4 @@ export interface ManifestDriverCapabilitiesOptions {
   readonly title: LocalizedStrings
   readonly type: string
   readonly values?: readonly CapabilitiesOptionsValues<string>[]
-}
-
-export interface ManifestDriverSetting {
-  readonly label: LocalizedStrings
-  readonly children?: readonly ManifestDriverSettingData[]
-  readonly id?: string
-}
-
-export interface ManifestDriverSettingData {
-  readonly id: string
-  readonly label: LocalizedStrings
-  readonly type: string
-  readonly max?: number
-  readonly min?: number
-  readonly units?: string
-  readonly values?: readonly {
-    readonly id: string
-    readonly label: LocalizedStrings
-  }[]
-}
-
-export interface PairSetting {
-  readonly id: string
 }

--- a/widgets/ata-group-setting/public/animation.mts
+++ b/widgets/ata-group-setting/public/animation.mts
@@ -57,6 +57,10 @@ const AnimationGap = {
 const LEAF_OSCILLATION_FACTOR = 5
 const ANIMATION_KEYFRAME_COUNT = 101
 
+// Safe widening: lets runtime `number` modes be probed without asserting
+// them down to ClassicOperationMode.
+const heatModeNumbers: ReadonlySet<number> = classicHeatModes
+
 // Calculates a randomized delay with exponential speed scaling. Higher speed
 // values produce shorter delays via exponential interpolation between
 // factorMin and factorMax
@@ -195,8 +199,7 @@ const getPreviousElement = (name: string, index?: string): HTMLElement | null =>
   document.querySelector<HTMLElement>(`#${name}-${String(Number(index) - 1)}`)
 
 const scheduleFlameRemoval = (): void => {
-  // eslint-disable-next-line unicorn/prefer-spread -- NodeListOf not iterable without DOM.Iterable lib
-  const flames = Array.from(document.querySelectorAll<HTMLElement>('.flame'))
+  const flames = [...document.querySelectorAll<HTMLElement>('.flame')]
   for (const flame of flames) {
     setTimeout(
       () => {
@@ -609,13 +612,9 @@ export class AnimationController {
       const modes = await this.#getModes()
       if (
         isSomethingOn &&
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- runtime mode is a ClassicOperationMode value or MIXED (0)
-        (classicHeatModes.has(mode as ClassicOperationMode) ||
+        (heatModeNumbers.has(mode) ||
           (mode === CLASSIC_OPERATION_MODE_MIXED &&
-            modes.some((currentMode) =>
-              // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- API contract: detailed states return ClassicOperationMode values
-              classicHeatModes.has(currentMode as ClassicOperationMode),
-            )))
+            modes.some((currentMode) => heatModeNumbers.has(currentMode))))
       ) {
         if (this.#smokeAnimationFrameId !== null) {
           cancelAnimationFrame(this.#smokeAnimationFrameId)

--- a/widgets/ata-group-setting/public/ata-values.mts
+++ b/widgets/ata-group-setting/public/ata-values.mts
@@ -1,6 +1,5 @@
 import type * as Classic from '@olivierzal/melcloud-api/classic'
 import {
-  type ClassicOperationMode,
   ClassicTemperature,
   classicCoolModes,
 } from '@olivierzal/melcloud-api/constants'
@@ -100,13 +99,14 @@ const createSelect = (
 
 // ── Value processing ──
 
+// Safe widening: lets the runtime `number` select value be probed without
+// asserting it down to ClassicOperationMode.
+const coolModeNumbers: ReadonlySet<number> = classicCoolModes
+
 const getCoolingAdjustedMin = (id: string, min: string): string =>
   (
     id === 'SetTemperature' &&
-    classicCoolModes.has(
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- DOM <select> value is one of ClassicOperationMode values by markup contract
-      Number(getSelect('OperationMode').value) as ClassicOperationMode,
-    )
+    coolModeNumbers.has(Number(getSelect('OperationMode').value))
   ) ?
     String(ClassicTemperature.cooling_min)
   : min
@@ -223,7 +223,7 @@ export class AtaValueManager {
     return values
   }
 
-  public async populateZoneOptions(zones: Classic.Zone[] = []): Promise<void> {
+  public populateZoneOptions(zones: Classic.Zone[] = []): void {
     if (zones.length > 0) {
       for (const zone of zones) {
         const { id, level, model, name } = zone
@@ -231,8 +231,7 @@ export class AtaValueManager {
           id: getZoneId(id, model),
           label: getZoneName(name, level),
         })
-        // eslint-disable-next-line no-await-in-loop -- Sequential: parent-child order required for tree rendering
-        await this.populateZoneOptions(getSubzones(zone))
+        this.populateZoneOptions(getSubzones(zone))
       }
     }
   }
@@ -250,10 +249,7 @@ export class AtaValueManager {
 
   #buildAtaValuesBody(): Classic.GroupState {
     return Object.fromEntries(
-      // eslint-disable-next-line unicorn/prefer-spread -- NodeListOf not iterable without DOM.Iterable lib
-      Array.from(
-        this.#ataValues.querySelectorAll<HTMLValueElement>('input, select'),
-      )
+      [...this.#ataValues.querySelectorAll<HTMLValueElement>('input, select')]
         .filter(
           ({ id, value }) =>
             this.#isGroupAtaState(id) &&

--- a/widgets/ata-group-setting/public/index.mts
+++ b/widgets/ata-group-setting/public/index.mts
@@ -97,7 +97,7 @@ class WidgetApp {
       this.#isAnimations = isAnimations
       this.#addEventListeners()
       this.#ataValueManager.createAtaFormControls()
-      await this.#ataValueManager.populateZoneOptions(buildings)
+      this.#ataValueManager.populateZoneOptions(buildings)
       this.#ataValueManager.applyDefaultZone(defaultZone)
       await this.#fetchAndAnimate()
     }

--- a/widgets/charts/public/index.mts
+++ b/widgets/charts/public/index.mts
@@ -25,10 +25,8 @@ import {
 } from '../../../public/homey-api.mts'
 import { getZoneId, getZonePath } from '../../../public/zones.mts'
 
-// Below --homey-font-size-small (14px) — intentional for compact chart labels
 const FONT_SIZE_VERY_SMALL = '12px'
-const NEXT_TIMEOUT = 60_000
-const AGGREGATION_DELAY_MINUTES = 5
+const HOURLY_CHART_REFRESH_MS = 60_000
 
 const chartsWithDays = new Set<HomeySettings['chart']>([
   'operation_modes',
@@ -210,21 +208,22 @@ const fetchChartData = async (
   )
 }
 
-// Daily charts refresh 5 minutes after each full hour (to allow data
-// aggregation). Hourly charts refresh every 60 seconds
+// Charts of hourly data poll every minute so the latest point shows up
+// promptly; daily aggregates only change after the full hour plus
+// MELCloud's 5-minute aggregation delay, so wait for that instant.
 const getTimeout = (chart: HomeySettings['chart']): number => {
   if (hourlyCharts.has(chart)) {
-    return NEXT_TIMEOUT
+    return HOURLY_CHART_REFRESH_MS
   }
   const now = Temporal.Now.zonedDateTimeISO()
   const next = now.add({ hours: 1 }).with({
     microsecond: 0,
     millisecond: 0,
-    minute: AGGREGATION_DELAY_MINUTES,
+    minute: 5,
     nanosecond: 0,
     second: 0,
   })
-  return next.epochMilliseconds - now.epochMilliseconds
+  return now.until(next).total('milliseconds')
 }
 
 interface DrawConfig {


### PR DESCRIPTION
Stacked on #1373 (retarget to main after it merges). Consolidates the three post-refactor hunts (Temporal legacy, redundancy vs lib v40, inline-disable resolutions) — every item pre-verified against the installed packages, code adapted to the rules, zero config weakening.

## Disables : 71 → 47 (−34 %)

- **`DOM.Iterable`** ajouté au tsconfig (types seuls — `NodeList` est itérable dans Chromium depuis 2016 ; `tsgo --noEmit` full-repo vérifié avant/après) → 4 spreads idiomatiques, 4 disables `unicorn/prefer-spread` supprimés.
- **9× `no-unsafe-type-assertion` résolus** : guard `Classic.isDeviceOfType` du v40 (avec annotation du destructure pour effondrer l'union `BuildingFacade | ZoneFacade`, commentée) ; `BaseMELCloudDevice` devient générique `<TFacade extends ClassicDeviceFacade = ClassicDeviceFacade>` (défaut non-cassant, la sous-classe Home lie `Home.DeviceAtaFacade`) ; élargissements sûrs `ReadonlySet<number>` ; typeof-guards aux frontières `any` du SDK.
- **4× `consistent-type-assertions`** : les littéraux `as never` passent par le helper `mock<T>()` déjà présent dans le fichier.
- **2× `no-await-in-loop`** : `populateZoneOptions` n'était async que par sa propre récursion → synchrone, parcours DFS identique et désormais atomique.
- **1× chacun** : `consistent-type-imports`, `func-style` (l'assertion fn n'exige qu'une annotation, pas une déclaration).
- **3 disables tombés par déduplication** (copies locales supprimées, voir plus bas).
- Les **47 restants sont tous structurels** et documentés (bivariance, casts de frontière brandés, `prefer-import-in-mock`, webviews sans logger Homey…).

## Legacy Temporal

- `createDateRange` → `daysAgo` seul (la borne `to` duplique le défaut lib-side, même timezone).
- `fromDateHuman` : l'aller-retour de zone était un no-op → `PlainDate.toLocaleString`, `dateFullFormat` supprimé.
- `parseErrorDate` renvoie un `Temporal.Instant` (formaté via l'`Intl` du polyfill).
- Widget charts : `now.until(next).total('milliseconds')` au lieu de la soustraction d'epochs.

## Redondance & code mort

- `typedKeys` supprimée (production-morte : seul son test l'importait — même angle mort de `no-unused-modules` que `HOUR_MIN`).
- settings importe `fireAndForget`/`defaultOnError` (copie octet-pour-octet de `public/homey-api.mts`) et `getErrorMessage` (copie de `lib/`).
- 7 `export` superflus retirés (symboles à usage strictement local).

## Clarté (demandes de review)

- `AGGREGATION_DELAY_MINUTES` inlinée en `minute: 5` (position propriété d'objet : `detectObjects: false` — le nommage-par-clé suffit) ; `NEXT_TIMEOUT` → `HOURLY_CHART_REFRESH_MS` ; commentaires charts et `FONT_SIZE_VERY_SMALL` reformulés.

## Adaptations au contact (3, documentées)

Le guard v40 nécessitait l'annotation d'union ; `daysAgo` inliné dépassait `unicorn/max-nested-calls` → locale aux 2 sites ; `perfectionist/sort-modules` a réordonné les fichiers `types/` dé-exportés.

## Vérification

Lint exit 0 (aucune directive orpheline), Prettier, tsgo, **431/431 tests** (le −1 est le bloc `typedKeys` supprimé), `homey app validate --level=publish`. Non inclus, à dessein : consolidation de la dépendance `temporal-polyfill` (défendable dans les deux sens, bundles navigateur en jeu).

🤖 Generated with [Claude Code](https://claude.com/claude-code)