### PR TITLE
Right-align the temperature value with the selects' chevron edge

### DIFF
--- a/widgets/ata-group-setting/public/styles/layout.css
+++ b/widgets/ata-group-setting/public/styles/layout.css
@@ -80,8 +80,9 @@ select:not(.zone-select) {
 }
 
 input {
-  /* Matches the selects' chevron padding so the value column stays aligned */
-  padding-inline-end: 1.5rem;
+  /* Lines up the value's right edge with the selects' chevron, whose right
+     edge sits 6px in (second 4px gradient drawn at calc(100% - 10px)) */
+  padding-inline-end: 6px;
   text-align: end;
 }
 


### PR DESCRIPTION
In the air-to-air widget, the target-temperature number input reserved the selects' full chevron padding (`padding-inline-end: 1.5rem`), so the value stopped 24px short of the widget's right edge and looked misaligned next to the rows whose chevrons reach the edge.

The input now reserves only 6px — the inset of the chevron's right edge (its second 4px gradient is drawn at `calc(100% - 10px)`) — so the value's right edge lines up with the value column's visual right edge.

| Before | After |
| --- | --- |
| Value ends 24px in, left of the chevron column | Value flush with the chevrons' right edge |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SFL2C8wuEAYrQVuqzeMdEh

---
_Generated by [Claude Code](https://claude.ai/code/session_01SFL2C8wuEAYrQVuqzeMdEh)_