### PR TITLE
chore: release Homey app v45.0.0

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -346,5 +346,20 @@
     "pl": "Naprawiono stronę ustawień proszącą o dane logowania MELCloud Home, mimo że były prawidłowe.",
     "ru": "Исправлена страница настроек, запрашивавшая учётные данные MELCloud Home, хотя они были действительны.",
     "sv": "Åtgärdat att inställningssidan bad om MELCloud Home-uppgifter trots att de var giltiga."
+  },
+  "45.0.0": {
+    "ar": "إضافة دعم مضخات الحرارة هواء-ماء لحسابات MELCloud Home، وإعادة تصميم الأدوات، وإصلاح تعطل رسوم أداة مجموعة المكيفات.",
+    "da": "Tilføjet understøttelse af luft-til-vand varmepumper til MELCloud Home-konti, redesignet widgets og rettet et nedbrud i gruppe-widgettens animationer.",
+    "de": "Luft-Wasser-Wärmepumpen für MELCloud-Home-Konten hinzugefügt, Widgets neu gestaltet und einen Absturz der Animationen des Gruppen-Widgets behoben.",
+    "en": "Added air-to-water heat pump support for MELCloud Home accounts, redesigned the widgets, and fixed a crash in the group air-conditioner widget animations.",
+    "es": "Añadida compatibilidad con bombas de calor aire-agua para cuentas MELCloud Home, rediseño de los widgets y corrección de un fallo en las animaciones del widget de grupo.",
+    "fr": "Ajout de la prise en charge des pompes à chaleur air-eau pour les comptes MELCloud Home, refonte des widgets et correction d'un plantage des animations du widget de groupe de climatiseurs.",
+    "it": "Aggiunto il supporto delle pompe di calore aria-acqua per gli account MELCloud Home, riprogettati i widget e corretto un arresto anomalo delle animazioni del widget di gruppo.",
+    "ko": "MELCloud Home 계정에 공기-물 히트펌프 지원을 추가하고, 위젯을 새로 디자인했으며, 그룹 에어컨 위젯 애니메이션의 충돌을 수정했습니다.",
+    "nl": "Ondersteuning voor lucht-water warmtepompen toegevoegd voor MELCloud Home-accounts, de widgets opnieuw ontworpen en een crash in de animaties van de groepswidget verholpen.",
+    "no": "Lagt til støtte for luft-til-vann varmepumper for MELCloud Home-kontoer, redesignet widgetene og fikset et krasj i gruppe-widgetens animasjoner.",
+    "pl": "Dodano obsługę pomp ciepła powietrze-woda dla kont MELCloud Home, przeprojektowano widżety i naprawiono awarię animacji widżetu grupowego.",
+    "ru": "Добавлена поддержка тепловых насосов воздух-вода для аккаунтов MELCloud Home, переработаны виджеты и исправлен сбой анимаций группового виджета.",
+    "sv": "Lagt till stöd för luft-till-vatten värmepumpar för MELCloud Home-konton, omdesignade widgetarna och fixade en krasch i gruppwidgetens animationer."
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -266,5 +266,5 @@
       "värmeåtervinning"
     ]
   },
-  "version": "44.1.1"
+  "version": "45.0.0"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,7 +171,16 @@ coverage.
 - Verify claimed library behavior empirically (headless chromium against
   the real dist/bundle in the scratchpad) rather than from memory — this
   repo's PRs document several review claims refuted that way.
-- `update-version.yml` pushes directly to `main` and will fail against
-  the ruleset (known debt).
+- Homey App Store releases: write the user-facing changelog entry into
+  `.homeychangelog.json` under the NEW version key (all 13 locales,
+  non-exhaustive store-facing wording), bump `version` in
+  `.homeycompose/app.json`, align `package.json` via
+  `npm version X.Y.Z --no-git-tag-version`, run `homey:validate` to
+  regenerate `app.json`, and land it all through a PR. Then tag
+  `vX.Y.Z` and publish a GitHub release: `publish.yml` fires on
+  release-published (environment `homey`) and pushes to the App Store
+  via athombv's action. Do NOT dispatch `update-version.yml` — it
+  commits directly to `main` and fails against the ruleset (known
+  debt); the PR + release flow above replaces it.
 - Store submissions: a rejected version number cannot be resubmitted —
   bump the patch version.

--- a/app.json
+++ b/app.json
@@ -267,7 +267,7 @@
       "värmeåtervinning"
     ]
   },
-  "version": "44.1.1",
+  "version": "45.0.0",
   "flow": {
     "triggers": [
       {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "com.melcloud",
-  "version": "44.1.1",
+  "version": "45.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "com.melcloud",
-      "version": "44.1.1",
+      "version": "45.0.0",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@olivierzal/melcloud-api": "^41.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.melcloud",
-  "version": "44.1.1",
+  "version": "45.0.0",
   "description": "MELCloud for Homey",
   "homepage": "https://github.com/OlivierZal/com.melcloud/",
   "bugs": {


### PR DESCRIPTION
Bumps the app to 45.0.0 with the store changelog entry (13 locales): air-to-water heat pumps on MELCloud Home, redesigned widgets, group air-conditioner widget animation crash fix.

Once merged, the v45.0.0 tag + GitHub release triggers publish.yml (Homey App Store).

🤖 Generated with [Claude Code](https://claude.com/claude-code)