### PR TITLE
Add CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,8 +17,10 @@ caught real failures that the others miss:
 - `npm run typecheck` — `tsc` from `@typescript/native` (TypeScript 7).
 - `npm test` / `npm run test:coverage` — vitest; branches are at 100%,
   keep them there.
-- `npm run build` — esbuild bundles (`scripts/bundle.mjs`) + `tsgo`
-  emit. Widget/settings `*.mjs` bundles are committed build outputs.
+- `npm run build` — esbuild bundles (`scripts/bundle.mjs`) + `tsc` emit.
+  `settings/index.mjs` and `widgets/*/public/index.mjs` are gitignored
+  build outputs, never checked in; the Homey CLI regenerates them on
+  validate/install/run.
 - `npm run homey:validate` — Homey validation at publish level; may
   rewrite files (see locales below), re-stage if it does.
 - `npm run homey:start` — `homey app run --remote` for on-device testing.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,107 @@
+# CLAUDE.md
+
+Homey app for MELCloud (Mitsubishi Electric AC/heat-pump cloud). ESM only,
+Node >= 22.19. The API layer lives in `@olivierzal/melcloud-api` (GitHub
+Packages, sibling repo with its own CLAUDE.md) — API bugs are fixed there,
+not worked around here.
+
+## Commands
+
+Run the FULL suite before any push — CI runs all of it and each step has
+caught real failures that the others miss:
+
+- `npm run format` / `npm run format:fix` — prettier (eslint does NOT
+  cover formatting).
+- `npm run lint` / `npm run lint:fix` — ESLint (needs its 8 GB heap; also
+  lints CSS and HTML via the css/html plugins).
+- `npm run typecheck` — `tsc` from `@typescript/native` (TypeScript 7).
+- `npm test` / `npm run test:coverage` — vitest; branches are at 100%,
+  keep them there.
+- `npm run build` — esbuild bundles (`scripts/bundle.mjs`) + `tsgo`
+  emit. Widget/settings `*.mjs` bundles are committed build outputs.
+- `npm run homey:validate` — Homey validation at publish level; may
+  rewrite files (see locales below), re-stage if it does.
+- `npm run homey:start` — `homey app run --remote` for on-device testing.
+
+Check real exit codes; never pipe a check's output through `tail`/`grep`
+to judge success. Remove any `.claude/worktrees/**` leftovers before
+running the suite — the vitest/eslint globs sweep them and corrupt
+coverage.
+
+## Homey platform gotchas
+
+- `.homeycompose/` is the SOURCE for `app.json` and `locales/*.json`; the
+  Homey CLI regenerates those outputs on every preprocess and writes them
+  WITHOUT a trailing newline. Commit the CLI-generated form verbatim — do
+  not "fix" the missing newline, and never edit generated files directly.
+- `homey:validate` acts as a pre-push formatter hook of sorts: if it
+  touches files, amend before pushing.
+- Widget webviews get Homey's injected class-based stylesheet and the
+  `--homey-*` design tokens at runtime; that stylesheet is not in the repo
+  and not available offline.
+- The settings page (`settings/`) uses Homey's official `homey-form-*` /
+  `homey-button-*` classes; `settings/index.css` only fills documented SDK
+  gaps (date inputs, checkbox `:indeterminate`, `fieldset[hidden]`
+  specificity) and app-specific design.
+
+## Widgets
+
+- Widgets ship separately; they cannot share files at runtime. The zone
+  selector's ghost styling is deliberately duplicated as byte-identical
+  `styles/zone-select.css` twins, pinned by `tests/unit/widget-styles.test.ts`
+  — edit both or the suite fails.
+- `ata-group-setting` animations are WAAPI on compositor-only properties
+  (`transform`/`translate`/`rotate`/`scale`, `opacity`): no per-element
+  `filter` on particles (a blur per smoke puff collapsed real devices),
+  no rAF loops, budgets on particle counts. Individual transform
+  properties compose without clashing on `transform`.
+- Animation orchestration is AbortController-based: the scene controller
+  owns spawn loops, each flame owns its smoke chain via its own
+  controller, `applyAnimation` is guarded by a generation token re-checked
+  after every await, and the mode→scene mapping lives in one pure resolver
+  (`MODE_SCENES`). Fetches happen BEFORE teardown so failures leave the
+  running scene untouched. Desktop POCs lie about widget-scale
+  performance: dozens of flames × per-flame chains is the real load —
+  measure with a widget-scale harness before trusting an animation change.
+- `charts` uses Chart.js v4 tree-shaken registration. `border.dash` styles
+  the grid lines (the axis border is always solid) — that is v4 semantics,
+  not a bug. Legend-toggle state is index-keyed or identity-keyed inside
+  Chart.js and does not survive config replacement: visibility is carried
+  across refreshes by label (`#captureHiddenByLabel`).
+- Scale ids are `xAxis`/`yAxis` because the id-length lint bans `x`/`y`
+  keys.
+
+## Lint doctrine
+
+- Code adapts to the rules, never the reverse. Fix violations in code;
+  never loosen a rule or add options to accommodate existing code. Order
+  of preference: refactor > scoped `files` block for an imposed shape >
+  documented inline disable.
+- Inline disables need a `-- reason`; never a bare disable. Zero-warning
+  policy: every enabled rule is at `error`.
+- Metric caps (`complexity`, `max-statements` 10, `max-depth`,
+  `unicorn/try-complexity` 1…) are measured codebase ceilings: exceeding
+  one means extract/refactor, not bump.
+- Class members sort alphabetically (perfectionist), fields before
+  methods, public before private. Increments use prefix `++`/`--`.
+- Comments state intent or a constraint the code cannot show — never
+  history ("was X before"), narration, or the library something came from.
+- Beware `no-unnecessary-condition` vs TypeScript's control-flow
+  narrowing across `await`: a re-check of externally-mutated state (e.g.
+  `signal.aborted`) reads as "always false" — route through an API that
+  reads the live value instead (`signal.throwIfAborted()`).
+
+## Repo process
+
+- `main` is protected (PRs only, squash merges, 6 required contexts,
+  `strict=false`); merge queue is impossible (user-owned repo, org-only
+  feature). Copilot reviews every PR — answer every comment, and verify
+  its claims against sources before acting: it has been wrong about
+  library semantics.
+- Verify claimed library behavior empirically (headless chromium against
+  the real dist/bundle in the scratchpad) rather than from memory — this
+  repo's PRs document several review claims refuted that way.
+- `update-version.yml` pushes directly to `main` and will fail against
+  the ruleset (known debt).
+- Store submissions: a rejected version number cannot be resubmitted —
+  bump the patch version.


### PR DESCRIPTION
Pendant du CLAUDE.md de melcloud-api (OlivierZal/melcloud-api#1579), nourri de tout le non-évident accumulé sur ce repo :

- **Commands** : la suite complète pré-push (dont `format` que le lint ne couvre pas, le heap 8 Go du lint, les bundles commités) et les pièges de process (codes de sortie réels, worktrees `.claude/` qui contaminent les globs vitest/eslint).
- **Homey** : `.homeycompose` source de vérité, forme CLI des locales (pas de newline final — ne pas « corriger »), stylesheet injectée des webviews absente du repo, `settings/` sur les classes officielles.
- **Widgets** : jumeaux `zone-select.css` verrouillés par test, animations compositor-only (l'histoire du blur par particule), orchestration AbortController + jeton de génération + résolveur de scène, sémantique Chart.js v4 (`border.dash` = grille), visibilité portée par label.
- **Doctrine lint** : le code s'adapte aux règles, plafonds mesurés, disables motivés, ordre alphabétique perfectionist, piège `no-unnecessary-condition` × narrowing à travers `await`.
- **Process** : protection de main, review Copilot (vérifier ses claims sur sources — plusieurs réfutés), dette `update-version.yml`, versions refusées par le Store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)