### PR TITLE
Enable exactOptionalPropertyTypes

### DIFF
--- a/api.mts
+++ b/api.mts
@@ -38,13 +38,16 @@ const api = {
   }: {
     homey: Homey
     query: Partial<ClassicErrorLogQueryParams>
-  }): Promise<FormattedErrorLog> =>
-    app.getClassicErrorLog({
-      from,
-      offset: toNumber(offset),
-      period: toNumber(period),
-      to,
-    }),
+  }): Promise<FormattedErrorLog> => {
+    const parsedOffset = toNumber(offset)
+    const parsedPeriod = toNumber(period)
+    return app.getClassicErrorLog({
+      ...(from !== undefined && { from }),
+      ...(parsedOffset !== undefined && { offset: parsedOffset }),
+      ...(parsedPeriod !== undefined && { period: parsedPeriod }),
+      ...(to !== undefined && { to }),
+    })
+  },
   getClassicFrostProtection: async ({
     homey: { app },
     params,

--- a/app.mts
+++ b/app.mts
@@ -401,7 +401,7 @@ export default class MELCloudApp extends App {
     hour,
   }: {
     deviceId: string
-    hour?: Hour
+    hour?: Hour | undefined
   }): Promise<ReportChartLineOptions> {
     return unwrapResult(
       await this.getClassicFacade('devices', deviceId).getHourlyTemperatures(
@@ -430,7 +430,7 @@ export default class MELCloudApp extends App {
     hour,
   }: {
     deviceId: string
-    hour?: Hour
+    hour?: Hour | undefined
   }): Promise<ReportChartLineOptions> {
     return unwrapResult(
       await this.getClassicFacade('devices', deviceId).getSignalStrength(hour),
@@ -539,7 +539,7 @@ export default class MELCloudApp extends App {
     settings,
   }: {
     settings: Settings
-    driverId?: string
+    driverId?: string | undefined
   }): Promise<void> {
     await Promise.all(
       this.#getDevices({ driverId }).map(async (device) => {
@@ -571,7 +571,10 @@ export default class MELCloudApp extends App {
   // Sync matching classic devices by pulling their latest state from MELCloud.
   // Per-device sync failures are logged without aborting the full sync run.
   async #classicSyncDevices(
-    filter: { driverId?: string; ids?: (number | string)[] } = {},
+    filter: {
+      driverId?: string | undefined
+      ids?: (number | string)[] | undefined
+    } = {},
   ): Promise<void> {
     const results = await Promise.allSettled(
       this.#getDevices(filter).map(async (device) => device.syncFromDevice()),
@@ -683,8 +686,8 @@ export default class MELCloudApp extends App {
     driverId,
     ids,
   }: {
-    driverId?: string
-    ids?: (number | string)[]
+    driverId?: string | undefined
+    ids?: (number | string)[] | undefined
   } = {}): MELCloudDevice[] {
     const drivers = this.#getDrivers(driverId)
     const stringIds = ids?.map(String)
@@ -832,7 +835,7 @@ export default class MELCloudApp extends App {
     { kind, type }: { kind?: ZoneKind; type?: Classic.DeviceType } = {},
   ): Classic.Zone[] {
     const zones = this.#facadeManager
-      .getZones({ type })
+      .getZones(type === undefined ? {} : { type })
       .filter(({ model }) => matchesZoneKind(model, kind))
     return filterZonesByName(zones, query)
   }

--- a/drivers/base-report.mts
+++ b/drivers/base-report.mts
@@ -145,10 +145,12 @@ export class EnergyReport<T extends Classic.DeviceType> {
     // Fetch energy data from the previous period (offset by config.minus)
     const toDateTime = getNow(this.#homey).subtract(this.#config.minus)
     const to = toDateTime.toPlainDate().toString()
-    const from = this.#config.mode === 'total' ? undefined : to
+    // Total mode reports from the epoch: omitting `from` lets the API
+    // default to its full-history lower bound.
+    const query = this.#config.mode === 'total' ? { to } : { from: to, to }
     try {
       await this.#set(
-        unwrapResult(await device.getEnergy({ from, to })),
+        unwrapResult(await device.getEnergy(query)),
         toDateTime.hour,
       )
     } catch (error) {

--- a/lib/classic-facade-manager.mts
+++ b/lib/classic-facade-manager.mts
@@ -16,10 +16,10 @@ export const setClassicFacadeManager = (value: Classic.FacadeManager): void => {
 
 export const getClassicBuildings = ({
   type,
-}: { type?: Classic.DeviceType } = {}): Classic.BuildingZone[] =>
-  getClassicFacadeManager().getBuildings({ type })
+}: { type?: Classic.DeviceType | undefined } = {}): Classic.BuildingZone[] =>
+  getClassicFacadeManager().getBuildings(type === undefined ? {} : { type })
 
 export const getClassicZones = ({
   type,
-}: { type?: Classic.DeviceType } = {}): Classic.Zone[] =>
-  getClassicFacadeManager().getZones({ type })
+}: { type?: Classic.DeviceType | undefined } = {}): Classic.Zone[] =>
+  getClassicFacadeManager().getZones(type === undefined ? {} : { type })

--- a/lib/validation.mts
+++ b/lib/validation.mts
@@ -16,7 +16,7 @@ const deviceOrZoneTypes = new Set<DeviceOrZoneData['zoneType']>([
 ])
 
 interface NonNegativeIntOptions {
-  readonly field?: string
+  readonly field?: string | undefined
   readonly max?: number
 }
 

--- a/public/dom.mts
+++ b/public/dom.mts
@@ -66,7 +66,7 @@ export const translateAriaLabels = (
 
 export const configureNumericInput = (
   input: HTMLInputElement,
-  { max, min }: { max?: number; min?: number },
+  { max, min }: { max?: number | undefined; min?: number | undefined },
 ): void => {
   if (input.type !== 'number') {
     return

--- a/settings/index.mts
+++ b/settings/index.mts
@@ -220,7 +220,7 @@ const createInput = ({
   type: string
   max?: number
   min?: number
-  placeholder?: string
+  placeholder?: string | undefined
   value?: string | null
 }): HTMLInputElement => {
   const input = document.createElement('input')
@@ -1110,17 +1110,23 @@ class ZoneSettingsManager {
     min,
   }: Classic.FrostProtectionQuery): Promise<void> {
     await withDisablingButtonPair('frost_protection', async () => {
+      const query = {
+        max,
+        min,
+        ...(isEnabled !== undefined && { isEnabled }),
+      } satisfies Classic.FrostProtectionQuery
+      const zoneSettings: Partial<Classic.ZoneSettings> = {
+        FPMaxTemperature: max,
+        FPMinTemperature: min,
+        ...(isEnabled !== undefined && { FPEnabled: isEnabled }),
+      }
       try {
         await homeyApiPut<unknown>(
           this.#homey,
           `/classic/zones/${this.#getZonePath()}/settings/frost-protection`,
-          { isEnabled, max, min } satisfies Classic.FrostProtectionQuery,
+          query,
         )
-        this.#updateZoneMapping({
-          FPEnabled: isEnabled,
-          FPMaxTemperature: max,
-          FPMinTemperature: min,
-        })
+        this.#updateZoneMapping(zoneSettings)
         this.displayFrostProtectionData()
         await this.#homey.alert(this.#homey.__('settings.success'))
       } catch (error) {
@@ -1135,17 +1141,22 @@ class ZoneSettingsManager {
     to: endDate,
   }: Classic.HolidayModeQuery): Promise<void> {
     await withDisablingButtonPair('holiday_mode', async () => {
+      const query = {
+        ...(startDate !== undefined && { from: startDate }),
+        ...(endDate !== undefined && { to: endDate }),
+      } satisfies Classic.HolidayModeQuery
+      const zoneSettings: Partial<Classic.ZoneSettings> = {
+        HMEnabled: Boolean(endDate),
+        HMEndDate: endDate ?? null,
+        HMStartDate: startDate ?? null,
+      }
       try {
         await homeyApiPut<unknown>(
           this.#homey,
           `/classic/zones/${this.#getZonePath()}/settings/holiday-mode`,
-          { from: startDate, to: endDate } satisfies Classic.HolidayModeQuery,
+          query,
         )
-        this.#updateZoneMapping({
-          HMEnabled: Boolean(endDate),
-          HMEndDate: endDate,
-          HMStartDate: startDate,
-        })
+        this.#updateZoneMapping(zoneSettings)
         this.displayHolidayModeData()
         await this.#homey.alert(this.#homey.__('settings.success'))
       } catch (error) {
@@ -1241,8 +1252,8 @@ class ZoneSettingsManager {
       }
       fireAndForget(
         this.setHolidayModeData({
-          from: startDateValue === '' ? undefined : startDateValue,
-          to: endDate,
+          ...(startDateValue !== '' && { from: startDateValue }),
+          ...(endDate !== undefined && { to: endDate }),
         }),
       )
     })
@@ -1448,16 +1459,16 @@ class SettingsApp {
   }: HomeySettings): Promise<void> {
     const driverSettings =
       await this.#deviceSettingsManager.fetchDriverSettings()
-    // Homey Settings may return `null` for a cleared key; coerce to
-    // `undefined` to match `Partial<LoginCredentials>`.
+    // Homey Settings may return `null` for a cleared key; omit such keys
+    // to match `Partial<LoginCredentials>`.
     this.#authManager.createCredentialFields(driverSettings, {
       classic: {
-        password: password ?? undefined,
-        username: username ?? undefined,
+        ...(typeof password === 'string' && { password }),
+        ...(typeof username === 'string' && { username }),
       },
       home: {
-        password: homePassword ?? undefined,
-        username: homeUsername ?? undefined,
+        ...(typeof homePassword === 'string' && { password: homePassword }),
+        ...(typeof homeUsername === 'string' && { username: homeUsername }),
       },
     })
   }

--- a/tests/unit/api.test.ts
+++ b/tests/unit/api.test.ts
@@ -121,7 +121,7 @@ describe('api', () => {
       })
     })
 
-    it('should pass undefined for missing numeric query params', async () => {
+    it('should omit missing numeric query params', async () => {
       const errorLog = mock<FormattedErrorLog>()
       mockApp.getClassicErrorLog.mockResolvedValue(errorLog)
 
@@ -130,12 +130,7 @@ describe('api', () => {
         query: mock<Partial<ClassicErrorLogQueryParams>>(),
       })
 
-      expect(mockApp.getClassicErrorLog).toHaveBeenCalledWith({
-        from: undefined,
-        offset: undefined,
-        period: undefined,
-        to: undefined,
-      })
+      expect(mockApp.getClassicErrorLog).toHaveBeenCalledWith({})
     })
 
     it('should throw on empty string numeric query param', async () => {

--- a/tests/unit/api.test.ts
+++ b/tests/unit/api.test.ts
@@ -13,7 +13,11 @@ import type { ZoneData } from '../../types/zone.mts'
 import { mock } from '../helpers.js'
 
 const mockGetBuildings =
-  vi.fn<(options?: { type?: Classic.DeviceType }) => Classic.BuildingZone[]>()
+  vi.fn<
+    (options?: {
+      type?: Classic.DeviceType | undefined
+    }) => Classic.BuildingZone[]
+  >()
 
 vi.mock(import('../../lib/classic-facade-manager.mts'), () => ({
   getClassicBuildings: mockGetBuildings,
@@ -334,7 +338,7 @@ describe('api', () => {
       await api.updateDeviceSettings({
         body,
         homey,
-        query: { driverId: undefined },
+        query: {},
       })
 
       expect(mockApp.updateDeviceSettings).toHaveBeenCalledWith({

--- a/tests/unit/ata-group-setting-api.test.ts
+++ b/tests/unit/ata-group-setting-api.test.ts
@@ -95,7 +95,7 @@ describe('ata-group-setting api', () => {
       const buildings = mock<Classic.BuildingZone[]>()
       mockGetBuildings.mockReturnValue(buildings)
 
-      const result = api.getClassicBuildings({ query: { type: undefined } })
+      const result = api.getClassicBuildings({ query: {} })
 
       expect(result).toBe(buildings)
       expect(mockGetBuildings).toHaveBeenCalledWith({ type: undefined })

--- a/tests/unit/base-report.test.ts
+++ b/tests/unit/base-report.test.ts
@@ -391,7 +391,7 @@ describe(EnergyReport, () => {
   })
 
   describe('total mode', () => {
-    it('should pass undefined from for total mode energy requests', async () => {
+    it('should omit from for total mode energy requests', async () => {
       cleanMappingMock.mockReturnValue({
         meter_power: ['TotalAutoConsumed'],
       })
@@ -403,9 +403,7 @@ describe(EnergyReport, () => {
       const report = new EnergyReport(mockDevice, totalConfig)
       await report.start()
 
-      expect(getEnergyMockLocal).toHaveBeenCalledWith(
-        expect.objectContaining({ from: undefined }),
-      )
+      expect(getEnergyMockLocal).toHaveBeenCalledWith({ to: '2026-03-18' })
     })
   })
 

--- a/tests/unit/charts-api.test.ts
+++ b/tests/unit/charts-api.test.ts
@@ -9,7 +9,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { mock } from '../helpers.js'
 
 const mockGetClassicZones =
-  vi.fn<(options?: { type?: Classic.DeviceType }) => Classic.Zone[]>()
+  vi.fn<
+    (options?: { type?: Classic.DeviceType | undefined }) => Classic.Zone[]
+  >()
 
 vi.mock(
   import('../../lib/classic-facade-manager.mts'),
@@ -51,7 +53,7 @@ describe('charts api', () => {
       ] as unknown as Classic.Zone[]
       mockGetClassicZones.mockReturnValue(zones)
 
-      const result = api.getClassicDevices({ query: { type: undefined } })
+      const result = api.getClassicDevices({ query: {} })
 
       expect(result).toStrictEqual([
         { id: 2, level: 1, model: 'devices', name: 'Device 1' },
@@ -91,7 +93,7 @@ describe('charts api', () => {
       ] as unknown as Classic.Zone[]
       mockGetClassicZones.mockReturnValue(zones)
 
-      const result = api.getClassicDevices({ query: { type: undefined } })
+      const result = api.getClassicDevices({ query: {} })
 
       expect(result).toStrictEqual([])
     })
@@ -122,7 +124,7 @@ describe('charts api', () => {
       const result = await api.getClassicHourlyTemperatures({
         homey,
         params: { deviceId: 'dev1' },
-        query: { hour: undefined },
+        query: {},
       })
 
       expect(result).toBe(lineOptions)
@@ -188,7 +190,7 @@ describe('charts api', () => {
       const result = await api.getClassicSignal({
         homey,
         params: { deviceId: 'dev1' },
-        query: { hour: undefined },
+        query: {},
       })
 
       expect(result).toBe(lineOptions)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "allowUnusedLabels": false,
     "declaration": true,
     "erasableSyntaxOnly": true,
+    "exactOptionalPropertyTypes": true,
     "isolatedDeclarations": true,
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "libReplacement": false,

--- a/types/driver-settings.mts
+++ b/types/driver-settings.mts
@@ -8,7 +8,7 @@ interface DriverSettingValue {
 export interface DriverCapabilitiesOptions {
   readonly title: string
   readonly type: string
-  readonly values?: readonly DriverSettingValue[]
+  readonly values?: readonly DriverSettingValue[] | undefined
 }
 
 export interface DriverSetting {
@@ -16,13 +16,13 @@ export interface DriverSetting {
   readonly id: string
   readonly title: string
   readonly type: string
-  readonly groupId?: string
+  readonly groupId?: string | undefined
   readonly groupLabel?: string
-  readonly max?: number
-  readonly min?: number
+  readonly max?: number | undefined
+  readonly min?: number | undefined
   readonly placeholder?: string
-  readonly units?: string
-  readonly values?: readonly DriverSettingValue[]
+  readonly units?: string | undefined
+  readonly values?: readonly DriverSettingValue[] | undefined
 }
 
 export interface LoginDriverSetting extends DriverSetting {

--- a/types/manifest.mts
+++ b/types/manifest.mts
@@ -52,5 +52,5 @@ export interface ManifestDriver {
 export interface ManifestDriverCapabilitiesOptions {
   readonly title: LocalizedStrings
   readonly type: string
-  readonly values?: readonly CapabilitiesOptionsValues<string>[]
+  readonly values?: readonly CapabilitiesOptionsValues<string>[] | undefined
 }

--- a/types/widgets.mts
+++ b/types/widgets.mts
@@ -21,7 +21,7 @@ export interface DaysQuery {
 }
 
 export interface GetAtaOptions {
-  readonly status?: 'on'
+  readonly status?: 'on' | undefined
 }
 
 export interface HourQuery {

--- a/widgets/ata-group-setting/public/ata-values.mts
+++ b/widgets/ata-group-setting/public/ata-values.mts
@@ -62,8 +62,8 @@ const createInput = ({
 }: {
   id: string
   type: string
-  max?: number
-  min?: number
+  max?: number | undefined
+  min?: number | undefined
   placeholder?: string
   value?: string
 }): HTMLInputElement => {
@@ -272,7 +272,7 @@ export class AtaValueManager {
   }: {
     id: string
     type: string
-    values?: readonly { id: string; label: string }[]
+    values?: readonly { id: string; label: string }[] | undefined
   }): HTMLValueElement | null {
     if (elementTypes.has(type)) {
       return createSelect(this.#homey, id, values)

--- a/widgets/charts/public/index.mts
+++ b/widgets/charts/public/index.mts
@@ -270,7 +270,9 @@ const getLineDatasets = (
     }
   })
 
-const getLineScalesConfig = (unit: string): WidgetChartOptions['scales'] => {
+const getLineScalesConfig = (
+  unit: string,
+): NonNullable<WidgetChartOptions['scales']> => {
   const colorLight = getStyle('--homey-text-color-light')
   const ticksStyle = { color: colorLight, font: getFontConfig() }
   return {
@@ -402,7 +404,11 @@ const fetchChartData = async (
     chart,
     days,
     zoneValue,
-  }: { chart: HomeySettings['chart']; zoneValue: string; days?: number },
+  }: {
+    chart: HomeySettings['chart']
+    zoneValue: string
+    days?: number | undefined
+  },
 ): Promise<ReportChartLineOptions | ReportChartPieOptions> => {
   const daysQuery =
     chartsWithDays.has(chart) && days !== undefined ?
@@ -435,7 +441,7 @@ const getTimeout = (chart: HomeySettings['chart']): number => {
 interface DrawConfig {
   readonly chart: HomeySettings['chart']
   readonly height: number
-  readonly days?: number
+  readonly days?: number | undefined
 }
 
 // Line-dataset visibility flows through `dataset.hidden`: replacing the data


### PR DESCRIPTION
## Pourquoi

`exactOptionalPropertyTypes` était le seul flag « beyond-strict » manquant d'une tsconfig par ailleurs maximale (`noUncheckedIndexedAccess`, `isolatedDeclarations`, `erasableSyntaxOnly`…). Évaluation empirique préalable : le flag surfaçait **40 erreurs dans 13 fichiers**, toutes du motif « écrire `T | undefined` dans une prop optionnelle » — et **aucune n'était un bug runtime** : chaque puits neutralise déjà `undefined` (le client HTTP de melcloud-api filtre `value !== undefined` avant `URLSearchParams`, les corps POST passent par `JSON.stringify`, les lecteurs app utilisent gardes `!== undefined` / défauts de déstructuration / `?? défaut`).

Le flag vaut néanmoins la peine : melcloud-api contient deux vraies divergences absent ≠ présent-`undefined` (`updateValues` Home et Classic — la garde `Object.keys(...).length === 0` est défaite par une clé présente-`undefined`), aujourd'hui non atteintes ; eOPT empêche d'introduire ce genre d'appel par construction. Adoption en un seul PR flip-and-resolve, conformément au pattern maison.

## Résolutions, par propriétaire du type cible

- **Types et params app** : élargis en `| undefined` là où les appelants forwardent légitimement une valeur peut-être-`undefined` (`DriverSetting`, `DriverCapabilitiesOptions`, `ManifestDriverCapabilitiesOptions.values`, `GetAtaOptions.status`, `NonNegativeIntOptions.field`, `DrawConfig.days`, params de `#getDevices`/`updateDeviceSettings`/`getClassicHourlyTemperatures`/`getClassicSignal`/`configureNumericInput`/`createInput`…).
- **Frontières melcloud-api** (types non modifiables ici) : spreads conditionnels `...(x !== undefined && { x })` au lieu d'`undefined` explicite ; la construction des payloads sort des blocs `try` pour respecter `unicorn/try-complexity: 1`.
- **Cache de zone** : une date de holiday mode effacée est désormais stockée `null` (modèle API `string | null`) au lieu d'`undefined` ; les lecteurs coalescent déjà (`?? ''`), comportement inchangé.
- **Chart.js** : `getLineScalesConfig` retourne `NonNullable<WidgetChartOptions['scales']>` (le helper retourne toujours un objet concret).
- **Tests** : les chemins « paramètre absent » passent `{}` au lieu de `{ key: undefined }` ; le rapport d'énergie en mode total affirme l'appel exact `{ to }` maintenant que `from` est réellement omis.

Aucun changement de comportement runtime attendu : le diff ne contient que des types, des spreads conditionnels et des littéraux de test.

## Suivi (repo sibling)

Élargir dans `@olivierzal/melcloud-api` les props optionnelles des types query (`ErrorLogQuery`, `HolidayModeQuery`, `FrostProtectionQuery`, `ReportQuery`, `GetAtaOptions`, `Partial<ZoneSettings>`, `LoginCredentials`) en `| undefined` — prouvé runtime-safe (son client HTTP filtre les valeurs `undefined`) — ce qui permettra de retransformer les spreads conditionnels d'ici en littéraux simples. Y activer eOPT aussi aurait encore plus de valeur : les hazards `updateValues` y vivent.

## Vérification

- `npm run format` ✓ · `npm run lint` ✓ · `npm run typecheck` ✓ (flag actif)
- `npm run test:coverage` ✓ — 448/448, statements/branches/functions/lines à 100 %
- `npm run build` ✓ · `npm run homey:validate` (niveau publish) ✓ — aucun fichier régénéré

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hAJmy7RdUjScMhCGK7fBu

---
_Generated by [Claude Code](https://claude.ai/code/session_018hAJmy7RdUjScMhCGK7fBu)_