### PR TITLE
Harden the animation orchestration against races and fetch failures

### DIFF
--- a/widgets/ata-group-setting/public/animation.mts
+++ b/widgets/ata-group-setting/public/animation.mts
@@ -3,7 +3,6 @@ import {
   CLASSIC_OPERATION_MODE_MIXED,
   ClassicFanSpeed,
   ClassicOperationMode,
-  classicHeatModes,
 } from '@olivierzal/melcloud-api/constants'
 
 import type { GroupAtaStates } from '../../../types/classic-ata.mts'
@@ -23,10 +22,7 @@ import {
 
 type AnimatedElement = 'flame' | 'leaf' | 'snowflake' | 'sun'
 
-interface ResetParams {
-  readonly isSomethingOn: boolean
-  readonly mode: number
-}
+type SceneElement = 'fire' | 'leaf' | 'snow' | 'sun'
 
 // ── Animation speed factors ──
 
@@ -98,9 +94,22 @@ const createSmokeParams = (): {
   speedY: generateStyleNumber({ gap: 0.6, min: 0.2 }),
 })
 
-// Safe widening: lets runtime `number` modes be probed without asserting
-// them down to ClassicOperationMode.
-const heatModeNumbers: ReadonlySet<number> = classicHeatModes
+// Scene composition per direct operation mode; a mixed group resolves to
+// the union over its members' modes. Keys are plain numbers so runtime
+// modes can be probed without asserting them down to ClassicOperationMode.
+const MODE_SCENES: Readonly<Partial<Record<number, readonly SceneElement[]>>> =
+  {
+    [ClassicOperationMode.auto]: ['fire', 'snow'],
+    [ClassicOperationMode.cool]: ['snow'],
+    [ClassicOperationMode.dry]: ['sun'],
+    [ClassicOperationMode.fan]: ['leaf'],
+    [ClassicOperationMode.heat]: ['fire'],
+  }
+
+const resolveMemberScene = (
+  modes: readonly number[],
+): ReadonlySet<SceneElement> =>
+  new Set(modes.flatMap((mode) => MODE_SCENES[mode] ?? []))
 
 // Queried lazily so module evaluation stays side-effect-free, and so each
 // animation pass reads the current OS preference.
@@ -372,23 +381,20 @@ const generateSunShineAnimation = (sun: HTMLDivElement): Animation =>
 const getPreviousElement = (name: string, index?: string): HTMLElement | null =>
   document.querySelector<HTMLElement>(`#${name}-${String(Number(index) - 1)}`)
 
+// Every removal path ends a flame through its own controller, so
+// everything bound to it — expiry, smoke chain — stops with it.
+const flameControllers = new WeakMap<HTMLDivElement, AbortController>()
+
+// Ends the flame after `delayMs` unless its controller aborts first.
 // Lifetime is orchestrated here because the flicker animations are
 // infinite and cannot signal completion themselves.
-const scheduleFlameExpiry = async (
+const expireFlame = async (
   flame: HTMLDivElement,
   controller: AbortController,
-  speed: number,
+  delayMs: number,
 ): Promise<void> => {
   try {
-    await sleep(
-      generateStyleNumber({
-        divisor: speed,
-        gap: 10,
-        min: 20,
-        multiplier: 1000,
-      }),
-      controller.signal,
-    )
+    await sleep(delayMs, controller.signal)
   } catch (error) {
     if (isAbortError(error)) {
       return
@@ -400,16 +406,21 @@ const scheduleFlameExpiry = async (
   controller.abort()
 }
 
+// Graceful clear when the scene leaves fire: each flame lingers a random
+// beat, then dies through its own controller. A flame whose natural
+// expiry wins the race aborts first, turning this into a no-op.
 const scheduleFlameRemoval = (): void => {
-  const flames = [...document.querySelectorAll<HTMLElement>('.flame')]
-  for (const flame of flames) {
-    setTimeout(
-      () => {
-        cancelAnimations(flame)
-        flame.remove()
-      },
-      generateDelay(AnimationDelay.flame, ClassicFanSpeed.very_slow),
-    )
+  for (const flame of document.querySelectorAll<HTMLDivElement>('.flame')) {
+    const controller = flameControllers.get(flame)
+    if (controller !== undefined) {
+      fireAndForget(
+        expireFlame(
+          flame,
+          controller,
+          generateDelay(AnimationDelay.flame, ClassicFanSpeed.very_slow),
+        ),
+      )
+    }
   }
 }
 
@@ -423,31 +434,9 @@ export class AnimationController {
     { readonly textContent: string; readonly getIndex: () => number }
   >
 
-  readonly #animationRunners: Record<
-    number,
-    (speed: number) => Promise<void> | void
-  > = {
-    [CLASSIC_OPERATION_MODE_MIXED]: async (speed) =>
-      this.#runMixedAnimation(speed),
-    [ClassicOperationMode.auto]: (speed) => {
-      this.#runFireAnimation(speed)
-      this.#runSnowAnimation(speed)
-    },
-    [ClassicOperationMode.cool]: (speed) => {
-      this.#runSnowAnimation(speed)
-    },
-    [ClassicOperationMode.dry]: (speed) => {
-      this.#runSunAnimation(speed)
-    },
-    [ClassicOperationMode.fan]: (speed) => {
-      this.#runLeafAnimation(speed)
-    },
-    [ClassicOperationMode.heat]: (speed) => {
-      this.#runFireAnimation(speed)
-    },
-  }
-
   #controller = new AbortController()
+
+  #generation = 0
 
   readonly #homey: Homey
 
@@ -472,30 +461,24 @@ export class AnimationController {
     this.#lastState = state
 
     // A state update landing while the page is hidden must not rebuild the
-    // scene: #reset would replace the aborted controller and restart spawn
-    // loops offscreen. The visibilitychange handler replays #lastState when
+    // scene offscreen. The visibilitychange handler replays #lastState when
     // the page shows again.
     if (document.visibilityState === 'hidden') {
       return
     }
 
-    // Honor the OS-level reduced-motion preference: clear the scene and stop.
-    if (prefersReducedMotion()) {
-      await this.#reset()
+    const generation = ++this.#generation
+    const scene = await this.#resolveScene(state)
+
+    // Bail without touching the scene when the fetch failed (the running
+    // scene stays live and the next update retries) or when a newer apply —
+    // or a hide — superseded this pass while it awaited.
+    if (scene === null || generation !== this.#generation) {
       return
     }
 
-    const { isSomethingOn, newMode, newSpeed } = parseStateParams(state)
-
-    await this.#reset({ isSomethingOn, mode: newMode })
-
-    if (isSomethingOn && this.#hasModeAnimation(newMode)) {
-      await this.#animationRunners[newMode]?.(newSpeed)
-    }
-  }
-
-  public async reset(resetParams?: ResetParams): Promise<void> {
-    await this.#reset(resetParams)
+    this.#reset(scene)
+    this.#startScene(scene, parseStateParams(state).newSpeed)
   }
 
   #createAnimatedElement(name: AnimatedElement): HTMLDivElement {
@@ -680,7 +663,9 @@ export class AnimationController {
 
   #handleVisibilityChange(): void {
     if (document.visibilityState === 'hidden') {
-      // Stop spawning offscreen; already-running animations are harmless.
+      // Stop spawning offscreen and invalidate any apply pass still in
+      // flight; already-running animations are harmless.
+      this.#generation += 1
       this.#controller.abort()
       return
     }
@@ -689,20 +674,29 @@ export class AnimationController {
     }
   }
 
-  #hasModeAnimation(mode: number): boolean {
-    return Object.hasOwn(this.#animationRunners, mode)
-  }
-
   #igniteFlame(flame: HTMLDivElement, speed: number): void {
     const flameController = new AbortController()
+    flameControllers.set(flame, flameController)
     startFlameFlicker(flame)
-    fireAndForget(scheduleFlameExpiry(flame, flameController, speed))
-    // The smoke chain dies with its flame or with the global reset,
-    // whichever aborts first.
+    fireAndForget(
+      expireFlame(
+        flame,
+        flameController,
+        generateStyleNumber({
+          divisor: speed,
+          gap: 10,
+          min: 20,
+          multiplier: 1000,
+        }),
+      ),
+    )
+    // The smoke chain belongs to its flame alone: a reset that keeps the
+    // flames alive keeps their smoke too, and every removal path ends the
+    // flame through its controller.
     fireAndForget(
       runSpawnLoop(
         () => generateDelay(AnimationDelay.smoke, ClassicFanSpeed.very_slow),
-        AbortSignal.any([this.#controller.signal, flameController.signal]),
+        flameController.signal,
         () => {
           this.#spawnSmokeBatch(flame, speed)
         },
@@ -710,46 +704,48 @@ export class AnimationController {
     )
   }
 
-  async #reset(resetParams?: ResetParams): Promise<void> {
+  // Everything spawned by the previous scene stops here — except flames
+  // when the next scene still contains fire: they and their smoke chains
+  // live on their own controllers.
+  #reset(scene: ReadonlySet<SceneElement>): void {
     this.#controller.abort()
     this.#controller = new AbortController()
-    await this.#resetFireAnimation(resetParams)
-    await this.#resetSunAnimation(resetParams)
-  }
-
-  async #resetFireAnimation(resetParams?: ResetParams): Promise<void> {
-    if (resetParams !== undefined) {
-      const { isSomethingOn, mode } = resetParams
-      const modes = await this.#getModes()
-      if (
-        isSomethingOn &&
-        (heatModeNumbers.has(mode) ||
-          (mode === CLASSIC_OPERATION_MODE_MIXED &&
-            modes.some((currentMode) => heatModeNumbers.has(currentMode))))
-      ) {
-        return
-      }
+    if (!scene.has('fire')) {
+      scheduleFlameRemoval()
     }
-    scheduleFlameRemoval()
+    this.#resetSunAnimation(scene.has('sun'))
   }
 
-  async #resetSunAnimation(resetParams?: ResetParams): Promise<void> {
+  #resetSunAnimation(isSunActive: boolean): void {
     const motion = this.#sunMotion
-    if (motion === null) {
+    if (motion === null || isSunActive) {
       return
-    }
-    if (resetParams?.isSomethingOn === true) {
-      const modes = await this.#getModes()
-      const isDryActive =
-        resetParams.mode === ClassicOperationMode.dry ||
-        (resetParams.mode === CLASSIC_OPERATION_MODE_MIXED &&
-          modes.includes(ClassicOperationMode.dry))
-      if (isDryActive) {
-        return
-      }
     }
     if (motion.playbackRate > 0) {
       motion.reverse()
+    }
+  }
+
+  // Resolves which scene elements the new state activates — none when
+  // everything is off or reduced motion is requested. The member-mode
+  // fetch (mixed groups only) happens before any teardown, so a failure
+  // resolves to null with the running scene untouched.
+  async #resolveScene(
+    state: Classic.GroupState,
+  ): Promise<ReadonlySet<SceneElement> | null> {
+    const { isSomethingOn, newMode } = parseStateParams(state)
+    if (!isSomethingOn || prefersReducedMotion()) {
+      return new Set()
+    }
+    if (newMode !== CLASSIC_OPERATION_MODE_MIXED) {
+      return resolveMemberScene([newMode])
+    }
+    try {
+      return resolveMemberScene(await this.#getModes())
+    } catch (error) {
+      // eslint-disable-next-line no-console -- surfaces the failure in widget dev tools; the next update retries
+      console.error('Scene resolution failed:', error)
+      return null
     }
   }
 
@@ -773,28 +769,6 @@ export class AnimationController {
     )
   }
 
-  async #runMixedAnimation(speed: number): Promise<void> {
-    const modes = new Set(await this.#getModes())
-    if (
-      modes.has(ClassicOperationMode.auto) ||
-      modes.has(ClassicOperationMode.cool)
-    ) {
-      this.#runSnowAnimation(speed)
-    }
-    if (
-      modes.has(ClassicOperationMode.auto) ||
-      modes.has(ClassicOperationMode.heat)
-    ) {
-      this.#runFireAnimation(speed)
-    }
-    if (modes.has(ClassicOperationMode.dry)) {
-      this.#runSunAnimation(speed)
-    }
-    if (modes.has(ClassicOperationMode.fan)) {
-      this.#runLeafAnimation(speed)
-    }
-  }
-
   #runSnowAnimation(speed: number): void {
     this.#generateRecurring(
       (snowSpeed) => {
@@ -816,6 +790,12 @@ export class AnimationController {
   }
 
   #spawnSmokeBatch(flame: HTMLDivElement, speed: number): void {
+    // The chain outlives the scene signal, so it sits out hidden pages on
+    // its own: the loop keeps ticking (throttled by the browser) and
+    // resumes spawning when the page shows again.
+    if (document.visibilityState === 'hidden') {
+      return
+    }
     // `#animation` is fixed at the viewport origin, so the flame's
     // viewport coordinates are also its coordinates in the container.
     const { left, top, width } = flame.getBoundingClientRect()
@@ -886,5 +866,22 @@ export class AnimationController {
       this.#liveSmokeCount -= 1
     }
     return true
+  }
+
+  // Runs synchronously right after #reset installs the fresh controller,
+  // so every spawn loop is bound to it with no interleaving window.
+  #startScene(scene: ReadonlySet<SceneElement>, speed: number): void {
+    if (scene.has('fire')) {
+      this.#runFireAnimation(speed)
+    }
+    if (scene.has('leaf')) {
+      this.#runLeafAnimation(speed)
+    }
+    if (scene.has('snow')) {
+      this.#runSnowAnimation(speed)
+    }
+    if (scene.has('sun')) {
+      this.#runSunAnimation(speed)
+    }
   }
 }

--- a/widgets/ata-group-setting/public/animation.mts
+++ b/widgets/ata-group-setting/public/animation.mts
@@ -316,7 +316,6 @@ const startLeafWobble = (leaf: HTMLDivElement): void => {
 
 const generateLeafAnimation = (leaf: HTMLDivElement, speed: number): void => {
   leaf.style.offsetPath = `path('${generateLeafPath()}')`
-  leaf.style.offsetRotate = 'auto'
   startLeafWobble(leaf)
   const drift = leaf.animate(
     [{ offsetDistance: '0%' }, { offsetDistance: '100%' }],
@@ -364,19 +363,14 @@ const generateSnowflakeAnimation = (
 }
 
 // The shine spins the individual `rotate` property, so it composes with
-// the motion's `translate` instead of clashing on transform.
+// the motion's `translate` instead of clashing on transform. The glow
+// filter is static and lives in sun.css.
 const generateSunShineAnimation = (sun: HTMLDivElement): Animation =>
-  sun.animate(
-    [
-      { filter: 'brightness(120%) blur(18px)', rotate: '0deg' },
-      { filter: 'brightness(120%) blur(18px)', rotate: '360deg' },
-    ],
-    {
-      duration: AnimationDelay.sunShine,
-      easing: 'linear',
-      iterations: Infinity,
-    },
-  )
+  sun.animate([{ rotate: '0deg' }, { rotate: '360deg' }], {
+    duration: AnimationDelay.sunShine,
+    easing: 'linear',
+    iterations: Infinity,
+  })
 
 const getPreviousElement = (name: string, index?: string): HTMLElement | null =>
   document.querySelector<HTMLElement>(`#${name}-${String(Number(index) - 1)}`)
@@ -439,6 +433,8 @@ export class AnimationController {
   #generation = 0
 
   readonly #homey: Homey
+
+  #isFireActive = false
 
   #lastState: Classic.GroupState | null = null
 
@@ -574,7 +570,7 @@ export class AnimationController {
     particle.classList.add('smoke')
     particle.style.setProperty('--size', `${String(2 * size)}px`)
     this.#animation.append(particle)
-    this.#liveSmokeCount += 1
+    ++this.#liveSmokeCount
     return particle
   }
 
@@ -665,7 +661,7 @@ export class AnimationController {
     if (document.visibilityState === 'hidden') {
       // Stop spawning offscreen and invalidate any apply pass still in
       // flight; already-running animations are harmless.
-      this.#generation += 1
+      ++this.#generation
       this.#controller.abort()
       return
     }
@@ -710,7 +706,8 @@ export class AnimationController {
   #reset(scene: ReadonlySet<SceneElement>): void {
     this.#controller.abort()
     this.#controller = new AbortController()
-    if (!scene.has('fire')) {
+    this.#isFireActive = scene.has('fire')
+    if (!this.#isFireActive) {
       scheduleFlameRemoval()
     }
     this.#resetSunAnimation(scene.has('sun'))
@@ -790,10 +787,12 @@ export class AnimationController {
   }
 
   #spawnSmokeBatch(flame: HTMLDivElement, speed: number): void {
-    // The chain outlives the scene signal, so it sits out hidden pages on
-    // its own: the loop keeps ticking (throttled by the browser) and
-    // resumes spawning when the page shows again.
-    if (document.visibilityState === 'hidden') {
+    // The chain deliberately outlives the scene signal (a heat-to-heat
+    // reset keeps it), so standing down is its own job: instantly when
+    // fire leaves the scene — lingering flames must not keep puffing —
+    // and while the page is hidden. The loop keeps ticking and resumes
+    // spawning when conditions return.
+    if (!this.#isFireActive || document.visibilityState === 'hidden') {
       return
     }
     // `#animation` is fixed at the viewport origin, so the flame's
@@ -863,7 +862,7 @@ export class AnimationController {
     )
     animation.onfinish = (): void => {
       particle.remove()
-      this.#liveSmokeCount -= 1
+      --this.#liveSmokeCount
     }
     return true
   }

--- a/widgets/ata-group-setting/public/styles/leaf.css
+++ b/widgets/ata-group-setting/public/styles/leaf.css
@@ -1,6 +1,8 @@
+/* The offset path itself is random per leaf and stays inline. */
 .leaf {
   filter: brightness(var(--brightness));
   font-size: var(--size);
   inset-block-start: -50px;
+  offset-rotate: auto;
   position: absolute;
 }

--- a/widgets/ata-group-setting/public/styles/sun.css
+++ b/widgets/ata-group-setting/public/styles/sun.css
@@ -1,6 +1,7 @@
 /* The centering offset and the offscreen offset both live in the
    animated `translate` property. */
 .sun {
+  filter: brightness(120%) blur(18px);
   font-size: 14rem;
   inset-block-start: 50%;
   inset-inline-end: 50%;


### PR DESCRIPTION
Suite du panel de design post-#1379 : trois assesseurs indépendants avaient convergé sur les mêmes défauts d'orchestration. Cette PR les corrige tous, sans changer la forme du fichier (le panel a aussi unanimement écarté split en fichiers et hiérarchie de classes — la composition par fonctions pilotées par config est déjà la bonne abstraction).

## Les quatre défauts corrigés

1. **Race de générations dans `applyAnimation`** — `#reset` remplaçait `#controller` *puis* attendait le réseau ; un apply entrelacé (le `change` de zone n'est pas débouncé) démarrait un second jeu de boucles de spawn sur le contrôleur le plus récent → densité doublée. Désormais : jeton de génération pris avant l'`await`, re-vérifié après — un pass supplanté (par un update plus récent **ou** par un passage en `hidden`) abandonne sans toucher à la scène.
2. **Triple fetch `#getModes` séquentiel, sans gestion d'erreur** — le mapping mode→scène était encodé quatre fois (table des runners, prédicat feu, prédicat soleil, dispatch mixed), d'où jusqu'à trois fetchs par pass, *au milieu* du teardown : un échec laissait la scène figée à moitié détruite. Désormais : un résolveur pur unique (`MODE_SCENES` + `resolveMemberScene`, fidèle à `classicHeatModes = {auto, heat}`), **un seul** fetch (groupes mixtes uniquement), **avant** tout teardown — un échec résout `null` et la scène courante continue de tourner ; le prochain update réessaie. Après résolution, reset + démarrage sont synchrones : la fenêtre d'entrelacement disparaît structurellement.
3. **La fumée appartient à sa flamme** — la chaîne écoutait `AbortSignal.any([global, flamme])` : un reset heat→heat qui *gardait* les flammes tuait quand même leur fumée (le delta cosmétique documenté de #1379). Désormais liée au seul contrôleur de la flamme — et la review adversariale du diff a attrapé la régression symétrique que cela introduisait (des flammes en sursis qui continuaient à fumer ~2 s après la sortie du feu, reduced-motion compris) : `#isFireActive` posé au reset arrête les nouvelles particules **instantanément**, sans reperdre la survie heat→heat.
4. **Le retrait des flammes rejoint le régime de signaux** — `scheduleFlameRemoval` passait par des `setTimeout` bruts ; il termine maintenant chaque flamme via son propre contrôleur (`WeakMap`), par le même chemin `expireFlame` que l'expiration naturelle.

Au passage : `reset()` public supprimé (aucun appelant), `++`/`--` unifiés, et deux styles statiques déplacés en CSS (le glow du soleil, constant dans ses keyframes ; l'`offset-rotate` de la feuille).

## Vérification

Le **vrai module** (bundlé avec les modules Homey stubbés) rejoue les scénarios dans chromium headless — chacun conçu pour discriminer ancien/nouveau comportement :

| Scénario | Résultat |
|---|---|
| Apply mixed lent supplanté par un apply direct → le fetch périmé atterrit | 0 élément de la scène périmée, la scène courante continue |
| Échec réseau en plein apply | Scène intacte, spawn continue (7 → 25 flammes) |
| Reset heat→heat | 364 nouvelles particules aux positions des flammes *d'avant* le reset |
| Sortie du feu | **0** particule spawnée pendant le sursis, drain complet ≤ 2,6 s, 0 fumée ensuite |
| Update reçu page cachée | 0 spawn, rejeu au retour (12 flammes) |

La contre-épreuve sur le code de main est parlante : la batterie n'y termine même pas — l'ancien code fetche pendant *chaque* reset, exactement le défaut n° 2.

Review multi-agents du diff (3 lentilles, réfutation adversariale, 19 agents) : 8 findings bruts → **1 confirmé** (intégré, point 3) → re-vérifié vert. Suite locale : format/lint/tsgo exit 0, 432 tests, build (le bundle *rétrécit* : 15,3 → 14,9 kB), validate publish.

## Comportements sciemment conservés

- Les flammes en sursis (sortie du feu) vivent leur délai aléatoire ≤ 2 s comme avant — mais sans fumée neuve et sous signal.
- Pendant un fetch mixed, l'ancienne scène reste visible jusqu'à la résolution (avant : écran vidé pendant le fetch) — trou mort en moins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
