### PR TITLE
Load webview bundles as static module scripts — fixes Android loading (45.2.5)

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -451,5 +451,20 @@
     "pl": "Lepsza diagnostyka, gdy widżet lub strona ustawień się nie ładuje.",
     "ru": "Улучшена диагностика, когда виджет или страница настроек не загружается.",
     "sv": "Bättre diagnostik när en widget eller inställningssidan inte laddas."
+  },
+  "45.2.5": {
+    "ar": "إصلاح فشل تحميل الأدوات وصفحة الإعدادات على أندرويد.",
+    "da": "Retter widgets og indstillingssiden, der ikke kunne indlæses på Android.",
+    "de": "Behebt das Nichtladen von Widgets und der Einstellungsseite auf Android.",
+    "en": "Fixes widgets and the settings page failing to load on Android.",
+    "es": "Corrige los widgets y la página de ajustes que no cargaban en Android.",
+    "fr": "Corrige les widgets et la page de réglages qui ne se chargeaient pas sur Android.",
+    "it": "Corregge i widget e la pagina delle impostazioni che non si caricavano su Android.",
+    "ko": "Android에서 위젯과 설정 페이지가 로드되지 않던 문제를 수정했습니다.",
+    "nl": "Verhelpt widgets en de instellingenpagina die niet laadden op Android.",
+    "no": "Fikser widgeter og innstillingssiden som ikke lastet på Android.",
+    "pl": "Naprawia widżety i stronę ustawień, które nie ładowały się na Androidzie.",
+    "ru": "Исправлена загрузка виджетов и страницы настроек на Android.",
+    "sv": "Åtgärdar widgetar och inställningssidan som inte laddades på Android."
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -274,5 +274,5 @@
       "värmeåtervinning"
     ]
   },
-  "version": "45.2.4"
+  "version": "45.2.5"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,21 +129,29 @@ coverage.
 ## Widgets
 
 - Webview lifecycle (settings page included): the SDK dispatches
-  `onHomeyReady` on its own schedule — the widget SDK is injected by the
-  host app at a time the page does not control — so each HTML declares
-  the docs' canonical global `function onHomeyReady(homey)` inline (it
-  must exist at parse time; a bundle only exists after its fetch), whose
-  body `import()`s the ESM bundle and hands the instance to its exported
-  `start(homey)`; the inline `.catch` ends the overlay even when the
-  bundle itself fails to load. Init work is time-bounded
-  (`withInitTimeout`) and `Homey.ready()` fires in a `finally`: a hung
-  or failed fetch surfaces an error (`#init_error` / post-ready alert),
-  never an endless loading overlay. `scripts/bundle.mjs` stamps every
-  local asset reference — attributes and the inline `import()` alike —
-  with a content hash (`?v=`): phone webviews cache assets across app
-  versions. Webview code must stick to es2020-era runtime APIs (no
-  `Object.groupBy` & co.): esbuild lowers syntax only, and old iOS
-  engines are real.
+  `onHomeyReady` on its own schedule, before the bundle has loaded, so
+  each HTML registers the handler in a parse-time inline bootstrap that
+  resolves `globalThis.homeyReady`. The bundle loads as a
+  **parser-discovered static `<script type="module" src>`**, NOT a
+  JS-initiated dynamic `import()`: on Android the dynamic import fails to
+  fetch against Homey's local `.homeylocal.com` origin while
+  parser-discovered resources (the same path as the stylesheets) load —
+  diagnosed from a v45.2.4 boot-error report. A static module can only
+  self-boot, so each entry module ends with `fireAndForget(boot())`
+  where `boot` awaits `globalThis.homeyReady` and calls the (now
+  non-exported) `start`. Two documented disables per entry are the
+  honest cost: the SDK-handoff cast (parse boundary) and
+  `unicorn/prefer-top-level-await` — a top-level await would force an
+  es2022 target, and esbuild would then emit private fields natively
+  instead of lowering them, breaking older webview engines (the exact
+  class of the `Object.groupBy` breakage). The `<script onerror>` +
+  runWebview keep `Homey.ready()` guaranteed and surface a boot failure
+  (`#init_error` / post-ready alert) to a `/boot-error` route
+  (`app.error`), so a diagnostic report shows WHY a bundle failed to
+  load. `scripts/bundle.mjs` stamps every local asset reference with a
+  content hash (`?v=`): phone webviews cache assets across app versions.
+  Webview code must stick to es2020-era runtime APIs (no `Object.groupBy`
+  & co.): esbuild lowers syntax only, and old iOS engines are real.
 - Widgets ship separately; they cannot share files at runtime. The zone
   selector's ghost styling is deliberately duplicated as byte-identical
   `styles/zone-select.css` twins, pinned by `tests/unit/widget-styles.test.ts`

--- a/app.json
+++ b/app.json
@@ -275,7 +275,7 @@
       "värmeåtervinning"
     ]
   },
-  "version": "45.2.4",
+  "version": "45.2.5",
   "flow": {
     "triggers": [
       {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "com.melcloud",
-  "version": "45.2.4",
+  "version": "45.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "com.melcloud",
-      "version": "45.2.4",
+      "version": "45.2.5",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@olivierzal/melcloud-api": "^41.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.melcloud",
-  "version": "45.2.4",
+  "version": "45.2.5",
   "description": "MELCloud for Homey",
   "homepage": "https://github.com/OlivierZal/com.melcloud/",
   "bugs": {

--- a/public/homey-api.mts
+++ b/public/homey-api.mts
@@ -6,6 +6,12 @@ export interface Homey<
   readonly getSettings: () => TSettings
 }
 
+declare global {
+  // Resolved by each page's inline bootstrap with the instance the SDK
+  // hands to onHomeyReady (see the <script> in every webview <head>).
+  var homeyReady: Promise<unknown>
+}
+
 // Give slow transports a real chance while keeping the loading overlay
 // finite: past this point the page surfaces the failure instead.
 const INIT_TIMEOUT_MS = 10_000

--- a/settings/index.html
+++ b/settings/index.html
@@ -5,27 +5,31 @@
         <meta content="width=device-width, initial-scale=1.0" name="viewport">
         <title>MELCloud Settings</title>
         <script>
-            // Canonical entry point from the app-settings docs: the SDK
-            // needs this global at parse time. The page logic lives in the
-            // module bundle; a failed bundle load still ends the overlay.
-            function onHomeyReady(homey) {
-                import('./index.mjs?v=50b46cac')
-                    .then((module) => module.start(homey))
-                    .catch((error) => {
+            // Registered at parse time: the SDK dispatches onHomeyReady on
+            // its own schedule, before the module bundle has loaded. The
+            // bundle loads as a parser-discovered static module (same fetch
+            // path as the stylesheets) rather than a JS-initiated dynamic
+            // import(), whose fetch fails on Android against Homey's local
+            // .homeylocal.com origin (diagnosed from a v45.2.4 boot-error
+            // report).
+            window.homeyReady = new Promise((resolve) => {
+                window.onHomeyReady = resolve
+            })
+            // onerror only fires if the module script itself fails to load;
+            // once it loads, its own init ends the overlay.
+            function reportSettingsBootFailure() {
+                window.homeyReady.then((homey) => {
+                    homey.api('POST', '/boot-error', { message: 'Failed to load the settings module script', name: 'BootError', stack: '' }, () => {})
+                    homey.ready()
+                    homey.alert(homey.__('settings.loadFailed')).catch((error) => {
                         globalThis.reportError?.(error)
-                        homey.api('POST', '/boot-error', { message: String((error && error.message) || error || ''), name: String((error && error.name) || ''), stack: String((error && error.stack) || '') }, () => {})
-                        homey.ready()
-                        homey
-                            .alert(homey.__('settings.loadFailed'))
-                            .catch((alertError) => {
-                                globalThis.reportError?.(alertError)
-                            })
                     })
+                })
             }
         </script>
         <link href="index.css?v=b7fc840a" rel="stylesheet">
-        <link href="index.mjs?v=50b46cac" rel="modulepreload">
         <script data-origin="settings" defer src="/homey.js"></script>
+        <script type="module" onerror="reportSettingsBootFailure()" src="index.mjs?v=e1bfaba5"></script>
         <meta content="MELCloud settings" name="description">
     </head>
     <body>

--- a/settings/index.mts
+++ b/settings/index.mts
@@ -1559,8 +1559,24 @@ class SettingsApp {
  * the SDK has dispatched (see the inline script in the page head).
  * @param homey - The Homey instance handed to `onHomeyReady`.
  */
-export const start = async (homey: Homey): Promise<void> => {
+const start = async (homey: Homey): Promise<void> => {
   translateAriaLabels((key) => homey.__(key))
   const app = new SettingsApp(homey)
   await app.init()
 }
+
+// Entry module: the SDK hands over Homey via the parse-time
+// bootstrap in the page <head>. This file boots on that handoff
+// rather than exporting a start() for the HTML to call, because
+// the bundle now loads as a parser-discovered static
+// <script type="module"> (a JS-initiated dynamic import fails to
+// fetch on Android against Homey's local origin) and a static
+// module can only self-boot.
+const boot = async (): Promise<void> => {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- the SDK passes an untyped instance to onHomeyReady; this is that parse boundary
+  const homey = (await globalThis.homeyReady) as Homey
+  await start(homey)
+}
+
+// eslint-disable-next-line unicorn/prefer-top-level-await -- a top-level await would force an es2022 bundle target; esbuild then emits private fields natively instead of lowering them, breaking the older webview engines this static-load change exists to keep working
+fireAndForget(boot())

--- a/widgets/ata-group-setting/public/index.html
+++ b/widgets/ata-group-setting/public/index.html
@@ -5,24 +5,30 @@
         <meta content="width=device-width, initial-scale=1.0" name="viewport">
         <title>Air-to-air device values</title>
         <script>
-            // Canonical entry point from the widget docs: the SDK needs
-            // this global at parse time. The page logic lives in the
-            // module bundle; a failed bundle load still ends the overlay.
-            function onHomeyReady(homey) {
-                import('./index.mjs?v=943d5a32')
-                    .then((module) => module.start(homey))
-                    .catch((error) => {
-                        globalThis.reportError?.(error)
-                        homey
-                            .api('POST', '/boot-error', { message: String((error && error.message) || error || ''), name: String((error && error.name) || ''), stack: String((error && error.stack) || '') })
-                            .catch(() => {})
-                        const message = document.querySelector('#init_error')
-                        if (message) {
-                            message.hidden = false
-                            message.textContent = homey.__('widgets.loadFailed')
-                        }
-                        homey.ready()
-                    })
+            // Registered at parse time: the SDK dispatches onHomeyReady on
+            // its own schedule, before the module bundle has loaded. The
+            // bundle loads as a parser-discovered static module (same fetch
+            // path as the stylesheets) rather than a JS-initiated dynamic
+            // import(), whose fetch fails on Android against Homey's local
+            // .homeylocal.com origin (diagnosed from a v45.2.4 boot-error
+            // report).
+            window.homeyReady = new Promise((resolve) => {
+                window.onHomeyReady = resolve
+            })
+            // onerror only fires if the module script itself fails to load;
+            // once it loads, its own init ends the overlay.
+            function reportWidgetBootFailure() {
+                window.homeyReady.then((homey) => {
+                    homey
+                        .api('POST', '/boot-error', { message: 'Failed to load the widget module script', name: 'BootError', stack: '' })
+                        .catch(() => {})
+                    const message = document.querySelector('#init_error')
+                    if (message) {
+                        message.hidden = false
+                        message.textContent = homey.__('widgets.loadFailed')
+                    }
+                    homey.ready()
+                })
             }
         </script>
         <link href="styles/layout.css?v=7d7e3bf5" rel="stylesheet">
@@ -32,7 +38,7 @@
         <link href="styles/smoke.css?v=a17bb95c" rel="stylesheet">
         <link href="styles/snowflake.css?v=06f4b14b" rel="stylesheet">
         <link href="styles/sun.css?v=da326d17" rel="stylesheet">
-        <link href="index.mjs?v=943d5a32" rel="modulepreload">
+        <script type="module" onerror="reportWidgetBootFailure()" src="index.mjs?v=18ccd605"></script>
         <meta content="MELCloud air-to-air device setting" name="description">
     </head>
     <body class="homey-widget-full homey-text-align-center">

--- a/widgets/ata-group-setting/public/index.mts
+++ b/widgets/ata-group-setting/public/index.mts
@@ -141,7 +141,23 @@ class WidgetApp {
  * the SDK has dispatched (see the inline script in the page head).
  * @param homey - The Homey instance handed to `onHomeyReady`.
  */
-export const start = async (homey: Homey<HomeySettings>): Promise<void> => {
+const start = async (homey: Homey<HomeySettings>): Promise<void> => {
   const app = new WidgetApp(homey)
   await app.init()
 }
+
+// Entry module: the SDK hands over Homey via the parse-time
+// bootstrap in the page <head>. This file boots on that handoff
+// rather than exporting a start() for the HTML to call, because
+// the bundle now loads as a parser-discovered static
+// <script type="module"> (a JS-initiated dynamic import fails to
+// fetch on Android against Homey's local origin) and a static
+// module can only self-boot.
+const boot = async (): Promise<void> => {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- the SDK passes an untyped instance to onHomeyReady; this is that parse boundary
+  const homey = (await globalThis.homeyReady) as Homey<HomeySettings>
+  await start(homey)
+}
+
+// eslint-disable-next-line unicorn/prefer-top-level-await -- a top-level await would force an es2022 bundle target; esbuild then emits private fields natively instead of lowering them, breaking the older webview engines this static-load change exists to keep working
+fireAndForget(boot())

--- a/widgets/charts/public/index.html
+++ b/widgets/charts/public/index.html
@@ -5,29 +5,35 @@
         <meta content="width=device-width, initial-scale=1.0" name="viewport">
         <title>MELCloud charts</title>
         <script>
-            // Canonical entry point from the widget docs: the SDK needs
-            // this global at parse time. The page logic lives in the
-            // module bundle; a failed bundle load still ends the overlay.
-            function onHomeyReady(homey) {
-                import('./index.mjs?v=29e2a468')
-                    .then((module) => module.start(homey))
-                    .catch((error) => {
-                        globalThis.reportError?.(error)
-                        homey
-                            .api('POST', '/boot-error', { message: String((error && error.message) || error || ''), name: String((error && error.name) || ''), stack: String((error && error.stack) || '') })
-                            .catch(() => {})
-                        const message = document.querySelector('#init_error')
-                        if (message) {
-                            message.hidden = false
-                            message.textContent = homey.__('widgets.loadFailed')
-                        }
-                        homey.ready()
-                    })
+            // Registered at parse time: the SDK dispatches onHomeyReady on
+            // its own schedule, before the module bundle has loaded. The
+            // bundle loads as a parser-discovered static module (same fetch
+            // path as the stylesheets) rather than a JS-initiated dynamic
+            // import(), whose fetch fails on Android against Homey's local
+            // .homeylocal.com origin (diagnosed from a v45.2.4 boot-error
+            // report).
+            window.homeyReady = new Promise((resolve) => {
+                window.onHomeyReady = resolve
+            })
+            // onerror only fires if the module script itself fails to load;
+            // once it loads, its own init ends the overlay.
+            function reportWidgetBootFailure() {
+                window.homeyReady.then((homey) => {
+                    homey
+                        .api('POST', '/boot-error', { message: 'Failed to load the widget module script', name: 'BootError', stack: '' })
+                        .catch(() => {})
+                    const message = document.querySelector('#init_error')
+                    if (message) {
+                        message.hidden = false
+                        message.textContent = homey.__('widgets.loadFailed')
+                    }
+                    homey.ready()
+                })
             }
         </script>
         <link href="styles/layout.css?v=b98ed57e" rel="stylesheet">
         <link href="styles/zone-select.css?v=2cded214" rel="stylesheet">
-        <link href="index.mjs?v=29e2a468" rel="modulepreload">
+        <script type="module" onerror="reportWidgetBootFailure()" src="index.mjs?v=16aa2a29"></script>
         <meta content="MELCloud charts" name="description">
     </head>
     <body class="homey-widget-full homey-text-align-center">

--- a/widgets/charts/public/index.mts
+++ b/widgets/charts/public/index.mts
@@ -883,7 +883,7 @@ class ChartWidget {
  * the SDK has dispatched (see the inline script in the page head).
  * @param homey - The Homey instance handed to `onHomeyReady`.
  */
-export const start = async (homey: Homey<HomeySettings>): Promise<void> => {
+const start = async (homey: Homey<HomeySettings>): Promise<void> => {
   // Register only what the two chart types use so esbuild tree-shakes the rest.
   Chart.register(
     ArcElement,
@@ -900,3 +900,19 @@ export const start = async (homey: Homey<HomeySettings>): Promise<void> => {
   const widget = new ChartWidget(homey)
   await widget.init()
 }
+
+// Entry module: the SDK hands over Homey via the parse-time
+// bootstrap in the page <head>. This file boots on that handoff
+// rather than exporting a start() for the HTML to call, because
+// the bundle now loads as a parser-discovered static
+// <script type="module"> (a JS-initiated dynamic import fails to
+// fetch on Android against Homey's local origin) and a static
+// module can only self-boot.
+const boot = async (): Promise<void> => {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- the SDK passes an untyped instance to onHomeyReady; this is that parse boundary
+  const homey = (await globalThis.homeyReady) as Homey<HomeySettings>
+  await start(homey)
+}
+
+// eslint-disable-next-line unicorn/prefer-top-level-await -- a top-level await would force an es2022 bundle target; esbuild then emits private fields natively instead of lowering them, breaking the older webview engines this static-load change exists to keep working
+fireAndForget(boot())


### PR DESCRIPTION
## Root cause, from the v45.2.4 boot-error capture

The instrumentation shipped in 45.2.4 returned the exact error behind the Android "Loading failed":

```
TypeError: Failed to fetch dynamically imported module:
https://<homey>.homey.homeylocal.com/app/com.mecloud/settings/index.mjs?v=…
```

So the bundle's **dynamic `import()` fails to fetch on Android** — a JS-initiated fetch against Homey's local `.homeylocal.com` origin — while **parser-discovered resources load fine** (the stylesheets render; the widget shows styled chrome). MIME is correct (`application/javascript`), so it's the fetch path, not the content.

## Fix: parser-discovered static module

Each page now loads its bundle as a static `<script type="module" src="index.mjs?v=…">` (the same fetch path as the stylesheets that work) instead of an inline dynamic `import()`. A parse-time inline bootstrap resolves `globalThis.homeyReady`; the entry module self-boots via `fireAndForget(boot())`.

This is also the general best practice (static module scripts are for the always-needed entry bundle; dynamic `import()` is for code-splitting).

## The two disables per entry are the honest cost

- **SDK-handoff cast** — the SDK passes an untyped instance to `onHomeyReady`; a sanctioned parse-boundary cast.
- **`unicorn/prefer-top-level-await`** — a top-level await would force an **es2022** bundle target, and esbuild would then emit private fields natively instead of lowering them, breaking the older webview engines this app supports (the exact class of the `Object.groupBy` breakage #1406 removed). Keeping `boot()` + `fireAndForget` stays es2020. Justified inline and in CLAUDE.md.

## Safety net kept

The `<script onerror>` still ends the overlay and POSTs to `/boot-error`, so if the static form *also* fails on some device, the next diagnostic report says so — we're not flying blind.

Release 45.2.5 (changelog ×13). Suite: 541 tests, 100 %. Settings + both widgets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
