### PR TITLE
Settings-page routes leave diagnostics breadcrumbs, release 45.2.2

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -406,5 +406,20 @@
     "pl": "Naprawia niekończący się ekran ładowania, który czasami pojawiał się w widżetach i na stronie ustawień.",
     "ru": "Исправлен бесконечный экран загрузки, который иногда появлялся в виджетах и на странице настроек.",
     "sv": "Åtgärdar den oändliga laddningsskärmen som ibland visades i widgetar och på inställningssidan."
+  },
+  "45.2.2": {
+    "ar": "تحسين التشخيصات لصفحة الإعدادات.",
+    "da": "Forbedret diagnostik for indstillingssiden.",
+    "de": "Verbesserte Diagnose für die Einstellungsseite.",
+    "en": "Improved diagnostics for the settings page.",
+    "es": "Diagnósticos mejorados para la página de ajustes.",
+    "fr": "Diagnostics améliorés pour la page de réglages.",
+    "it": "Diagnostica migliorata per la pagina delle impostazioni.",
+    "ko": "설정 페이지의 진단 기능이 개선되었습니다.",
+    "nl": "Verbeterde diagnostiek voor de instellingenpagina.",
+    "no": "Forbedret diagnostikk for innstillingssiden.",
+    "pl": "Ulepszona diagnostyka strony ustawień.",
+    "ru": "Улучшена диагностика страницы настроек.",
+    "sv": "Förbättrad diagnostik för inställningssidan."
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -270,5 +270,5 @@
       "värmeåtervinning"
     ]
   },
-  "version": "45.2.1"
+  "version": "45.2.2"
 }

--- a/api.mts
+++ b/api.mts
@@ -125,7 +125,7 @@ const api = {
       .toSorted((group1, group2) => group1.name.localeCompare(group2.name))
   },
   getDeviceSettings: ({ homey: { app } }: { homey: Homey }): DeviceSettings => {
-    logSettingsRoute(app, 'devices/settings')
+    logSettingsRoute(app, '/settings/devices')
     return app.getDeviceSettings()
   },
   getDriverSettings: ({
@@ -133,7 +133,7 @@ const api = {
   }: {
     homey: Homey
   }): Partial<Record<string, DriverSetting[]>> => {
-    logSettingsRoute(app, 'drivers/settings')
+    logSettingsRoute(app, '/settings/drivers')
     return app.getDriverSettings()
   },
   getLanguage: ({ homey: { i18n } }: { homey: Homey }): string =>
@@ -146,7 +146,7 @@ const api = {
     homey: Homey
   }): Promise<void> => app.homeApi.authenticate(body),
   isClassicAuthenticated: ({ homey: { app } }: { homey: Homey }): boolean => {
-    logSettingsRoute(app, 'classic/sessions')
+    logSettingsRoute(app, '/classic/sessions')
     return app.classicApi.isAuthenticated()
   },
   // Home authentication is only "restored" once a /context fetch has
@@ -160,7 +160,7 @@ const api = {
   }: {
     homey: Homey
   }): Promise<boolean> {
-    logSettingsRoute(app, 'home/sessions')
+    logSettingsRoute(app, '/home/sessions')
     if (!app.homeApi.isAuthenticated()) {
       await app.homeApi.list()
     }

--- a/api.mts
+++ b/api.mts
@@ -45,6 +45,14 @@ const collectHomeGroups = (registry: Home.Registry): DeviceGroup[] => {
   return groups.values().toArray()
 }
 
+// Diagnostics breadcrumb: the settings webview is otherwise invisible in
+// diagnostic reports (its routes never touch MELCloud), which made
+// "settings fail to load" reports undecidable — no line = the page's JS
+// never ran; lines without a completed sequence = where it stopped.
+const logSettingsRoute = (app: Homey['app'], route: string): void => {
+  app.log({ dataType: 'Settings page', route })
+}
+
 const toNumber = (value: string | undefined): number | undefined => {
   if (value === undefined) {
     return undefined
@@ -116,13 +124,18 @@ const api = {
       .filter(({ deviceIds }) => deviceIds.length > 0)
       .toSorted((group1, group2) => group1.name.localeCompare(group2.name))
   },
-  getDeviceSettings: ({ homey: { app } }: { homey: Homey }): DeviceSettings =>
-    app.getDeviceSettings(),
+  getDeviceSettings: ({ homey: { app } }: { homey: Homey }): DeviceSettings => {
+    logSettingsRoute(app, 'devices/settings')
+    return app.getDeviceSettings()
+  },
   getDriverSettings: ({
     homey: { app },
   }: {
     homey: Homey
-  }): Partial<Record<string, DriverSetting[]>> => app.getDriverSettings(),
+  }): Partial<Record<string, DriverSetting[]>> => {
+    logSettingsRoute(app, 'drivers/settings')
+    return app.getDriverSettings()
+  },
   getLanguage: ({ homey: { i18n } }: { homey: Homey }): string =>
     i18n.getLanguage(),
   homeAuthenticate: async ({
@@ -132,8 +145,10 @@ const api = {
     body: LoginCredentials
     homey: Homey
   }): Promise<void> => app.homeApi.authenticate(body),
-  isClassicAuthenticated: ({ homey: { app } }: { homey: Homey }): boolean =>
-    app.classicApi.isAuthenticated(),
+  isClassicAuthenticated: ({ homey: { app } }: { homey: Homey }): boolean => {
+    logSettingsRoute(app, 'classic/sessions')
+    return app.classicApi.isAuthenticated()
+  },
   // Home authentication is only "restored" once a /context fetch has
   // succeeded. That boot-time fetch can fail transiently (e.g. the box
   // network is not ready right after an app restart) even though the
@@ -145,6 +160,7 @@ const api = {
   }: {
     homey: Homey
   }): Promise<boolean> {
+    logSettingsRoute(app, 'home/sessions')
     if (!app.homeApi.isAuthenticated()) {
       await app.homeApi.list()
     }

--- a/app.json
+++ b/app.json
@@ -271,7 +271,7 @@
       "värmeåtervinning"
     ]
   },
-  "version": "45.2.1",
+  "version": "45.2.2",
   "flow": {
     "triggers": [
       {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "com.melcloud",
-  "version": "45.2.1",
+  "version": "45.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "com.melcloud",
-      "version": "45.2.1",
+      "version": "45.2.2",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@olivierzal/melcloud-api": "^41.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.melcloud",
-  "version": "45.2.1",
+  "version": "45.2.2",
   "description": "MELCloud for Homey",
   "homepage": "https://github.com/OlivierZal/com.melcloud/",
   "bugs": {

--- a/tests/unit/api.test.ts
+++ b/tests/unit/api.test.ts
@@ -50,6 +50,7 @@ const mockApp = {
     list: mockHomeList,
     registry: { getBuildingsByType: mockGetBuildingsByType },
   },
+  log: vi.fn<(...args: readonly unknown[]) => void>(),
   updateClassicFrostProtection: vi.fn<() => Promise<void>>(),
   updateClassicHolidayMode: vi.fn<() => Promise<void>>(),
   updateDeviceSettings: vi.fn<() => Promise<void>>(),


### PR DESCRIPTION
Follow-up to the settings-loading reports (#1404 family — a new diagnostic, log a192b244, arrived on v45.2.1): the app log is perfectly healthy (60 s `/context` syncs, no errors) and contains **nothing** about the settings page, because its routes never touch MELCloud and were never logged. Such reports are therefore undecidable between "the page's JS never ran" (phone-cached pre-45.2.1 document, blocked bundle fetch) and "init stalled mid-chain".

The four routes the page hits during init (`devices/settings`, `drivers/settings`, `classic/sessions`, `home/sessions`) now log a structured one-line breadcrumb. Next diagnostic report reads directly:
- **no breadcrumb** → the webview never executed (document cache / bundle delivery / platform issue);
- **breadcrumbs then silence** → which call the init chain died on.

Release 45.2.2 (changelog ×13, bumps, validate green). Suite: 535 tests, 100 % everywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)