### PR TITLE
feat: device_groups endpoint for the extension's per-building settings

### DIFF
--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -20,6 +20,10 @@
       "method": "GET",
       "path": "/classic/zones/:zoneType/:zoneId/settings/holiday-mode"
     },
+    "getDeviceGroups": {
+      "method": "GET",
+      "path": "/device_groups"
+    },
     "getDeviceSettings": {
       "method": "GET",
       "path": "/settings/devices"

--- a/api.mts
+++ b/api.mts
@@ -8,9 +8,23 @@ import type {
   ClassicErrorLogQueryParams,
   FormattedErrorLog,
 } from './types/error-log.mts'
-import type { DeviceOrZoneData } from './types/zone.mts'
+import type { DeviceGroup, DeviceOrZoneData } from './types/zone.mts'
 import { getClassicBuildings } from './lib/classic-facade-manager.mts'
 import { toDeviceOrZoneData } from './lib/validation.mts'
+
+// The registry zone tree nests devices under the building itself, its
+// areas, and its floors (which nest areas of their own)
+const collectClassicDeviceIds = (
+  building: Classic.BuildingZone,
+): readonly string[] =>
+  [
+    ...building.devices,
+    ...building.areas.flatMap(({ devices }) => devices),
+    ...building.floors.flatMap((floor) => [
+      ...floor.devices,
+      ...floor.areas.flatMap(({ devices }) => devices),
+    ]),
+  ].map(({ id }) => String(id))
 
 const toNumber = (value: string | undefined): number | undefined => {
   if (value === undefined) {
@@ -64,6 +78,35 @@ const api = {
     params: DeviceOrZoneData
   }): Promise<Classic.HolidayModeData> =>
     app.getClassicHolidayMode(toDeviceOrZoneData(params)),
+  /**
+   * Lists the MELCloud buildings of both dialects with the device ids
+   * they own, for the extension app's per-building settings grouping.
+   * Home buildings come from the live context (owned and guest); a
+   * failed Home fetch simply yields no Home entries.
+   * @param options - Homey API context.
+   * @param options.homey - Homey instance carrying the app.
+   * @returns One entry per non-empty building, sorted by name.
+   */
+  getDeviceGroups: async ({
+    homey: { app },
+  }: {
+    homey: Homey
+  }): Promise<DeviceGroup[]> => {
+    const classicGroups = getClassicBuildings().map((building) => ({
+      deviceIds: collectClassicDeviceIds(building),
+      name: building.name,
+    }))
+    const homeBuildings = await app.homeApi.list()
+    const homeGroups = homeBuildings.map(
+      ({ airToAirUnits, airToWaterUnits, name }) => ({
+        deviceIds: [...airToAirUnits, ...airToWaterUnits].map(({ id }) => id),
+        name,
+      }),
+    )
+    return [...classicGroups, ...homeGroups]
+      .filter(({ deviceIds }) => deviceIds.length > 0)
+      .toSorted((group1, group2) => group1.name.localeCompare(group2.name))
+  },
   getDeviceSettings: ({ homey: { app } }: { homey: Homey }): DeviceSettings =>
     app.getDeviceSettings(),
   getDriverSettings: ({

--- a/app.json
+++ b/app.json
@@ -21,6 +21,10 @@
       "method": "GET",
       "path": "/classic/zones/:zoneType/:zoneId/settings/holiday-mode"
     },
+    "getDeviceGroups": {
+      "method": "GET",
+      "path": "/device_groups"
+    },
     "getDeviceSettings": {
       "method": "GET",
       "path": "/settings/devices"

--- a/tests/unit/api.test.ts
+++ b/tests/unit/api.test.ts
@@ -75,6 +75,49 @@ describe('api', () => {
     })
   })
 
+  describe('device groups retrieval', () => {
+    it('should flatten both dialects into named groups sorted by name', async () => {
+      mockGetBuildings.mockReturnValue([
+        mock<Classic.BuildingZone>({
+          areas: [mock<Classic.AreaZone>({ devices: [{ id: 3 }] })],
+          devices: [{ id: 1 }, { id: 2 }],
+          floors: [
+            mock<Classic.FloorZone>({
+              areas: [mock<Classic.AreaZone>({ devices: [{ id: 5 }] })],
+              devices: [{ id: 4 }],
+            }),
+          ],
+          name: 'Ma maison',
+        }),
+        mock<Classic.BuildingZone>({
+          areas: [],
+          devices: [],
+          floors: [],
+          name: 'Bâtiment vide',
+        }),
+      ])
+      mockHomeList.mockResolvedValue([
+        {
+          airToAirUnits: [{ id: 'uuid-1' }],
+          airToWaterUnits: [{ id: 'uuid-2' }],
+          name: 'Appartement',
+        },
+      ])
+
+      await expect(api.getDeviceGroups({ homey })).resolves.toStrictEqual([
+        { deviceIds: ['uuid-1', 'uuid-2'], name: 'Appartement' },
+        { deviceIds: ['1', '2', '3', '4', '5'], name: 'Ma maison' },
+      ])
+    })
+
+    it('should return no groups when both dialects are empty', async () => {
+      mockGetBuildings.mockReturnValue([])
+      mockHomeList.mockResolvedValue([])
+
+      await expect(api.getDeviceGroups({ homey })).resolves.toStrictEqual([])
+    })
+  })
+
   describe('device settings retrieval', () => {
     it('should delegate to app.getDeviceSettings', () => {
       const deviceSettings = mock<DeviceSettings>()

--- a/types/zone.mts
+++ b/types/zone.mts
@@ -1,3 +1,10 @@
+// One entry per MELCloud building (either dialect), for the extension
+// app's per-building settings grouping.
+export interface DeviceGroup {
+  readonly deviceIds: readonly string[]
+  readonly name: string
+}
+
 // Frost protection and holiday mode can also target a single device (the
 // settings page lists devices in its zone selector), unlike the ATA group
 // endpoints which only operate on zone collections.


### PR DESCRIPTION
## What

Adds `GET /device_groups` to the app's Web API: one entry per MELCloud building across both dialects — Classic from the `getClassicBuildings()` zone tree (building + areas + floors + nested areas flattened), MELCloud Home from `homeApi.list()` (`airToAirUnits` + `airToWaterUnits`). Groups are `{ name, deviceIds }`, non-empty only, sorted by name. Consumed by com.melcloud.extension to render one outdoor-source select per building.

## Tests

- Unit tests for both dialects (zone-tree flattening, sorting) and the empty case; suite green at 100% coverage.
- Live-probed on the Homey: 7 groups returned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)