### PR TITLE
Document the ?v= cache-busting rules in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,20 @@ caught real failures that the others miss:
   `settings/index.mjs` and `widgets/*/public/index.mjs` are gitignored
   build outputs, never checked in; the Homey CLI regenerates them on
   validate/install/run.
+- Cache-busting `?v=` — the build also stamps every local asset reference
+  in the tracked `*/index.html` with a content hash (`?v=<hash>`), so
+  phone webviews (which cache assets across app versions) refetch an
+  asset exactly when its bytes change. **Never hand-edit a `?v=` or bump
+  it "for a release": it is a content hash, not a version** — the build
+  sets it, and it moves automatically iff the asset content changes
+  (identical bytes → identical hash → no diff; a release that touches no
+  webview asset leaves every `?v=` untouched, which is correct). Because
+  the HTML is committed, any change to a bundled webview source
+  (`settings/**`, `widgets/*/public/**`, their CSS) must be followed by
+  `npm run build` and a commit of the re-stamped HTML. The mandatory
+  pre-push suite runs the build, so following it keeps the stamp in sync;
+  skipping it ships a stale `?v=` and phones keep serving the old cached
+  bundle — the exact staleness `?v=` exists to prevent.
 - `npm run homey:validate` — Homey validation at publish level; may
   rewrite files (see locales below), re-stage if it does.
 - `node scripts/sync-capability-definitions.mjs` — refreshes the


### PR DESCRIPTION
You asked when the `?v=` value should change, given Claude runs the releases. Documented in CLAUDE.md (next to `npm run build`):

- **It's a content hash, not a version** — `scripts/bundle.mjs` computes it from the built asset's bytes and stamps the tracked `*/index.html`.
- **Never hand-edit it or bump it 'for a release'** — the build sets it; it moves automatically iff the asset content changes (identical bytes → identical hash → no diff; a release with no webview change leaves it untouched, which is correct).
- **Rebuild + commit after any webview-source change** (`settings/**`, `widgets/*/public/**`, their CSS) — the mandatory pre-push suite runs the build, so following it keeps the stamp in sync; skipping it ships a stale `?v=` and phones keep serving the old cached bundle (the exact staleness `?v=` prevents).

Doc-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)