### PR TITLE
ci(review): skip runs triggered by the claude bot's own pushes

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -4,6 +4,7 @@ concurrency:
 jobs:
   review:
     if: |
+      github.actor != 'claude[bot]' &&
       github.actor != 'dependabot[bot]' &&
       !github.event.pull_request.draft &&
       github.event.pull_request.head.repo.full_name == github.repository


### PR DESCRIPTION
Sister of OlivierZal/melcloud-api#1576 — same anti-loop guard failure class (`Workflow initiated by non-human actor: claude (type: Bot)`) whenever an `@claude` mention pushes to a PR branch. Extends the existing dependabot exclusion to `claude[bot]` so bot pushes skip the review (neutral) instead of failing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)