### PR TITLE
Share the zone selector styling as enforced twin stylesheets

### DIFF
--- a/tests/unit/widget-styles.test.ts
+++ b/tests/unit/widget-styles.test.ts
@@ -1,0 +1,19 @@
+import { readFile } from 'node:fs/promises'
+
+import { describe, expect, it } from 'vitest'
+
+// The two widgets ship separately, so the zone selector's ghost styling is
+// duplicated on purpose; this pins the copies byte-identical so they cannot
+// drift apart silently.
+describe('widget styles', () => {
+  it('should keep the zone-select stylesheets byte-identical', async () => {
+    const [ataGroupSetting, charts] = await Promise.all(
+      [
+        'widgets/ata-group-setting/public/styles/zone-select.css',
+        'widgets/charts/public/styles/zone-select.css',
+      ].map(async (path) => readFile(path, 'utf8')),
+    )
+
+    expect(ataGroupSetting).toBe(charts)
+  })
+})

--- a/widgets/ata-group-setting/public/index.html
+++ b/widgets/ata-group-setting/public/index.html
@@ -5,6 +5,7 @@
         <meta content="width=device-width, initial-scale=1.0" name="viewport">
         <title>Air-to-air device values</title>
         <link href="styles/layout.css" rel="stylesheet">
+        <link href="styles/zone-select.css" rel="stylesheet">
         <link href="styles/flame.css" rel="stylesheet">
         <link href="styles/leaf.css" rel="stylesheet">
         <link href="styles/smoke.css" rel="stylesheet">

--- a/widgets/ata-group-setting/public/styles/layout.css
+++ b/widgets/ata-group-setting/public/styles/layout.css
@@ -8,44 +8,16 @@
   z-index: -1;
 }
 
-/* Zone selector — borderless "ghost" control on Homey design tokens.
-   `appearance: none` drops the native dropdown arrow, so the small
-   triangle chevron is redrawn with two currentcolor gradients (the
-   daisyUI technique). */
+/* The shared ghost styling lives in zone-select.css; the spacing to the
+   value rows below is specific to this widget. */
 .zone-select {
-  appearance: none;
-  background-color: transparent;
-  background-image:
-    linear-gradient(45deg, transparent 50%, currentcolor 50%),
-    linear-gradient(135deg, currentcolor 50%, transparent 50%);
-  background-position:
-    calc(100% - 14px) calc(50% + 1px),
-    calc(100% - 10px) calc(50% + 1px);
-  background-repeat: no-repeat;
-  background-size: 4px 4px;
-  border: none;
-  border-radius: var(--homey-border-radius-small);
-  color: var(--homey-text-color);
-  cursor: pointer;
-  font-family: inherit;
-  font-size: var(--homey-font-size-default);
-  font-weight: var(--homey-font-weight-bold);
-  line-height: var(--homey-line-height-default);
   margin-block-end: var(--homey-su-2);
-  padding: var(--homey-su-1);
-  padding-inline-end: 1.5rem;
-  text-align-last: center;
 }
 
-.zone-select:hover {
-  /* background-color (not the shorthand) so the chevron gradients survive */
-  background-color: color-mix(in srgb, currentcolor 8%, transparent);
-}
-
-/* The zone select touches the top edge and value controls touch the right
-   edge of the widget card, so a default focus ring drawn around the element
-   spills outside the frame. Draw it inside instead. */
-.zone-select:focus,
+/* Value controls touch the right edge of the widget card, so a default
+   focus ring drawn around the element spills outside the frame. Draw it
+   inside instead (the zone select gets the same treatment in
+   zone-select.css). */
 .ghost-button:focus,
 input:focus,
 select:focus {

--- a/widgets/ata-group-setting/public/styles/zone-select.css
+++ b/widgets/ata-group-setting/public/styles/zone-select.css
@@ -1,7 +1,8 @@
 /* Zone selector — borderless "ghost" control on Homey design tokens.
-   `appearance: none` drops the native dropdown arrow, so the small
-   triangle chevron is redrawn with two currentcolor gradients (the
-   daisyUI technique). */
+   `appearance: none` drops the native dropdown arrow, so a small triangle
+   chevron is redrawn with two currentcolor gradients. Kept byte-identical
+   across both widgets' styles/zone-select.css (the widgets ship
+   separately; a unit test enforces the mirror). */
 .zone-select {
   appearance: none;
   background-color: transparent;
@@ -31,9 +32,9 @@
   background-color: color-mix(in srgb, currentcolor 8%, transparent);
 }
 
-/* The zone select touches the top edge of the widget card, so a default
-   focus ring drawn around the element spills outside the frame. Draw it
-   inside instead. */
+/* The select touches the top edge of the widget card, so a default focus
+   ring drawn around the element spills outside the frame. Draw it inside
+   instead. */
 .zone-select:focus {
   outline: 2px solid var(--homey-text-color-blue);
   outline-offset: -2px;

--- a/widgets/charts/public/index.html
+++ b/widgets/charts/public/index.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta content="width=device-width, initial-scale=1.0" name="viewport">
         <title>MELCloud charts</title>
-        <link href="styles/index.css" rel="stylesheet">
+        <link href="styles/zone-select.css" rel="stylesheet">
         <script type="module" src="index.mjs"></script>
         <meta content="MELCloud charts" name="description">
     </head>

--- a/widgets/charts/public/styles/zone-select.css
+++ b/widgets/charts/public/styles/zone-select.css
@@ -1,0 +1,41 @@
+/* Zone selector — borderless "ghost" control on Homey design tokens.
+   `appearance: none` drops the native dropdown arrow, so a small triangle
+   chevron is redrawn with two currentcolor gradients. Kept byte-identical
+   across both widgets' styles/zone-select.css (the widgets ship
+   separately; a unit test enforces the mirror). */
+.zone-select {
+  appearance: none;
+  background-color: transparent;
+  background-image:
+    linear-gradient(45deg, transparent 50%, currentcolor 50%),
+    linear-gradient(135deg, currentcolor 50%, transparent 50%);
+  background-position:
+    calc(100% - 14px) calc(50% + 1px),
+    calc(100% - 10px) calc(50% + 1px);
+  background-repeat: no-repeat;
+  background-size: 4px 4px;
+  border: none;
+  border-radius: var(--homey-border-radius-small);
+  color: var(--homey-text-color);
+  cursor: pointer;
+  font-family: inherit;
+  font-size: var(--homey-font-size-default);
+  font-weight: var(--homey-font-weight-bold);
+  line-height: var(--homey-line-height-default);
+  padding: var(--homey-su-1);
+  padding-inline-end: 1.5rem;
+  text-align-last: center;
+}
+
+.zone-select:hover {
+  /* background-color (not the shorthand) so the chevron gradients survive */
+  background-color: color-mix(in srgb, currentcolor 8%, transparent);
+}
+
+/* The select touches the top edge of the widget card, so a default focus
+   ring drawn around the element spills outside the frame. Draw it inside
+   instead. */
+.zone-select:focus {
+  outline: 2px solid var(--homey-text-color-blue);
+  outline-offset: -2px;
+}


### PR DESCRIPTION
Suite de l'état des lieux CSS post-DaisyUI/Tailwind : l'audit a montré qu'**aucune règle résiduelle** ne datait de cette époque (le nettoyage était complet depuis #1359) — mais il a mis au jour la seule vraie simplification disponible.

## Ce que fait cette PR

- **Dédup du bloc `.zone-select`** (~40 lignes : chevron aux deux gradients `currentcolor`, hover, focus ring intérieur), dupliqué entre les deux widgets avec une divergence silencieuse (`margin-block-end` présent d'un côté seulement).
- Les widgets étant **livrés séparément** (pas de partage de fichiers à l'exécution), la dédup prend la forme de **fichiers jumeaux `styles/zone-select.css` imposés octet-pour-octet identiques par un test unitaire** — la duplication devient un invariant vérifié au lieu d'un accident.
- La divergence légitime (l'espacement vers les lignes de valeurs, propre à ata-group-setting) devient une règle explicite et commentée dans `layout.css`.
- `charts/styles/index.css`, vidé par l'extraction, est supprimé.
- Les commentaires décrivent la technique du chevron par ce qu'elle fait, sans plus citer la bibliothèque d'origine.

## Non-changements garantis

Règles déplacées verbatim — aucune valeur modifiée, aucun sélecteur ajouté ni retiré, ordre de chargement sans recouvrement de spécificité. Suite complète verte : format/lint/tsgo exit 0, **433 tests** (dont le nouveau test-miroir), build, validate publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)