### PR TITLE
A rejected load-failure alert routes to reportError

### DIFF
--- a/settings/index.html
+++ b/settings/index.html
@@ -9,7 +9,7 @@
             // needs this global at parse time. The page logic lives in the
             // module bundle; a failed bundle load still ends the overlay.
             function onHomeyReady(homey) {
-                import('./index.mjs?v=99ae2e8d')
+                import('./index.mjs?v=fa15976f')
                     .then((module) => module.start(homey))
                     .catch((error) => {
                         globalThis.reportError?.(error)
@@ -23,7 +23,7 @@
             }
         </script>
         <link href="index.css?v=b7fc840a" rel="stylesheet">
-        <link href="index.mjs?v=99ae2e8d" rel="modulepreload">
+        <link href="index.mjs?v=fa15976f" rel="modulepreload">
         <script data-origin="settings" defer src="/homey.js"></script>
         <meta content="MELCloud settings" name="description">
     </head>

--- a/settings/index.html
+++ b/settings/index.html
@@ -14,7 +14,11 @@
                     .catch((error) => {
                         globalThis.reportError?.(error)
                         homey.ready()
-                        homey.alert(homey.__('settings.loadFailed'))
+                        homey
+                            .alert(homey.__('settings.loadFailed'))
+                            .catch((alertError) => {
+                                globalThis.reportError?.(alertError)
+                            })
                     })
             }
         </script>

--- a/settings/index.mts
+++ b/settings/index.mts
@@ -1363,7 +1363,10 @@ class SettingsApp {
       this.#homey.ready()
     }
     if (hasInitFailed) {
-      await this.#homey.alert(getErrorMessage(initError))
+      // Fire-and-forget keeps `start()` non-throwing: a rejected alert
+      // must not trip the HTML loader's catch (double `ready()`, second
+      // generic alert).
+      fireAndForget(this.#homey.alert(getErrorMessage(initError)))
     }
   }
 


### PR DESCRIPTION
Follow-up to #1406, mirroring two Copilot findings from the extension twin (OlivierZal/com.melcloud.extension#1182):

1. `homey.alert` returns a promise — in the inline bundle-load-failure handler its rejection was the only unreported failure left; it now routes to `globalThis.reportError`.
2. `start()` is non-throwing by construction: the post-`ready` failure alert is fired through `fireAndForget` (rejections → `surfaceError`), so a rejected alert can no longer trip the HTML loader's catch (double `ready()`, second generic alert).

🤖 Generated with [Claude Code](https://claude.com/claude-code)