### PR TITLE
Drop the app-side Home boot fetch — kills the Classic-only 401 loop (45.2.7)

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -466,5 +466,20 @@
     "pl": "Naprawia stronę ustawień i widżety, które się nie otwierały.",
     "ru": "Исправлены страница настроек и виджеты, которые не открывались.",
     "sv": "Åtgärdar inställningssidan och widgetar som inte öppnades."
+  },
+  "45.2.7": {
+    "ar": "إيقاف محاولات تسجيل الدخول غير المجدية إلى MELCloud Home لمستخدمي Classic فقط.",
+    "da": "Stopper unødvendige MELCloud Home-loginforsøg for brugere med kun Classic.",
+    "de": "Stoppt unnötige MELCloud-Home-Anmeldeversuche bei reinen Classic-Nutzern.",
+    "en": "Stops needless MELCloud Home login attempts for Classic-only users.",
+    "es": "Detiene los intentos de inicio de sesión innecesarios en MELCloud Home para usuarios solo de Classic.",
+    "fr": "Arrête les tentatives de connexion inutiles à MELCloud Home pour les utilisateurs Classic uniquement.",
+    "it": "Interrompe i tentativi di accesso inutili a MELCloud Home per gli utenti solo Classic.",
+    "ko": "Classic 전용 사용자의 불필요한 MELCloud Home 로그인 시도를 중단합니다.",
+    "nl": "Stopt onnodige MELCloud Home-inlogpogingen voor gebruikers met alleen Classic.",
+    "no": "Stopper unødvendige MELCloud Home-innloggingsforsøk for brukere med kun Classic.",
+    "pl": "Zatrzymuje niepotrzebne próby logowania do MELCloud Home dla użytkowników korzystających tylko z Classic.",
+    "ru": "Прекращает ненужные попытки входа в MELCloud Home для пользователей только Classic.",
+    "sv": "Stoppar onödiga inloggningsförsök till MELCloud Home för användare med enbart Classic."
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -270,5 +270,5 @@
       "värmeåtervinning"
     ]
   },
-  "version": "45.2.6"
+  "version": "45.2.7"
 }

--- a/app.json
+++ b/app.json
@@ -271,7 +271,7 @@
       "värmeåtervinning"
     ]
   },
-  "version": "45.2.6",
+  "version": "45.2.7",
   "flow": {
     "triggers": [
       {

--- a/app.mts
+++ b/app.mts
@@ -853,6 +853,14 @@ export default class MELCloudApp extends App {
     setClassicFacadeManager(this.#facadeManager)
   }
 
+  // Mirrors #initClassicApi: create + facade wiring, no fetch. The
+  // boot-time registry contract lives in melcloud-api, identically for
+  // both APIs — `create()` populates the registry and arms the auto-sync
+  // whenever a session or credentials are available, `authenticate()`
+  // enforces a post-auth sync, and no credentials means total silence.
+  // An app-side `list()` here would duplicate that fetch when
+  // authenticated and, for a Classic-only user, 401 — and keep 401ing
+  // every cycle, since `runSyncCycle` reschedules from its `finally`.
   async #initHomeApi(): Promise<void> {
     this.#homeApi = await Home.API.create({
       events: { onSyncComplete: this.#onSync },
@@ -860,17 +868,6 @@ export default class MELCloudApp extends App {
       settingManager: this.#createSettingManager('home'),
     })
     this.#homeFacadeManager = new Home.FacadeManager(this.#homeApi)
-    // Only fetch (which also arms the recurring sync) once `create()`'s
-    // resumeSession has actually restored a session — the melcloud-api
-    // contract is to check `isAuthenticated()` after `create()`. A
-    // Classic-only user has no Home credentials, so an unconditional
-    // `list()` would 401 and `runSyncCycle` would then reschedule that
-    // 401 on every cycle. Classic needs no such guard: it never forces a
-    // fetch, so its sync stays disarmed until a session exists. A later
-    // Home login re-arms the sync through the settings authenticate flow.
-    if (this.#homeApi.isAuthenticated()) {
-      await this.#homeApi.list()
-    }
   }
 
   #registerFlowListeners(): void {

--- a/app.mts
+++ b/app.mts
@@ -860,7 +860,17 @@ export default class MELCloudApp extends App {
       settingManager: this.#createSettingManager('home'),
     })
     this.#homeFacadeManager = new Home.FacadeManager(this.#homeApi)
-    await this.#homeApi.list()
+    // Only fetch (which also arms the recurring sync) once `create()`'s
+    // resumeSession has actually restored a session — the melcloud-api
+    // contract is to check `isAuthenticated()` after `create()`. A
+    // Classic-only user has no Home credentials, so an unconditional
+    // `list()` would 401 and `runSyncCycle` would then reschedule that
+    // 401 on every cycle. Classic needs no such guard: it never forces a
+    // fetch, so its sync stays disarmed until a session exists. A later
+    // Home login re-arms the sync through the settings authenticate flow.
+    if (this.#homeApi.isAuthenticated()) {
+      await this.#homeApi.list()
+    }
   }
 
   #registerFlowListeners(): void {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "com.melcloud",
-  "version": "45.2.6",
+  "version": "45.2.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "com.melcloud",
-      "version": "45.2.6",
+      "version": "45.2.7",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@olivierzal/melcloud-api": "^41.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.melcloud",
-  "version": "45.2.6",
+  "version": "45.2.7",
   "description": "MELCloud for Homey",
   "homepage": "https://github.com/OlivierZal/com.melcloud/",
   "bugs": {

--- a/tests/unit/app.test.ts
+++ b/tests/unit/app.test.ts
@@ -95,7 +95,6 @@ const mockHomeRegistry = {
 const mockHomeApiInstance = {
   authenticate: vi.fn<() => Promise<void>>(),
   clearSync: vi.fn<() => void>(),
-  isAuthenticated: vi.fn<() => boolean>().mockReturnValue(true),
   list: vi.fn<() => Promise<unknown[]>>(),
   registry: mockHomeRegistry,
 }
@@ -490,17 +489,13 @@ describe('melCloudApp', () => {
       expect(mockSetFacadeManager).toHaveBeenCalledTimes(1)
     })
 
-    it('should fetch Home devices when Home is authenticated', async () => {
+    it('should not fetch Home devices itself (the API create contract owns it)', async () => {
       await app.onInit()
 
-      expect(mockHomeApiInstance.list).toHaveBeenCalledTimes(1)
-    })
-
-    it('should not fetch Home devices when Home is unauthenticated (Classic-only user)', async () => {
-      mockHomeApiInstance.isAuthenticated.mockReturnValue(false)
-
-      await app.onInit()
-
+      // Boot-time fetch + auto-sync arming live in melcloud-api's
+      // `create()`, identically for both APIs: an app-side `list()`
+      // would duplicate the fetch when authenticated and, for a
+      // Classic-only user, 401 on every rescheduled cycle.
       expect(mockHomeApiInstance.list).not.toHaveBeenCalled()
     })
 
@@ -943,9 +938,8 @@ describe('melCloudApp', () => {
   })
 
   describe('home device listing by type', () => {
-    it('should delegate to registry getByType after syncing', async () => {
+    it('should delegate to registry getByType', async () => {
       const mockModels = [{ id: 'device-1', name: 'Living Room' }]
-      mockHomeApiInstance.list.mockResolvedValue([])
       mockHomeRegistry.getByType.mockReturnValue(mockModels)
       await app.onInit()
 
@@ -977,7 +971,6 @@ describe('melCloudApp', () => {
 
     it('should return an ATA facade for a matching ATA device', async () => {
       const mockFacade = mock<Home.DeviceAtaFacade>()
-      mockHomeApiInstance.list.mockResolvedValue([])
       mockHomeRegistry.getById.mockReturnValue(mockAtaModel)
       mockHomeFacadeManagerGet.mockReturnValue(mockFacade)
       await app.onInit()
@@ -991,7 +984,6 @@ describe('melCloudApp', () => {
 
     it('should return an ATW facade for a matching ATW device', async () => {
       const mockFacade = mock<Home.DeviceAtwFacade>()
-      mockHomeApiInstance.list.mockResolvedValue([])
       mockHomeRegistry.getById.mockReturnValue(mockAtwModel)
       mockHomeFacadeManagerGet.mockReturnValue(mockFacade)
       await app.onInit()
@@ -1003,7 +995,6 @@ describe('melCloudApp', () => {
     })
 
     it('should throw when device is not found in registry', async () => {
-      mockHomeApiInstance.list.mockResolvedValue([])
       mockHomeRegistry.getById.mockReset()
       await app.onInit()
 
@@ -1014,7 +1005,6 @@ describe('melCloudApp', () => {
     })
 
     it('should throw when the device type does not match', async () => {
-      mockHomeApiInstance.list.mockResolvedValue([])
       mockHomeRegistry.getById.mockReturnValue(mockAtwModel)
       await app.onInit()
 
@@ -1024,7 +1014,6 @@ describe('melCloudApp', () => {
     })
 
     it('should throw when the model matches neither ATA nor ATW', async () => {
-      mockHomeApiInstance.list.mockResolvedValue([])
       mockHomeRegistry.getById.mockReturnValue({
         ...mockAtaModel,
         isAta: (): boolean => false,
@@ -1039,7 +1028,6 @@ describe('melCloudApp', () => {
 
   describe('home ata targets', () => {
     it('should nest alpha-sorted devices under their alpha-sorted building', async () => {
-      mockHomeApiInstance.list.mockResolvedValue([])
       mockHomeRegistry.getBuildingsByType.mockReturnValue([
         {
           devices: [
@@ -1099,7 +1087,6 @@ describe('melCloudApp', () => {
     }
 
     const setupHomeAtaFacade = (facade: Home.DeviceAtaFacade): void => {
-      mockHomeApiInstance.list.mockResolvedValue([])
       mockHomeRegistry.getById.mockReturnValue(mockAtaModel)
       mockHomeFacadeManagerGet.mockReturnValue(facade)
     }
@@ -1180,7 +1167,6 @@ describe('melCloudApp', () => {
     const groupState = { Power: true }
 
     it('should return the building group state', async () => {
-      mockHomeApiInstance.list.mockResolvedValue([])
       mockHomeFacadeManagerGetBuilding.mockReturnValue(
         mock<Home.BuildingAtaFacade>({
           getGroup: vi
@@ -1202,7 +1188,6 @@ describe('melCloudApp', () => {
       const mockUpdateGroupState = vi
         .fn<(state: unknown) => Promise<unknown>>()
         .mockResolvedValue({ AttributeErrors: null, Success: true })
-      mockHomeApiInstance.list.mockResolvedValue([])
       mockHomeFacadeManagerGetBuilding.mockReturnValue(
         mock<Home.BuildingAtaFacade>({
           updateGroupState: mockUpdateGroupState,
@@ -1220,7 +1205,6 @@ describe('melCloudApp', () => {
 
     it('should list the member modes in the classic vocabulary', async () => {
       const member = { id: 'device-1' }
-      mockHomeApiInstance.list.mockResolvedValue([])
       mockHomeFacadeManagerGetBuilding.mockReturnValue(
         mock<Home.BuildingAtaFacade>({ devices: [member] }),
       )
@@ -1236,7 +1220,6 @@ describe('melCloudApp', () => {
     })
 
     it('should throw not-found for an unknown building', async () => {
-      mockHomeApiInstance.list.mockResolvedValue([])
       mockHomeFacadeManagerGetBuilding.mockReturnValue(null)
       await app.onInit()
 
@@ -2033,7 +2016,6 @@ describe('melCloudApp', () => {
         [mock<ClassicMELCloudDevice>({ syncFromDevice: syncMock })],
         'home-melcloud',
       )
-      mockHomeApiInstance.list.mockResolvedValue([])
       await app.onInit()
 
       await getHomeSyncCallback()()
@@ -2057,7 +2039,6 @@ describe('melCloudApp', () => {
         ],
         'home-melcloud',
       )
-      mockHomeApiInstance.list.mockResolvedValue([])
       await app.onInit()
 
       await getHomeSyncCallback()({
@@ -2071,7 +2052,6 @@ describe('melCloudApp', () => {
     it('should silently skip sync when driver is not yet registered', async () => {
       const syncMock = vi.fn<() => Promise<void>>().mockResolvedValue()
       mockGetDrivers.mockReturnValue({})
-      mockHomeApiInstance.list.mockResolvedValue([])
       await app.onInit()
 
       await getHomeSyncCallback()()
@@ -2080,7 +2060,6 @@ describe('melCloudApp', () => {
     })
 
     it('should wire the same onSync callback on both Classic and Home APIs', async () => {
-      mockHomeApiInstance.list.mockResolvedValue([])
       await app.onInit()
 
       expect(getSyncCallback()).toBe(getHomeSyncCallback())

--- a/tests/unit/app.test.ts
+++ b/tests/unit/app.test.ts
@@ -95,6 +95,7 @@ const mockHomeRegistry = {
 const mockHomeApiInstance = {
   authenticate: vi.fn<() => Promise<void>>(),
   clearSync: vi.fn<() => void>(),
+  isAuthenticated: vi.fn<() => boolean>().mockReturnValue(true),
   list: vi.fn<() => Promise<unknown[]>>(),
   registry: mockHomeRegistry,
 }
@@ -487,6 +488,20 @@ describe('melCloudApp', () => {
       )
       expect(Classic.FacadeManager).toHaveBeenCalledTimes(1)
       expect(mockSetFacadeManager).toHaveBeenCalledTimes(1)
+    })
+
+    it('should fetch Home devices when Home is authenticated', async () => {
+      await app.onInit()
+
+      expect(mockHomeApiInstance.list).toHaveBeenCalledTimes(1)
+    })
+
+    it('should not fetch Home devices when Home is unauthenticated (Classic-only user)', async () => {
+      mockHomeApiInstance.isAuthenticated.mockReturnValue(false)
+
+      await app.onInit()
+
+      expect(mockHomeApiInstance.list).not.toHaveBeenCalled()
     })
 
     it('should pass logger callbacks that delegate to app.log and app.error', async () => {


### PR DESCRIPTION
## Problem

`#initHomeApi` called `list()` **unconditionally** after `create()`. For a Classic-only user (no MELCloud Home credentials), that 401s — and because `runSyncCycle` reschedules from its `finally` and Home's sync cadence is **1 minute**, the 401 repeats forever: **1,440 doomed login attempts a day** (live-measured on a Homey 2019 without a Home session: one 401 every 60 s).

## Fix: remove the call — the library already owns the contract, symmetrically

melcloud-api's base template enforces the same boot contract for BOTH APIs:

- `create()` → `initialize()`: session probe or `resumeSession()`, and on success `syncRegistry()` runs (`fetch()`/`list()`) → **registry populated + auto-sync armed by the lib** (the documented #1281-class invariant);
- `authenticate()` (explicit login from settings): post-auth sync **enforced in the base** — a later Home login re-arms everything;
- no credentials → no network call at all.

So `#initHomeApi` now mirrors `#initClassicApi` exactly: **create + facade wiring, nothing else**. The app-side `list()` was a duplicate fetch when authenticated and the 401 loop when not. No asymmetry left: Classic-only and Home-only setups behave identically (the other side stays completely silent), and the settings page's lazy `/home/sessions` re-probe remains the deliberate, user-triggered self-heal.

The expired-credentials case is unchanged: one best-effort resume at boot (logged), no recurrence — the silent-failure UX is a separate, already-flagged topic (re-login notification).

Regression test: `onInit` never calls `homeApi.list()`. Release 45.2.7. Suite green (536 tests, coverage gate, validate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
