### PR TITLE
chore: upgrade @olivierzal/melcloud-api to the stable ^41.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "44.1.1",
       "license": "GPL-3.0-only",
       "dependencies": {
-        "@olivierzal/melcloud-api": "41.0.0-alpha.7",
+        "@olivierzal/melcloud-api": "^41.0.0",
         "source-map-support": "^0.5.21",
         "temporal-polyfill": "^1.0.1"
       },
@@ -1065,14 +1065,14 @@
       }
     },
     "node_modules/@olivierzal/melcloud-api": {
-      "version": "41.0.0-alpha.7",
-      "resolved": "https://npm.pkg.github.com/download/@olivierzal/melcloud-api/41.0.0-alpha.7/ad251e4a380e3426e4ebc03a3f41f19868ad9f8d",
-      "integrity": "sha512-53kvvEwETFP4GCjUX+h9nQqXBUJ/MAHssRhMFH/LvF4QgVe6gUbQ2S1g1FRmTKFRo9jL+NDmH3bwooo73A0vdg==",
+      "version": "41.0.0",
+      "resolved": "https://npm.pkg.github.com/download/@olivierzal/melcloud-api/41.0.0/2d48d12de96cc3096400c76b1ac79ec3a1017819",
+      "integrity": "sha512-o+ticiiJsRx5GJTn5tZ+1zPuBPT3zpHPvj42MlO9gAjU8hFkvD5XxQOZ3ptwtpb80+wjziTwmaYZ1JTFqZaUhw==",
       "license": "MIT",
       "dependencies": {
         "temporal-polyfill": "^1.0.1",
         "tough-cookie": "^6.0.1",
-        "undici": "^8.5.0",
+        "undici": "^8.7.0",
         "zod": "^4.4.3"
       },
       "engines": {
@@ -6906,9 +6906,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.5.0.tgz",
-      "integrity": "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.7.0.tgz",
+      "integrity": "sha512-N7iQtfyLhIMOFgQubvmLV26svHpO0bqKnAiWotTQCVKCmWrcGbBotPuW1x+xwYZ2VHdSTVUfPQQnlEt1/LouTQ==",
       "license": "MIT",
       "engines": {
         "node": ">=22.19.0"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "typecheck": "node ./node_modules/@typescript/native/bin/tsc --noEmit"
   },
   "dependencies": {
-    "@olivierzal/melcloud-api": "41.0.0-alpha.7",
+    "@olivierzal/melcloud-api": "^41.0.0",
     "source-map-support": "^0.5.21",
     "temporal-polyfill": "^1.0.1"
   },


### PR DESCRIPTION
Moves off the exact prerelease pin (41.0.0-alpha.7) onto the stable caret range, back to the house style for released dependencies. No code change — the alpha line was consumed incrementally throughout #1396.

Full suite green: 506 tests, 100% coverage, publish-level validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)