### PR TITLE
ci(claude): drop the review triggers Copilot holds hostage

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -5,12 +5,6 @@ jobs:
         (github.event_name == 'issue_comment' &&
           contains(github.event.comment.body, '@claude') &&
           contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
-        (github.event_name == 'pull_request_review_comment' &&
-          contains(github.event.comment.body, '@claude') &&
-          contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
-        (github.event_name == 'pull_request_review' &&
-          contains(github.event.review.body || '', '@claude') &&
-          contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)) ||
         (github.event_name == 'issues' &&
           (contains(github.event.issue.body || '', '@claude') || contains(github.event.issue.title, '@claude')) &&
           contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association))
@@ -41,8 +35,4 @@ on:
     types: [created]
   issues:
     types: [opened]
-  pull_request_review:
-    types: [submitted]
-  pull_request_review_comment:
-    types: [created]
 permissions: {}


### PR DESCRIPTION
Ports [OlivierZal/melcloud-api#1582](https://github.com/OlivierZal/melcloud-api/pull/1582) to this repo.

## What

Removes the `pull_request_review` and `pull_request_review_comment` event triggers from `.github/workflows/claude.yml`, along with the guard conditions that only ever mattered for those events.

## Why

Since Copilot's automatic code review was enabled, every review submission and inline comment it posts triggers the `claude.yml` workflow. Because Copilot lacks write access, those runs accumulate as `action_required` and can never execute — the job's guard requires both an `@claude` mention **and** an `OWNER`/`MEMBER`/`COLLABORATOR` author, which Copilot never satisfies. This clears the "workflows awaiting approval" banner that appeared on every PR.

`@claude` remains reachable through PR conversation comments (`issue_comment`) and issue events (`issues`).


---
_Generated by [Claude Code](https://claude.ai/code/session_015YE1mZTrBd94p8Z3JeUwNZ)_