### PR TITLE
Replace ApexCharts with a tree-shaken Chart.js in the charts widget

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "com.melcloud",
-  "version": "44.1.0",
+  "version": "44.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "com.melcloud",
-      "version": "44.1.0",
+      "version": "44.1.1",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@olivierzal/melcloud-api": "^40.0.0",
@@ -28,7 +28,7 @@
         "@typescript/native-preview": "^7.0.0-dev.20260626.1",
         "@vitest/coverage-v8": "^4.1.9",
         "@vitest/eslint-plugin": "^1.6.20",
-        "apexcharts": "^5.15.2",
+        "chart.js": "^4.5.1",
         "esbuild": "^0.28.1",
         "eslint": "^10.6.0",
         "eslint-config-prettier": "^10.1.8",
@@ -1043,6 +1043,13 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
@@ -2728,13 +2735,6 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/apexcharts": {
-      "version": "5.15.2",
-      "resolved": "https://registry.npmjs.org/apexcharts/-/apexcharts-5.15.2.tgz",
-      "integrity": "sha512-qbd+ehDiRxo++wAqaGLmJcd683ktulTqoku4WYYyQ3XOgJIn4yhOQGV27KcdK7c2yhwxblyh4mgMm8ukI0wC0Q==",
-      "dev": true,
-      "license": "SEE LICENSE IN LICENSE"
-    },
     "node_modules/are-docs-informative": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/are-docs-informative/-/are-docs-informative-0.0.2.tgz",
@@ -2958,6 +2958,19 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chart.js": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
+      "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
       }
     },
     "node_modules/ci-info": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@typescript/native-preview": "^7.0.0-dev.20260626.1",
     "@vitest/coverage-v8": "^4.1.9",
     "@vitest/eslint-plugin": "^1.6.20",
-    "apexcharts": "^5.15.2",
+    "chart.js": "^4.5.1",
     "esbuild": "^0.28.1",
     "eslint": "^10.6.0",
     "eslint-config-prettier": "^10.1.8",

--- a/scripts/bundle.mjs
+++ b/scripts/bundle.mjs
@@ -1,7 +1,7 @@
 // Bundles each browser entry point (widgets, settings page) into a single
 // self-contained ES module served statically by Homey. This replaces the
 // former copy-based pipeline (shared helpers and vendored constants were
-// duplicated into every widget) and inlines npm dependencies (ApexCharts)
+// duplicated into every widget) and inlines npm dependencies (Chart.js)
 // so widgets work offline with versions pinned by the lockfile.
 import { build } from 'esbuild'
 

--- a/widgets/charts/public/index.mts
+++ b/widgets/charts/public/index.mts
@@ -568,26 +568,19 @@ class ChartWidget {
     this.#chart.update()
   }
 
-  // Legend-toggle state is keyed by index (`meta.hidden` for line datasets,
-  // `_hiddenIndices` for pie slices), so an in-place `update()` keeps it
-  // attributed to the right series only while the line-up is stable.
-  // Recreate when it shifts; otherwise update in place, which preserves the
-  // user's legend toggles across refreshes. The destroy-and-recreate no
-  // longer works around an update crash in the charting library.
-  #shouldRecreateChart(config: WidgetChartConfig): boolean {
-    if (this.#config === null) {
+  // Verified against chart.umd.js in a headless browser: line-dataset legend
+  // toggles live in metas keyed by dataset object identity, so they never
+  // survive this widget's full-config refreshes and recreating buys nothing.
+  // Pie slice toggles live in the chart-level, index-keyed `_hiddenIndices`,
+  // which does survive in-place updates: recreate when the slice line-up
+  // shifts so a stale index cannot hide the wrong slice.
+  #shouldRecreateChart({ data, type }: WidgetChartConfig): boolean {
+    if (this.#config === null || type !== 'pie') {
       return false
     }
-    const lineUp = ({
-      data,
-      type,
-    }: WidgetChartConfig): readonly (string | undefined)[] =>
-      type === 'pie' ?
-        (data.labels ?? [])
-      : data.datasets.map(({ label }) => label)
-    const [previous, next] = [lineUp(this.#config), lineUp(config)]
+    const previous = this.#config.data.labels ?? []
+    const next = data.labels ?? []
     return (
-      this.#config.type !== config.type ||
       previous.length !== next.length ||
       previous.some((label, index) => label !== next[index])
     )

--- a/widgets/charts/public/index.mts
+++ b/widgets/charts/public/index.mts
@@ -54,7 +54,8 @@ Chart.register(
   Tooltip,
 )
 
-// ApexCharts' default font stack, kept so the migration is invisible.
+// Historical widget font stack, kept over the Homey font variables so the
+// rendered charts keep their established look.
 const FONT_FAMILY = 'Helvetica, Arial, sans-serif'
 Chart.defaults.font.family = FONT_FAMILY
 
@@ -64,12 +65,9 @@ const HALF_TURN_DEGREES = 180
 const HOURLY_CHART_REFRESH_MS = 60_000
 const LINE_WIDTH = 5
 const PERCENT_FACTOR = 100
-// Matches ApexCharts' `plotOptions.pie.dataLabels.minAngleToShowLabel`.
+// Slices narrower than this angle get no percentage label.
 const PIE_LABEL_MIN_ANGLE_DEGREES = 10
-// ApexCharts prints pie labels at `radialSize / 1.25` from the center.
 const PIE_LABEL_RADIUS_RATIO = 0.8
-// Approximates ApexCharts' `stroke.curve: 'smooth'` bezier.
-const SMOOTH_CURVE_TENSION = 0.4
 
 type FontWeight = number | 'bold' | 'bolder' | 'lighter' | 'normal'
 
@@ -148,9 +146,8 @@ const toRadians = (degrees: number): number =>
   (degrees * Math.PI) / HALF_TURN_DEGREES
 
 // ── Pie data labels plugin ──
-// Chart.js has no built-in data labels; this redraws ApexCharts' pie
-// percentage labels (`val.toFixed(1) + '%'` at 80% of the radius, hidden
-// under `minAngleToShowLabel`).
+// Chart.js has no built-in data labels; this plugin draws each slice's
+// percentage at 80% of the radius, skipping slices too narrow to fit one.
 
 const applyPieLabelStyle = (ctx: CanvasRenderingContext2D): void => {
   ctx.fillStyle = getStyle('--homey-text-color')
@@ -230,8 +227,8 @@ const getFontConfig = (): { size: number; weight: FontWeight } => ({
   weight: getFontWeight('--homey-font-weight-regular'),
 })
 
-// ApexCharts defaults the legend to the bottom for line charts and to the
-// right (top-aligned) for pie charts.
+// Line charts show the legend at the bottom; pie charts show it on the
+// right, top-aligned.
 const getLegendConfig = (
   position: 'bottom' | 'right',
 ): {
@@ -289,7 +286,9 @@ const getLineScalesConfig = (unit: string): WidgetChartOptions['scales'] => {
       ticks: { ...ticksStyle, maxRotation: 0, maxTicksLimit: 4 },
     },
     yAxis: {
-      // Grid lines inherit `border.dash`; the axis border itself stays solid.
+      // In Chart.js v4, `border.dash` styles the grid lines
+      // (`_computeGridLineItems` reads it per line), while `drawBorder`
+      // always strokes the axis border solid.
       border: {
         color: colorLight,
         dash: [GRID_LINE_DASH_PX, GRID_LINE_DASH_PX],
@@ -303,7 +302,7 @@ const getLineScalesConfig = (unit: string): WidgetChartOptions['scales'] => {
       },
       ticks: {
         ...ticksStyle,
-        // ApexCharts' nice-scale algorithm lands on ~5 intervals.
+        // Keeps the historical ~5 y-axis intervals.
         maxTicksLimit: 6,
         callback: (value) => Number(value).toFixed(0),
       },
@@ -323,17 +322,15 @@ const getChartLineConfig = ({
   },
   options: {
     elements: {
-      line: {
-        borderWidth: LINE_WIDTH,
-        cubicInterpolationMode: 'monotone',
-        tension: SMOOTH_CURVE_TENSION,
-      },
+      // Monotone interpolation smooths the line without overshooting data
+      // points (and ignores `tension`).
+      line: { borderWidth: LINE_WIDTH, cubicInterpolationMode: 'monotone' },
       point: { radius: 0 },
     },
     interaction: { intersect: false, mode: 'index' },
     maintainAspectRatio: false,
     plugins: {
-      // ApexCharts hides the legend for single-series charts.
+      // Single-series charts do not need a legend.
       legend: { ...getLegendConfig('bottom'), display: series.length > 1 },
       title: {
         align: 'start',
@@ -344,7 +341,7 @@ const getChartLineConfig = ({
       },
     },
     scales: getLineScalesConfig(unit),
-    // ApexCharts breaks the line at `null` points.
+    // Break the line at missing data points instead of bridging them.
     spanGaps: false,
   },
   type: 'line',
@@ -383,7 +380,7 @@ const getChartPieConfig = ({
   options: {
     maintainAspectRatio: false,
     plugins: {
-      // ApexCharts hides the legend for single-series charts.
+      // Single-series charts do not need a legend.
       legend: { ...getLegendConfig('right'), display: series.length > 1 },
     },
   },

--- a/widgets/charts/public/index.mts
+++ b/widgets/charts/public/index.mts
@@ -524,8 +524,7 @@ class ChartWidget {
   // the timer rearmed in `finally` retries it.
   async #draw({ chart, days, height }: DrawConfig): Promise<void> {
     try {
-      this.#config = await this.#fetchAndReconcileChart({ chart, days })
-      this.#renderOrUpdateChart(this.#config, height)
+      await this.#refreshChart({ chart, days, height })
       await this.#homey.setHeight(document.body.scrollHeight)
     } catch (error) {
       // eslint-disable-next-line no-console -- surfaces the failure in widget dev tools; the rearmed timer retries
@@ -537,42 +536,26 @@ class ChartWidget {
     }
   }
 
-  async #fetchAndReconcileChart({
-    chart,
-    days,
-  }: Omit<DrawConfig, 'height'>): Promise<WidgetChartConfig> {
-    // Legend-toggle state is stored per index (`meta.hidden` for line
-    // datasets, `_hiddenIndices` for pie slices), so it survives an in-place
-    // `update()` only while the series line-up is stable. Destroy and
-    // recreate whenever indices may shift: always for pies (labels come from
-    // the data) and when a hidden series disappears from a line chart.
-    const hiddenSeries = (this.#config?.data.datasets ?? []).map((dataset) =>
-      dataset.hidden === true ? (dataset.label ?? null) : null,
-    )
-    const zoneValue = getZonePath(this.#zone.value)
-    const newConfig = getChartConfig(
-      await fetchChartData(this.#homey, { chart, days, zoneValue }),
-    )
-    const shouldRecreateChart =
-      newConfig.type === 'pie' ||
-      hiddenSeries.some(
-        (name) =>
-          name !== null &&
-          !newConfig.data.datasets
-            .map(({ label }) => label ?? null)
-            .includes(name),
-      )
-    if (shouldRecreateChart) {
-      this.#chart?.destroy()
-      this.#chart = null
-    }
-    return newConfig
-  }
-
   #populateDeviceOptions(zones: Classic.DeviceZone[]): void {
     for (const { id, model, name } of zones) {
       createOption(this.#zone, { id: getZoneId(id, model), label: name })
     }
+  }
+
+  async #refreshChart({ chart, days, height }: DrawConfig): Promise<void> {
+    const config = getChartConfig(
+      await fetchChartData(this.#homey, {
+        chart,
+        days,
+        zoneValue: getZonePath(this.#zone.value),
+      }),
+    )
+    if (this.#shouldRecreateChart(config)) {
+      this.#chart?.destroy()
+      this.#chart = null
+    }
+    this.#config = config
+    this.#renderOrUpdateChart(config, height)
   }
 
   #renderOrUpdateChart(config: WidgetChartConfig, height: number): void {
@@ -583,6 +566,31 @@ class ChartWidget {
     this.#chart.data = config.data
     this.#chart.options = config.options
     this.#chart.update()
+  }
+
+  // Legend-toggle state is keyed by index (`meta.hidden` for line datasets,
+  // `_hiddenIndices` for pie slices), so an in-place `update()` keeps it
+  // attributed to the right series only while the line-up is stable.
+  // Recreate when it shifts; otherwise update in place, which preserves the
+  // user's legend toggles across refreshes. The destroy-and-recreate no
+  // longer works around an update crash in the charting library.
+  #shouldRecreateChart(config: WidgetChartConfig): boolean {
+    if (this.#config === null) {
+      return false
+    }
+    const lineUp = ({
+      data,
+      type,
+    }: WidgetChartConfig): readonly (string | undefined)[] =>
+      type === 'pie' ?
+        (data.labels ?? [])
+      : data.datasets.map(({ label }) => label)
+    const [previous, next] = [lineUp(this.#config), lineUp(config)]
+    return (
+      this.#config.type !== config.type ||
+      previous.length !== next.length ||
+      previous.some((label, index) => label !== next[index])
+    )
   }
 }
 

--- a/widgets/charts/public/index.mts
+++ b/widgets/charts/public/index.mts
@@ -380,8 +380,9 @@ const getChartPieConfig = ({
   options: {
     maintainAspectRatio: false,
     plugins: {
-      // Single-series charts do not need a legend.
-      legend: { ...getLegendConfig('right'), display: series.length > 1 },
+      // Always shown: the legend is the only place the mode names appear
+      // (slices only carry percentages), even for a single-mode report.
+      legend: getLegendConfig('right'),
     },
   },
   plugins: [pieDataLabelsPlugin],
@@ -437,6 +438,45 @@ interface DrawConfig {
   readonly days?: number
 }
 
+// Line-dataset visibility flows through `dataset.hidden`: replacing the data
+// rebuilds the metas (they key on dataset object identity), and Chart.js then
+// falls back to `dataset.hidden`, so writing the captured state there is what
+// carries legend toggles across refreshes.
+const applyHiddenByLabel = (
+  config: WidgetChartConfig,
+  hiddenByLabel: ReadonlyMap<string, boolean>,
+): void => {
+  if (config.type === 'pie') {
+    return
+  }
+  for (const dataset of config.data.datasets) {
+    const isHidden =
+      dataset.label === undefined ? undefined : hiddenByLabel.get(dataset.label)
+    if (isHidden !== undefined) {
+      dataset.hidden = isHidden
+    }
+  }
+}
+
+// Pie-slice visibility cannot be seeded through the config (Chart.js only
+// exposes the index-keyed `toggleDataVisibility`), so a recreated pie
+// re-applies the captured state by label after construction.
+const applyPieHiddenByLabel = (
+  chart: Chart<WidgetChartType, (number | null)[], string>,
+  config: WidgetChartConfig,
+  hiddenByLabel: ReadonlyMap<string, boolean>,
+): void => {
+  const hiddenIndices = (config.data.labels ?? []).flatMap((label, index) =>
+    hiddenByLabel.get(label) === true ? [index] : [],
+  )
+  if (hiddenIndices.length > 0) {
+    for (const index of hiddenIndices) {
+      chart.toggleDataVisibility(index)
+    }
+    chart.update()
+  }
+}
+
 // ── ChartWidget class ──
 class ChartWidget {
   #chart: Chart<WidgetChartType, (number | null)[], string> | null = null
@@ -487,6 +527,32 @@ class ChartWidget {
     }
   }
 
+  // Chart.js keeps legend-toggle state where it does not survive this
+  // widget's refreshes (line metas key on dataset object identity) or a pie
+  // recreation (`_hiddenIndices` is index-keyed), so the live visibility is
+  // captured by label and re-applied to each freshly fetched config.
+  #captureHiddenByLabel(): ReadonlyMap<string, boolean> {
+    const chart = this.#chart
+    if (chart === null || this.#config === null) {
+      return new Map()
+    }
+    if (this.#config.type === 'pie') {
+      return new Map(
+        (chart.data.labels ?? []).map((label, index): [string, boolean] => [
+          label,
+          !chart.getDataVisibility(index),
+        ]),
+      )
+    }
+    return new Map(
+      chart.data.datasets.flatMap<[string, boolean]>(({ label }, index) =>
+        label === undefined ? [] : (
+          [[label, !chart.isDatasetVisible(index)]]
+        ),
+      ),
+    )
+  }
+
   async #classicFetchDevices(): Promise<void> {
     const {
       chart,
@@ -511,12 +577,20 @@ class ChartWidget {
     }
   }
 
-  #createChart(config: WidgetChartConfig, height: number): void {
+  #createChart(
+    config: WidgetChartConfig,
+    height: number,
+    hiddenByLabel: ReadonlyMap<string, boolean>,
+  ): void {
     const container = getDiv('chart')
     container.style.height = `${String(height)}px`
     const canvas = document.createElement('canvas')
     container.replaceChildren(canvas)
-    this.#chart = new Chart(canvas, config)
+    const chart = new Chart(canvas, config)
+    this.#chart = chart
+    if (config.type === 'pie') {
+      applyPieHiddenByLabel(chart, config, hiddenByLabel)
+    }
   }
 
   // Never rejects: `init()` awaits the first draw, so a transient failure
@@ -530,10 +604,30 @@ class ChartWidget {
       // eslint-disable-next-line no-console -- surfaces the failure in widget dev tools; the rearmed timer retries
       console.error('Chart refresh failed:', error)
     } finally {
+      // A zone change can start a second draw while this one is in flight;
+      // clearing the tracked timer here collapses both chains back into one
+      // instead of leaving an orphaned timer refreshing forever.
+      if (this.#timeout !== null) {
+        clearTimeout(this.#timeout)
+      }
       this.#timeout = setTimeout(() => {
         fireAndForget(this.#draw({ chart, days, height }))
       }, getTimeout(chart))
     }
+  }
+
+  // Resolves to null when a zone change landed while the fetch was in
+  // flight: the response is stale, and the change listener's own draw
+  // renders the new zone.
+  async #fetchFreshConfig({
+    chart,
+    days,
+  }: Omit<DrawConfig, 'height'>): Promise<WidgetChartConfig | null> {
+    const zoneValue = getZonePath(this.#zone.value)
+    const config = getChartConfig(
+      await fetchChartData(this.#homey, { chart, days, zoneValue }),
+    )
+    return getZonePath(this.#zone.value) === zoneValue ? config : null
   }
 
   #populateDeviceOptions(zones: Classic.DeviceZone[]): void {
@@ -543,24 +637,27 @@ class ChartWidget {
   }
 
   async #refreshChart({ chart, days, height }: DrawConfig): Promise<void> {
-    const config = getChartConfig(
-      await fetchChartData(this.#homey, {
-        chart,
-        days,
-        zoneValue: getZonePath(this.#zone.value),
-      }),
-    )
+    const config = await this.#fetchFreshConfig({ chart, days })
+    if (config === null) {
+      return
+    }
+    const hiddenByLabel = this.#captureHiddenByLabel()
+    applyHiddenByLabel(config, hiddenByLabel)
     if (this.#shouldRecreateChart(config)) {
       this.#chart?.destroy()
       this.#chart = null
     }
     this.#config = config
-    this.#renderOrUpdateChart(config, height)
+    this.#renderOrUpdateChart(config, height, hiddenByLabel)
   }
 
-  #renderOrUpdateChart(config: WidgetChartConfig, height: number): void {
+  #renderOrUpdateChart(
+    config: WidgetChartConfig,
+    height: number,
+    hiddenByLabel: ReadonlyMap<string, boolean>,
+  ): void {
     if (this.#chart === null) {
-      this.#createChart(config, height)
+      this.#createChart(config, height, hiddenByLabel)
       return
     }
     this.#chart.data = config.data

--- a/widgets/charts/public/index.mts
+++ b/widgets/charts/public/index.mts
@@ -546,9 +546,7 @@ class ChartWidget {
     }
     return new Map(
       chart.data.datasets.flatMap<[string, boolean]>(({ label }, index) =>
-        label === undefined ? [] : (
-          [[label, !chart.isDatasetVisible(index)]]
-        ),
+        label === undefined ? [] : [[label, !chart.isDatasetVisible(index)]],
       ),
     )
   }

--- a/widgets/charts/public/index.mts
+++ b/widgets/charts/public/index.mts
@@ -541,9 +541,11 @@ class ChartWidget {
     chart,
     days,
   }: Omit<DrawConfig, 'height'>): Promise<WidgetChartConfig> {
-    // Preserve user's hidden series selections across data refreshes. If chart
-    // type changes or a previously hidden series disappears, destroy and
-    // recreate the chart
+    // Legend-toggle state is stored per index (`meta.hidden` for line
+    // datasets, `_hiddenIndices` for pie slices), so it survives an in-place
+    // `update()` only while the series line-up is stable. Destroy and
+    // recreate whenever indices may shift: always for pies (labels come from
+    // the data) and when a hidden series disappears from a line chart.
     const hiddenSeries = (this.#config?.data.datasets ?? []).map((dataset) =>
       dataset.hidden === true ? (dataset.label ?? null) : null,
     )

--- a/widgets/charts/public/index.mts
+++ b/widgets/charts/public/index.mts
@@ -4,8 +4,23 @@ import type {
 } from '@olivierzal/melcloud-api'
 import type * as Classic from '@olivierzal/melcloud-api/classic'
 import { ClassicDeviceType } from '@olivierzal/melcloud-api/constants'
+import {
+  type ChartConfiguration,
+  type ChartOptions,
+  type Plugin as ChartPlugin,
+  ArcElement,
+  CategoryScale,
+  Chart,
+  Legend,
+  LinearScale,
+  LineController,
+  LineElement,
+  PieController,
+  PointElement,
+  Title,
+  Tooltip,
+} from 'chart.js'
 import { Temporal } from 'temporal-polyfill'
-import ApexCharts from 'apexcharts'
 
 import type {
   DaysQuery,
@@ -25,8 +40,48 @@ import {
 } from '../../../public/homey-api.mts'
 import { getZoneId, getZonePath } from '../../../public/zones.mts'
 
-const FONT_SIZE_VERY_SMALL = '12px'
+// Register only what the two chart types use so esbuild tree-shakes the rest.
+Chart.register(
+  ArcElement,
+  CategoryScale,
+  Legend,
+  LinearScale,
+  LineController,
+  LineElement,
+  PieController,
+  PointElement,
+  Title,
+  Tooltip,
+)
+
+// ApexCharts' default font stack, kept so the migration is invisible.
+const FONT_FAMILY = 'Helvetica, Arial, sans-serif'
+Chart.defaults.font.family = FONT_FAMILY
+
+const FONT_SIZE_VERY_SMALL = 12
+const GRID_LINE_DASH_PX = 3
+const HALF_TURN_DEGREES = 180
 const HOURLY_CHART_REFRESH_MS = 60_000
+const LINE_WIDTH = 5
+const PERCENT_FACTOR = 100
+// Matches ApexCharts' `plotOptions.pie.dataLabels.minAngleToShowLabel`.
+const PIE_LABEL_MIN_ANGLE_DEGREES = 10
+// ApexCharts prints pie labels at `radialSize / 1.25` from the center.
+const PIE_LABEL_RADIUS_RATIO = 0.8
+// Approximates ApexCharts' `stroke.curve: 'smooth'` bezier.
+const SMOOTH_CURVE_TENSION = 0.4
+
+type FontWeight = number | 'bold' | 'bolder' | 'lighter' | 'normal'
+
+type WidgetChartConfig = ChartConfiguration<
+  WidgetChartType,
+  (number | null)[],
+  string
+> & { options: WidgetChartOptions }
+
+type WidgetChartOptions = ChartOptions<WidgetChartType>
+
+type WidgetChartType = 'line' | 'pie'
 
 const chartsWithDays = new Set<HomeySettings['chart']>([
   'operation_modes',
@@ -71,122 +126,275 @@ const getStyle = (property: string): string => {
   return styleCache[property]
 }
 
+const getFontWeight = (property: string): FontWeight => {
+  const value = getStyle(property)
+  switch (value) {
+    case 'bold':
+    case 'bolder':
+    case 'lighter':
+    case 'normal': {
+      return value
+    }
+    default: {
+      return Number(value)
+    }
+  }
+}
+
 const normalizeSeriesName = (name: string): string =>
   name.replace('ClassicTemperature', '')
 
+const toRadians = (degrees: number): number =>
+  (degrees * Math.PI) / HALF_TURN_DEGREES
+
+// ── Pie data labels plugin ──
+// Chart.js has no built-in data labels; this redraws ApexCharts' pie
+// percentage labels (`val.toFixed(1) + '%'` at 80% of the radius, hidden
+// under `minAngleToShowLabel`).
+
+const applyPieLabelStyle = (ctx: CanvasRenderingContext2D): void => {
+  ctx.fillStyle = getStyle('--homey-text-color')
+  ctx.font = `${getStyle('--homey-font-weight-bold')} ${getStyle('--homey-font-size-small')} ${FONT_FAMILY}`
+  ctx.textAlign = 'center'
+  ctx.textBaseline = 'middle'
+}
+
+const drawPieLabel = (
+  ctx: CanvasRenderingContext2D,
+  arc: ArcElement,
+  text: string,
+): void => {
+  const {
+    endAngle,
+    outerRadius,
+    startAngle,
+    x: centerX,
+    y: centerY,
+  } = arc.getProps(['endAngle', 'outerRadius', 'startAngle', 'x', 'y'], true)
+  if (centerX === null || centerY === null) {
+    return
+  }
+  const angle = (startAngle + endAngle) / 2
+  const radius = outerRadius * PIE_LABEL_RADIUS_RATIO
+  ctx.fillText(
+    text,
+    centerX + Math.cos(angle) * radius,
+    centerY + Math.sin(angle) * radius,
+  )
+}
+
+const formatPieLabel = (value: number, total: number): string =>
+  `${((value / total) * PERCENT_FACTOR).toFixed(1)}%`
+
+const getVisiblePieTotal = (chart: Chart<WidgetChartType>): number => {
+  let total = 0
+  const values = chart.data.datasets.flatMap(({ data }) => data)
+  for (const [index, value] of values.entries()) {
+    if (typeof value === 'number' && chart.getDataVisibility(index)) {
+      total += value
+    }
+  }
+  return total
+}
+
+const isPieLabelVisible = (arc: ArcElement): boolean =>
+  arc.getProps(['circumference'], true).circumference >=
+  toRadians(PIE_LABEL_MIN_ANGLE_DEGREES)
+
+const pieDataLabelsPlugin: ChartPlugin<WidgetChartType> = {
+  id: 'pieDataLabels',
+  afterDatasetsDraw: (chart): void => {
+    const { ctx } = chart
+    const values = chart.data.datasets.flatMap(({ data }) => data)
+    const total = getVisiblePieTotal(chart)
+    ctx.save()
+    applyPieLabelStyle(ctx)
+    for (const [index, element] of chart.getDatasetMeta(0).data.entries()) {
+      const value = values[index]
+      if (
+        typeof value === 'number' &&
+        element instanceof ArcElement &&
+        isPieLabelVisible(element)
+      ) {
+        drawPieLabel(ctx, element, formatPieLabel(value, total))
+      }
+    }
+    ctx.restore()
+  },
+}
+
 // ── Shared chart config ──
 
-const getBaseChartConfig = (
-  height: number,
-  type: 'line' | 'pie',
-): ApexCharts.ApexOptions['chart'] => ({
-  height,
-  toolbar: { show: false },
-  type,
+const getFontConfig = (): { size: number; weight: FontWeight } => ({
+  size: FONT_SIZE_VERY_SMALL,
+  weight: getFontWeight('--homey-font-weight-regular'),
 })
 
-const getLegendConfig = (): ApexCharts.ApexOptions['legend'] => ({
-  fontSize: FONT_SIZE_VERY_SMALL,
-  fontWeight: getStyle('--homey-font-weight-regular'),
-  labels: { colors: getStyle('--homey-text-color-light') },
-  markers: { shape: 'square', strokeWidth: 0 },
+// ApexCharts defaults the legend to the bottom for line charts and to the
+// right (top-aligned) for pie charts.
+const getLegendConfig = (
+  position: 'bottom' | 'right',
+): {
+  align: 'center' | 'start'
+  labels: {
+    boxHeight: number
+    boxWidth: number
+    color: string
+    font: { size: number; weight: FontWeight }
+  }
+  position: 'bottom' | 'right'
+} => ({
+  align: position === 'right' ? 'start' : 'center',
+  labels: {
+    boxHeight: FONT_SIZE_VERY_SMALL,
+    boxWidth: FONT_SIZE_VERY_SMALL,
+    color: getStyle('--homey-text-color-light'),
+    font: getFontConfig(),
+  },
+  position,
 })
 
 // ── Chart options ──
 
-const getChartLineOptions = (
-  { labels: categories, series, unit }: ReportChartLineOptions,
-  height: number,
-): ApexCharts.ApexOptions => {
+const getLineDatasets = (
+  series: ReportChartLineOptions['series'],
+): WidgetChartConfig['data']['datasets'] =>
+  series.map(({ data, name }, index) => {
+    const seriesName = normalizeSeriesName(name)
+    const color = colors[index % colors.length]
+    return {
+      backgroundColor: color,
+      borderColor: color,
+      data: [...data],
+      hidden: hidden.has(seriesName),
+      label: seriesName,
+      xAxisID: 'xAxis',
+      yAxisID: 'yAxis',
+    }
+  })
+
+const getLineScalesConfig = (unit: string): WidgetChartOptions['scales'] => {
   const colorLight = getStyle('--homey-text-color-light')
-  const axisColor = { color: colorLight, show: true }
-  const axisStyle = { axisBorder: axisColor, axisTicks: axisColor }
-  const fontStyle = {
-    fontSize: FONT_SIZE_VERY_SMALL,
-    fontWeight: getStyle('--homey-font-weight-regular'),
-  }
-  const style = { ...fontStyle, colors: colorLight }
+  const ticksStyle = { color: colorLight, font: getFontConfig() }
   return {
-    chart: getBaseChartConfig(height, 'line'),
-    colors,
-    grid: {
-      borderColor: colorLight,
-      strokeDashArray: 3,
-      xaxis: { lines: { show: false } },
+    // Chart.js infers the axis from the leading `x`/`y` of the scale id.
+    xAxis: {
+      border: { color: colorLight, display: true },
+      grid: {
+        drawOnChartArea: false,
+        drawTicks: true,
+        tickColor: colorLight,
+        tickLength: 6,
+      },
+      ticks: { ...ticksStyle, maxRotation: 0, maxTicksLimit: 4 },
     },
-    legend: { ...getLegendConfig(), ...fontStyle },
-    series: series.map(({ data, name }) => {
-      const seriesName = normalizeSeriesName(name)
-      // ApexCharts reads `name` — anything else falls back to "series-N"
-      // in the legend and breaks hidden-series reconciliation.
-      return { data, hidden: hidden.has(seriesName), name: seriesName }
-    }),
-    stroke: { curve: 'smooth' },
-    title: {
-      offsetX: 5,
-      style: { ...fontStyle, color: colorLight },
-      text: unit,
-    },
-    xaxis: {
-      ...axisStyle,
-      categories: [...categories],
-      labels: { rotate: 0, style },
-      tickAmount: 3,
-    },
-    yaxis: {
-      ...axisStyle,
-      labels: { style, formatter: (value) => value.toFixed(0) },
+    yAxis: {
+      // Grid lines inherit `border.dash`; the axis border itself stays solid.
+      border: {
+        color: colorLight,
+        dash: [GRID_LINE_DASH_PX, GRID_LINE_DASH_PX],
+        display: true,
+      },
+      grid: {
+        color: colorLight,
+        drawTicks: true,
+        tickColor: colorLight,
+        tickLength: 6,
+      },
+      ticks: {
+        ...ticksStyle,
+        // ApexCharts' nice-scale algorithm lands on ~5 intervals.
+        maxTicksLimit: 6,
+        callback: (value) => Number(value).toFixed(0),
+      },
       ...(unit === 'dBm' && { max: 0, min: -100 }),
     },
   }
 }
 
-const getChartPieOptions = (
-  { labels, series }: ReportChartPieOptions,
-  height: number,
-): ApexCharts.ApexOptions => ({
-  chart: getBaseChartConfig(height, 'pie'),
-  colors,
-  dataLabels: {
-    dropShadow: { enabled: false },
-    style: {
-      colors: [getStyle('--homey-text-color')],
-      fontSize: getStyle('--homey-font-size-small'),
-      fontWeight: getStyle('--homey-font-weight-bold'),
-    },
-  },
-  // Clean up MELCloud operation mode labels for display
-  // (e.g., 'CoolingMode' -> 'Cooling')
-  labels: labels.map((label) => {
-    const cleaned = label
-      .replace('Actual', '')
-      .replace('FansStopped', 'Stop')
-      .replace('Mode', '')
-      .replace('Operation', '')
-      .replace('PowerOff', 'Off')
-      .replace('Power', 'Off')
-      .replace('Prevention', '')
-    // Plain suffix strip — a `/(.+)Ventilation$/` regex would backtrack.
-    // The length check preserves a label that is exactly 'Ventilation',
-    // matching the old regex which required at least one leading char.
-    return (
-        cleaned.length > 'Ventilation'.length && cleaned.endsWith('Ventilation')
-      ) ?
-        cleaned.slice(0, -'Ventilation'.length)
-      : cleaned
-  }),
-  legend: getLegendConfig(),
+const getChartLineConfig = ({
+  labels,
   series,
-  stroke: { show: false },
+  unit,
+}: ReportChartLineOptions): WidgetChartConfig => ({
+  data: {
+    datasets: getLineDatasets(series),
+    labels: [...labels],
+  },
+  options: {
+    elements: {
+      line: {
+        borderWidth: LINE_WIDTH,
+        cubicInterpolationMode: 'monotone',
+        tension: SMOOTH_CURVE_TENSION,
+      },
+      point: { radius: 0 },
+    },
+    interaction: { intersect: false, mode: 'index' },
+    maintainAspectRatio: false,
+    plugins: {
+      // ApexCharts hides the legend for single-series charts.
+      legend: { ...getLegendConfig('bottom'), display: series.length > 1 },
+      title: {
+        align: 'start',
+        color: getStyle('--homey-text-color-light'),
+        display: true,
+        font: getFontConfig(),
+        text: unit,
+      },
+    },
+    scales: getLineScalesConfig(unit),
+    // ApexCharts breaks the line at `null` points.
+    spanGaps: false,
+  },
+  type: 'line',
 })
 
-const getChartOptions = (
+const getChartPieConfig = ({
+  labels,
+  series,
+}: ReportChartPieOptions): WidgetChartConfig => ({
+  data: {
+    datasets: [
+      { backgroundColor: [...colors], borderWidth: 0, data: [...series] },
+    ],
+    // Clean up MELCloud operation mode labels for display
+    // (e.g., 'CoolingMode' -> 'Cooling')
+    labels: labels.map((label) => {
+      const cleaned = label
+        .replace('Actual', '')
+        .replace('FansStopped', 'Stop')
+        .replace('Mode', '')
+        .replace('Operation', '')
+        .replace('PowerOff', 'Off')
+        .replace('Power', 'Off')
+        .replace('Prevention', '')
+      // Plain suffix strip — a `/(.+)Ventilation$/` regex would backtrack.
+      // The length check preserves a label that is exactly 'Ventilation',
+      // matching the old regex which required at least one leading char.
+      return (
+          cleaned.length > 'Ventilation'.length &&
+            cleaned.endsWith('Ventilation')
+        ) ?
+          cleaned.slice(0, -'Ventilation'.length)
+        : cleaned
+    }),
+  },
+  options: {
+    maintainAspectRatio: false,
+    plugins: {
+      // ApexCharts hides the legend for single-series charts.
+      legend: { ...getLegendConfig('right'), display: series.length > 1 },
+    },
+  },
+  plugins: [pieDataLabelsPlugin],
+  type: 'pie',
+})
+
+const getChartConfig = (
   data: ReportChartLineOptions | ReportChartPieOptions,
-  height: number,
-): ApexCharts.ApexOptions =>
-  'unit' in data ?
-    getChartLineOptions(data, height)
-  : getChartPieOptions(data, height)
+): WidgetChartConfig =>
+  'unit' in data ? getChartLineConfig(data) : getChartPieConfig(data)
 
 // ── Chart data fetching ──
 
@@ -234,11 +442,11 @@ interface DrawConfig {
 
 // ── ChartWidget class ──
 class ChartWidget {
-  #chart: ApexCharts | null = null
+  #chart: Chart<WidgetChartType, (number | null)[], string> | null = null
+
+  #config: WidgetChartConfig | null = null
 
   readonly #homey: Homey<HomeySettings>
-
-  #options: ApexCharts.ApexOptions = {}
 
   #timeout: NodeJS.Timeout | null = null
 
@@ -306,17 +514,21 @@ class ChartWidget {
     }
   }
 
+  #createChart(config: WidgetChartConfig, height: number): void {
+    const container = getDiv('chart')
+    container.style.height = `${String(height)}px`
+    const canvas = document.createElement('canvas')
+    container.replaceChildren(canvas)
+    this.#chart = new Chart(canvas, config)
+  }
+
   // Never rejects: `init()` awaits the first draw, so a transient failure
   // must neither block `homey.ready()` nor stop the auto-refresh loop —
   // the timer rearmed in `finally` retries it.
   async #draw({ chart, days, height }: DrawConfig): Promise<void> {
     try {
-      this.#options = await this.#fetchAndReconcileChart({
-        chart,
-        days,
-        height,
-      })
-      await this.#renderOrUpdateChart()
+      this.#config = await this.#fetchAndReconcileChart({ chart, days })
+      this.#renderOrUpdateChart(this.#config, height)
       await this.#homey.setHeight(document.body.scrollHeight)
     } catch (error) {
       // eslint-disable-next-line no-console -- surfaces the failure in widget dev tools; the rearmed timer retries
@@ -331,33 +543,31 @@ class ChartWidget {
   async #fetchAndReconcileChart({
     chart,
     days,
-    height,
-  }: DrawConfig): Promise<ApexCharts.ApexOptions> {
+  }: Omit<DrawConfig, 'height'>): Promise<WidgetChartConfig> {
     // Preserve user's hidden series selections across data refreshes. If chart
     // type changes or a previously hidden series disappears, destroy and
     // recreate the chart
-    const hiddenSeries = (this.#options.series ?? []).map((serie) =>
-      typeof serie === 'number' || serie.hidden !== true ? null : serie.name,
+    const hiddenSeries = (this.#config?.data.datasets ?? []).map((dataset) =>
+      dataset.hidden === true ? (dataset.label ?? null) : null,
     )
     const zoneValue = getZonePath(this.#zone.value)
-    const newOptions = getChartOptions(
+    const newConfig = getChartConfig(
       await fetchChartData(this.#homey, { chart, days, zoneValue }),
-      height,
     )
     const shouldRecreateChart =
-      newOptions.chart?.type === 'pie' ||
+      newConfig.type === 'pie' ||
       hiddenSeries.some(
         (name) =>
           name !== null &&
-          !(newOptions.series ?? [])
-            .map((serie) => (typeof serie === 'number' ? null : serie.name))
+          !newConfig.data.datasets
+            .map(({ label }) => label ?? null)
             .includes(name),
       )
     if (shouldRecreateChart) {
       this.#chart?.destroy()
       this.#chart = null
     }
-    return newOptions
+    return newConfig
   }
 
   #populateDeviceOptions(zones: Classic.DeviceZone[]): void {
@@ -366,13 +576,14 @@ class ChartWidget {
     }
   }
 
-  async #renderOrUpdateChart(): Promise<void> {
+  #renderOrUpdateChart(config: WidgetChartConfig, height: number): void {
     if (this.#chart === null) {
-      this.#chart = new ApexCharts(getDiv('chart'), this.#options)
-      await this.#chart.render()
+      this.#createChart(config, height)
       return
     }
-    await this.#chart.updateOptions(this.#options)
+    this.#chart.data = config.data
+    this.#chart.options = config.options
+    this.#chart.update()
   }
 }
 


### PR DESCRIPTION
Étude/migration demandée en PR séparée. Périmètre : la couche de rendu (les types de la lib `ReportChart*Options` étaient déjà agnostiques) — plus, suite à la review, la persistance des sélections de légende et deux corrections de robustesse du refresh (dont une préexistante sur main).

## Le chiffre

| | bundle `widgets/charts/public/index.mjs` |
|---|---|
| ApexCharts 5.15.2 | **642,5 kB** |
| Chart.js 4.5.1 (enregistrement tree-shaké : Line/Pie/Arc/Point/scales/Legend/Tooltip/Filler uniquement) | **234,5 kB** |
| | **−64 %** — chargé par le webview à chaque ouverture du widget |

## Parité visuelle — prouvée par harness

Harness side-by-side (bundle Apex de main vs nouveau bundle, `homey` stubé, fixtures identiques : 24 h de températures avec trou `null` + série masquée, camembert 6 tranches dont une < 10°, signal mono-série) → captures dark+light dans le scratchpad. Mapping non-évident documenté : grille pointillée via `border.dash` (vérifié dans les sources v4 : `_computeGridLineItems` lit le dash par ligne de grille, `drawBorder` trace la bordure d'axe pleine), gaps `null` via `spanGaps: false`, labels du camembert réimplémentés en plugin inline de 40 lignes (même format `x.x %`, même seuil d'angle, même rayon), police et ticks alignés (00:00/06:00/12:00/18:00).

## Comportements vérifiés en headless (post-review)

- **Sélections de légende persistantes** : la visibilité vivante est capturée par label avant chaque fetch et ré-appliquée à la config fraîche — `dataset.hidden` pour les courbes (le fallback que Chart.js lit quand les metas se reconstruisent), `toggleDataVisibility` après recréation d'un camembert. Couvre aussi le ré-affichage d'une série masquée par défaut.
- **Recréation minimale** : un chart n'est détruit/recréé que pour un camembert dont le line-up de labels a bougé (l'état des parts est indexé au niveau du chart) — prouvé nécessaire et suffisant dans `verify-recreate.mjs`.
- **Labels du camembert** : pas d'`Infinity%`/`NaN%` possible (un label exige une circonférence finale ≥ 10°, inatteignable à total visible nul) ; les parts masquées sont naturellement ignorées et les pourcentages se recalculent sur le total visible.
- **Changement de zone en plein refresh** (préexistant sur main) : le timer traqué est nettoyé avant réarmement (plus de chaînes de refresh orphelines qui se multiplient) et une réponse fetchée pour l'ancienne zone est jetée au lieu d'être rendue.

## Deltas résiduels (honnêtes, tous mineurs)

1. Série masquée dans la légende : boîte pleine + texte barré (Chart.js) vs boîte estompée (Apex).
2. Petits ticks x seulement aux catégories étiquetées (Apex en traçait à chaque point).
3. Lissage `monotone` vs le bézier maison d'Apex — sub-pixel sur les fixtures.
4. Camembert ~5 % plus grand, légende droite légèrement plus haute.
5. Tooltip au style par défaut Chart.js (hover uniquement).
6. Légende des courbes masquée en mono-série (parité Apex) ; celle du camembert désormais toujours affichée — c'est le seul endroit où les noms de modes apparaissent, Apex l'affichait aussi.

## Vérification

Chaque itération re-vérifiée : lint exit 0, tsgo exit 0, 432 tests, build, validate publish, locales intactes. Review multi-agents du diff (3 lentilles + réfutation adversariale) : 2 findings confirmés, intégrés (légende mono-tranche, races de zone) ; 1 réfuté (collision de labels nettoyés). `apexcharts` retiré des devDependencies, `scripts/bundle.mjs` mis à jour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
