### PR TITLE
Registry-backed device groups, melcloud-api ^41.1.0, release 45.2.0

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -376,5 +376,20 @@
     "pl": "Informacje o budynkach są teraz udostępniane aplikacji MELCloud Extension.",
     "ru": "Информация о зданиях теперь передаётся приложению MELCloud Extension.",
     "sv": "Byggnadsinformation delas nu med MELCloud Extension-appen."
+  },
+  "45.2.0": {
+    "ar": "أصبحت أداة التكييف تتحكم الآن في مباني MELCloud Home والأجهزة الفردية، ويحصل الضيوف على تحكم كامل في مضخة الحرارة، وتكتسب أداة الرسوم البيانية محددات مدمجة.",
+    "da": "Klima-widgetten styrer nu MELCloud Home-bygninger og enkelte enheder, gæster får fuld kontrol over deres varmepumpe, og diagram-widgetten får indbyggede vælgere.",
+    "de": "Das Klima-Widget steuert jetzt MELCloud-Home-Gebäude und einzelne Geräte, Gäste erhalten volle Kontrolle über ihre Wärmepumpe, und das Diagramm-Widget bekommt integrierte Auswahlfelder.",
+    "en": "The AC widget now targets MELCloud Home buildings and individual devices, guests get full control of their heat pump, and the charts widget gains in-widget chart and period pickers.",
+    "es": "El widget de clima ahora controla edificios de MELCloud Home y dispositivos individuales, los invitados obtienen control total de su bomba de calor y el widget de gráficos gana selectores integrados.",
+    "fr": "Le widget clim pilote désormais les bâtiments MELCloud Home et les appareils individuels, les invités contrôlent intégralement leur pompe à chaleur, et le widget graphiques gagne des sélecteurs intégrés.",
+    "it": "Il widget clima ora controlla gli edifici MELCloud Home e i singoli dispositivi, gli ospiti ottengono il controllo completo della pompa di calore e il widget grafici guadagna selettori integrati.",
+    "ko": "에어컨 위젯이 이제 MELCloud Home 건물과 개별 장치를 제어하고, 게스트는 히트펌프를 완전히 제어할 수 있으며, 차트 위젯에 내장 선택기가 추가되었습니다.",
+    "nl": "De airco-widget bedient nu MELCloud Home-gebouwen en losse apparaten, gasten krijgen volledige controle over hun warmtepomp, en de grafiek-widget krijgt ingebouwde keuzelijsten.",
+    "no": "Klima-widgeten styrer nå MELCloud Home-bygninger og enkeltenheter, gjester får full kontroll over varmepumpen sin, og diagram-widgeten får innebygde velgere.",
+    "pl": "Widżet klimatyzacji obsługuje teraz budynki MELCloud Home i pojedyncze urządzenia, goście mają pełną kontrolę nad pompą ciepła, a widżet wykresów zyskuje wbudowane selektory.",
+    "ru": "Виджет кондиционера теперь управляет зданиями MELCloud Home и отдельными устройствами, гости получают полный контроль над тепловым насосом, а виджет графиков — встроенные селекторы.",
+    "sv": "Klimat-widgeten styr nu MELCloud Home-byggnader och enskilda enheter, gäster får full kontroll över sin värmepump, och diagram-widgeten får inbyggda väljare."
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -270,5 +270,5 @@
       "värmeåtervinning"
     ]
   },
-  "version": "45.1.0"
+  "version": "45.2.0"
 }

--- a/api.mts
+++ b/api.mts
@@ -1,6 +1,7 @@
 import type { LoginCredentials } from '@olivierzal/melcloud-api'
 import type * as Classic from '@olivierzal/melcloud-api/classic'
 import type { Homey } from 'homey/lib/Homey'
+import * as Home from '@olivierzal/melcloud-api/home'
 
 import type { DeviceSettings, Settings } from './types/device-settings.mts'
 import type { DriverSetting } from './types/driver-settings.mts'
@@ -25,6 +26,24 @@ const collectClassicDeviceIds = (
       ...floor.areas.flatMap(({ devices }) => devices),
     ]),
   ].map(({ id }) => String(id))
+
+// Home buildings can own units of both types; the per-type registry views
+// are merged by building id so a mixed building yields a single group.
+const collectHomeGroups = (registry: Home.Registry): DeviceGroup[] => {
+  const groups = new Map<string, DeviceGroup>()
+  for (const type of Object.values(Home.DeviceType)) {
+    for (const { devices, id, name } of registry.getBuildingsByType(type)) {
+      groups.set(id, {
+        deviceIds: [
+          ...(groups.get(id)?.deviceIds ?? []),
+          ...devices.map((device) => device.id),
+        ],
+        name,
+      })
+    }
+  }
+  return groups.values().toArray()
+}
 
 const toNumber = (value: string | undefined): number | undefined => {
   if (value === undefined) {
@@ -81,29 +100,19 @@ const api = {
   /**
    * Lists the MELCloud buildings of both dialects with the device ids
    * they own, for the extension app's per-building settings grouping.
-   * Home buildings come from the live context (owned and guest); a
-   * failed Home fetch simply yields no Home entries.
+   * Both dialects are served from the in-memory registries — no wire
+   * call, no sync-cycle interference; entries (owned and guest alike)
+   * reflect the latest sync.
    * @param options - Homey API context.
    * @param options.homey - Homey instance carrying the app.
    * @returns One entry per non-empty building, sorted by name.
    */
-  getDeviceGroups: async ({
-    homey: { app },
-  }: {
-    homey: Homey
-  }): Promise<DeviceGroup[]> => {
+  getDeviceGroups: ({ homey: { app } }: { homey: Homey }): DeviceGroup[] => {
     const classicGroups = getClassicBuildings().map((building) => ({
       deviceIds: collectClassicDeviceIds(building),
       name: building.name,
     }))
-    const homeBuildings = await app.homeApi.list()
-    const homeGroups = homeBuildings.map(
-      ({ airToAirUnits, airToWaterUnits, name }) => ({
-        deviceIds: [...airToAirUnits, ...airToWaterUnits].map(({ id }) => id),
-        name,
-      }),
-    )
-    return [...classicGroups, ...homeGroups]
+    return [...classicGroups, ...collectHomeGroups(app.homeApi.registry)]
       .filter(({ deviceIds }) => deviceIds.length > 0)
       .toSorted((group1, group2) => group1.name.localeCompare(group2.name))
   },

--- a/app.json
+++ b/app.json
@@ -271,7 +271,7 @@
       "värmeåtervinning"
     ]
   },
-  "version": "45.1.0",
+  "version": "45.2.0",
   "flow": {
     "triggers": [
       {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "com.melcloud",
-  "version": "45.1.0",
+  "version": "45.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "com.melcloud",
-      "version": "45.1.0",
+      "version": "45.2.0",
       "license": "GPL-3.0-only",
       "dependencies": {
-        "@olivierzal/melcloud-api": "41.1.0-alpha.1",
+        "@olivierzal/melcloud-api": "^41.1.0",
         "source-map-support": "^0.5.21",
         "temporal-polyfill": "^1.0.1"
       },
@@ -1065,9 +1065,9 @@
       }
     },
     "node_modules/@olivierzal/melcloud-api": {
-      "version": "41.1.0-alpha.1",
-      "resolved": "https://npm.pkg.github.com/download/@olivierzal/melcloud-api/41.1.0-alpha.1/f07ea0865a5a54664d8cab375702f76166d90c79",
-      "integrity": "sha512-+sqsx3QCEFxu44g3iCIt6HGbCQTI92HCGXMWAUSER/thxePRG04R20UXeRBxExxDbmqFy74StnLnrOILXV8+Eg==",
+      "version": "41.1.0",
+      "resolved": "https://npm.pkg.github.com/download/@olivierzal/melcloud-api/41.1.0/a1fa47a5a2f13b3d70f274b852cd389a3ad97808",
+      "integrity": "sha512-80XDpZAJSdoJUwedAgIv30RkoFVjQHZV6ES3pvyGkwms0QSNt8Uq8+cfntnqAFAx0MaAlD4Soy0GrX4vYyB+qg==",
       "license": "MIT",
       "dependencies": {
         "temporal-polyfill": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.melcloud",
-  "version": "45.1.0",
+  "version": "45.2.0",
   "description": "MELCloud for Homey",
   "homepage": "https://github.com/OlivierZal/com.melcloud/",
   "bugs": {
@@ -31,7 +31,7 @@
     "typecheck": "node ./node_modules/@typescript/native/bin/tsc --noEmit"
   },
   "dependencies": {
-    "@olivierzal/melcloud-api": "41.1.0-alpha.1",
+    "@olivierzal/melcloud-api": "^41.1.0",
     "source-map-support": "^0.5.21",
     "temporal-polyfill": "^1.0.1"
   },

--- a/tests/unit/api.test.ts
+++ b/tests/unit/api.test.ts
@@ -2,6 +2,7 @@ import type { LoginCredentials } from '@olivierzal/melcloud-api'
 import type * as Classic from '@olivierzal/melcloud-api/classic'
 import type { Homey } from 'homey/lib/Homey'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import * as Home from '@olivierzal/melcloud-api/home'
 
 import type { DeviceSettings, Settings } from '../../types/device-settings.mts'
 import type { DriverSetting } from '../../types/driver-settings.mts'
@@ -28,6 +29,7 @@ const { default: api } = await import('../../api.mts')
 const mockIsAuthenticated = vi.fn<() => boolean>()
 const mockIsHomeAuthenticated = vi.fn<() => boolean>()
 const mockHomeList = vi.fn<() => Promise<unknown[]>>()
+const mockGetBuildingsByType = vi.fn<Home.Registry['getBuildingsByType']>()
 const mockClassicAuthenticate = vi.fn<() => Promise<void>>()
 const mockHomeAuthenticate = vi.fn<() => Promise<void>>()
 
@@ -46,6 +48,7 @@ const mockApp = {
     authenticate: mockHomeAuthenticate,
     isAuthenticated: mockIsHomeAuthenticated,
     list: mockHomeList,
+    registry: { getBuildingsByType: mockGetBuildingsByType },
   },
   updateClassicFrostProtection: vi.fn<() => Promise<void>>(),
   updateClassicHolidayMode: vi.fn<() => Promise<void>>(),
@@ -76,7 +79,7 @@ describe('api', () => {
   })
 
   describe('device groups retrieval', () => {
-    it('should flatten both dialects into named groups sorted by name', async () => {
+    it('should flatten both dialects into named groups sorted by name', () => {
       mockGetBuildings.mockReturnValue([
         mock<Classic.BuildingZone>({
           areas: [mock<Classic.AreaZone>({ devices: [{ id: 3 }] })],
@@ -96,25 +99,48 @@ describe('api', () => {
           name: 'Bâtiment vide',
         }),
       ])
-      mockHomeList.mockResolvedValue([
+      mockGetBuildingsByType.mockImplementation((type) => [
         {
-          airToAirUnits: [{ id: 'uuid-1' }],
-          airToWaterUnits: [{ id: 'uuid-2' }],
+          devices:
+            type === Home.DeviceType.Ata ?
+              [mock<Home.Device>({ id: 'uuid-1' })]
+            : [mock<Home.Device>({ id: 'uuid-2' })],
+          id: 'home-building-1',
           name: 'Appartement',
         },
       ])
 
-      await expect(api.getDeviceGroups({ homey })).resolves.toStrictEqual([
+      expect(api.getDeviceGroups({ homey })).toStrictEqual([
         { deviceIds: ['uuid-1', 'uuid-2'], name: 'Appartement' },
         { deviceIds: ['1', '2', '3', '4', '5'], name: 'Ma maison' },
       ])
     })
 
-    it('should return no groups when both dialects are empty', async () => {
+    it('should serve Home groups from the registry without a wire call', () => {
       mockGetBuildings.mockReturnValue([])
-      mockHomeList.mockResolvedValue([])
+      mockGetBuildingsByType.mockImplementation((type) =>
+        type === Home.DeviceType.Ata ?
+          [
+            {
+              devices: [mock<Home.Device>({ id: 'uuid-1' })],
+              id: 'home-building-1',
+              name: 'Appartement',
+            },
+          ]
+        : [],
+      )
 
-      await expect(api.getDeviceGroups({ homey })).resolves.toStrictEqual([])
+      expect(api.getDeviceGroups({ homey })).toStrictEqual([
+        { deviceIds: ['uuid-1'], name: 'Appartement' },
+      ])
+      expect(mockHomeList).not.toHaveBeenCalled()
+    })
+
+    it('should return no groups when both dialects are empty', () => {
+      mockGetBuildings.mockReturnValue([])
+      mockGetBuildingsByType.mockReturnValue([])
+
+      expect(api.getDeviceGroups({ homey })).toStrictEqual([])
     })
   })
 


### PR DESCRIPTION
## What

- **`getDeviceGroups` is now registry-backed.** The Home side used to run `await app.homeApi.list()` on every call — a live BFF round-trip that also reset the auto-sync heartbeat (`runSyncCycle` pauses/reschedules the timer). It now reads `app.homeApi.registry.getBuildingsByType` for ATA and ATW and merges the per-type views by building id: no wire call, no sync-cycle interference, handler synchronous. Same output contract (`{deviceIds, name}[]`, non-empty, sorted by name) — the extension is untouched.
- **Dependency re-pinned** from the exact `41.1.0-alpha.1` prerelease to `^41.1.0` (stable, `latest`).
- **Store release 45.2.0**: changelog entry (13 locales — climate widget controls Home buildings and individual devices, guests get full heat-pump control, chart widget gains built-in pickers), compose + package bump, `app.json` regenerated by `homey:validate`.

## Tests

`tests/unit/api.test.ts` mocks the registry instead of `homeApi.list`, including the multi-type merge of one building (ATA + ATW at a single entry) and a no-wire-call assertion. Suite: 535 tests, 100 % everywhere, build + validate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)