### PR TITLE
Stale-HTML compat bundles + webview boot beacon (45.2.8)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,7 @@
 /env.json
 node_modules/
 /settings/index.js
+/settings/index.mjs
 /widgets/*/public/index.js
+/widgets/*/public/index.mjs
 /.claude/

--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -481,5 +481,20 @@
     "pl": "Zatrzymuje niepotrzebne próby logowania do MELCloud Home dla użytkowników korzystających tylko z Classic.",
     "ru": "Прекращает ненужные попытки входа в MELCloud Home для пользователей только Classic.",
     "sv": "Stoppar onödiga inloggningsförsök till MELCloud Home för användare med enbart Classic."
+  },
+  "45.2.8": {
+    "ar": "تشخيصات أفضل عندما تفشل صفحة أو أداة في التحميل.",
+    "da": "Bedre diagnostik når en side eller widget ikke kan indlæses.",
+    "de": "Bessere Diagnose, wenn eine Seite oder ein Widget nicht lädt.",
+    "en": "Better diagnostics when a page or widget fails to load.",
+    "es": "Mejores diagnósticos cuando una página o un widget no carga.",
+    "fr": "Meilleurs diagnostics lorsqu'une page ou un widget ne se charge pas.",
+    "it": "Diagnostica migliore quando una pagina o un widget non si carica.",
+    "ko": "페이지나 위젯이 로드되지 않을 때의 진단 기능이 개선되었습니다.",
+    "nl": "Betere diagnostiek wanneer een pagina of widget niet laadt.",
+    "no": "Bedre diagnostikk når en side eller widget ikke lastes.",
+    "pl": "Lepsza diagnostyka, gdy strona lub widżet się nie ładuje.",
+    "ru": "Улучшена диагностика, когда страница или виджет не загружается.",
+    "sv": "Bättre diagnostik när en sida eller widget inte laddas."
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -48,6 +48,10 @@
       "method": "GET",
       "path": "/home/sessions"
     },
+    "logWebviewBoot": {
+      "method": "POST",
+      "path": "/boot-error"
+    },
     "updateClassicFrostProtection": {
       "method": "PUT",
       "path": "/classic/zones/:zoneType/:zoneId/settings/frost-protection"
@@ -270,5 +274,5 @@
       "värmeåtervinning"
     ]
   },
-  "version": "45.2.7"
+  "version": "45.2.8"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,7 +160,19 @@ coverage.
   EVERY webview forever on a cold open (a stalled module fetch also
   blocks `onHomeyReady`; proven with breadcrumbs over `homey app run`) —
   both reverted. Classic `defer` is the proven, on-device-cold-verified
-  form.
+  form. Phone webviews also cache the HTML ITSELF across app versions
+  (proven in the wild: a cached dynamic-import-era HTML requested
+  `index.mjs?v=…` against a 45.2.6 app shipping only `index.js` → 404 →
+  "Loading failed"), so shipped bundle filenames are a COMPAT CONTRACT:
+  `scripts/bundle.mjs` builds every entry twice — `index.js` (IIFE) for
+  the current HTML, `index.mjs` (ESM) for every cached ESM-era HTML,
+  which is why the entries keep `export const start`. Never rename or
+  drop a shipped bundle filename; add alongside. When a bundle still
+  fails to boot, the `onHomeyReady` poll's timeout beacon POSTs the
+  `userAgent` plus a `fetch` probe of the bundle to `/boot-error`
+  (`app.error`) before degrading, so a diagnostic report distinguishes
+  a fetch failure (probe error / non-200) from a parse-or-runtime crash
+  (probe 200, global absent — think pre-es2020 engines).
 - Widgets ship separately; they cannot share files at runtime. The zone
   selector's ghost styling is deliberately duplicated as byte-identical
   `styles/zone-select.css` twins, pinned by `tests/unit/widget-styles.test.ts`

--- a/api.mts
+++ b/api.mts
@@ -166,6 +166,15 @@ const api = {
     }
     return app.homeApi.isAuthenticated()
   },
+  logWebviewBoot: ({
+    body,
+    homey: { app },
+  }: {
+    body: unknown
+    homey: Homey
+  }): void => {
+    app.error('Settings webview boot failed:', JSON.stringify(body))
+  },
   updateClassicFrostProtection: async ({
     body,
     homey: { app },

--- a/app.json
+++ b/app.json
@@ -49,6 +49,10 @@
       "method": "GET",
       "path": "/home/sessions"
     },
+    "logWebviewBoot": {
+      "method": "POST",
+      "path": "/boot-error"
+    },
     "updateClassicFrostProtection": {
       "method": "PUT",
       "path": "/classic/zones/:zoneType/:zoneId/settings/frost-protection"
@@ -271,7 +275,7 @@
       "värmeåtervinning"
     ]
   },
-  "version": "45.2.7",
+  "version": "45.2.8",
   "flow": {
     "triggers": [
       {
@@ -10564,6 +10568,10 @@
           "method": "GET",
           "path": "/language"
         },
+        "logWebviewBoot": {
+          "method": "POST",
+          "path": "/boot-error"
+        },
         "updateClassicAtaState": {
           "method": "PUT",
           "path": "/classic/zones/:zoneType/:zoneId/ata"
@@ -10629,6 +10637,10 @@
         "getLanguage": {
           "method": "GET",
           "path": "/language"
+        },
+        "logWebviewBoot": {
+          "method": "POST",
+          "path": "/boot-error"
         }
       },
       "name": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "com.melcloud",
-  "version": "45.2.7",
+  "version": "45.2.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "com.melcloud",
-      "version": "45.2.7",
+      "version": "45.2.8",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@olivierzal/melcloud-api": "^41.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.melcloud",
-  "version": "45.2.7",
+  "version": "45.2.8",
   "description": "MELCloud for Homey",
   "homepage": "https://github.com/OlivierZal/com.melcloud/",
   "bugs": {

--- a/scripts/bundle.mjs
+++ b/scripts/bundle.mjs
@@ -23,20 +23,38 @@ const entryPoints = [
   'settings/index.mts',
 ]
 
+const sharedOptions = {
+  bundle: true,
+  legalComments: 'none',
+  logLevel: 'info',
+  minify: true,
+  target: ['es2020'],
+}
+
+// Each entry builds TWICE. Phone webviews cache the HTML itself across
+// app versions (observed in the wild: a cached dynamic-import HTML
+// requesting index.mjs?v=… against an app shipping only index.js → 404 →
+// "Loading failed"), so previously-shipped bundle filenames are a compat
+// contract: index.js serves the current classic-defer HTML, index.mjs
+// keeps every cached ESM-era HTML working (their import('./index.mjs')
+// finds the exported `start`). Never rename or drop a shipped bundle
+// filename — add alongside instead.
 await Promise.all(
-  entryPoints.map(async (entryPoint) =>
+  entryPoints.flatMap((entryPoint) => [
     build({
-      bundle: true,
+      ...sharedOptions,
       entryPoints: [entryPoint],
       format: 'iife',
       globalName: GLOBAL_NAME,
-      legalComments: 'none',
-      logLevel: 'info',
-      minify: true,
       outfile: entryPoint.replace(/\.mts$/u, '.js'),
-      target: ['es2020'],
     }),
-  ),
+    build({
+      ...sharedOptions,
+      entryPoints: [entryPoint],
+      format: 'esm',
+      outfile: entryPoint.replace(/\.mts$/u, '.mjs'),
+    }),
+  ]),
 )
 
 // Cache-bust the static references: the phone webviews cache assets

--- a/settings/index.html
+++ b/settings/index.html
@@ -18,8 +18,20 @@
                     if (globalThis.MELCloudWebview) {
                         globalThis.MELCloudWebview.start(homey)
                     } else if (Date.now() > deadline) {
-                        homey.ready()
-                        homey.alert(homey.__('settings.loadFailed')).catch(() => {})
+                        // Boot beacon: the bundle never booted — report WHY
+                        // before degrading. A 200 probe with no global means
+                        // the script fetched but failed to parse/run (old
+                        // engine); a probe error means the fetch itself
+                        // fails on this device.
+                        const script = document.querySelector('script[src*="index.js"]')
+                        const report = (probe) => {
+                            homey.api('POST', '/boot-error', { message: 'The settings bundle did not boot within 10s', name: 'BootTimeout', probe, stack: '', userAgent: navigator.userAgent }, () => {})
+                            homey.ready()
+                            homey.alert(homey.__('settings.loadFailed')).catch(() => {})
+                        }
+                        fetch(script ? script.src : 'index.js')
+                            .then((response) => { report('fetch ' + String(response.status)) })
+                            .catch((error) => { report('fetch failed: ' + String(error)) })
                     } else {
                         setTimeout(waitForBundle, 50)
                     }

--- a/tests/unit/api.test.ts
+++ b/tests/unit/api.test.ts
@@ -263,6 +263,14 @@ describe('api', () => {
     })
   })
 
+  describe('webview boot logging', () => {
+    it('should log the boot failure body via app.error', () => {
+      api.logWebviewBoot({ body: { message: 'boom' }, homey })
+
+      expect(mockApp.error).toHaveBeenCalledTimes(1)
+    })
+  })
+
   describe('language retrieval', () => {
     it('should return the language from i18n', () => {
       mockI18n.getLanguage.mockReturnValue('en')

--- a/tests/unit/ata-group-setting-api.test.ts
+++ b/tests/unit/ata-group-setting-api.test.ts
@@ -48,6 +48,14 @@ describe('ata-group-setting api', () => {
     vi.clearAllMocks()
   })
 
+  describe('webview boot logging', () => {
+    it('should log the boot failure body via app.error', () => {
+      api.logWebviewBoot({ body: { message: 'boom' }, homey })
+
+      expect(mockApp.error).toHaveBeenCalledTimes(1)
+    })
+  })
+
   describe('ata capability retrieval', () => {
     it('should delegate to app.getClassicAtaCapabilities', () => {
       const capabilities =

--- a/tests/unit/charts-api.test.ts
+++ b/tests/unit/charts-api.test.ts
@@ -40,6 +40,14 @@ describe('charts api', () => {
     vi.clearAllMocks()
   })
 
+  describe('webview boot logging', () => {
+    it('should log the boot failure body via app.error', () => {
+      api.logWebviewBoot({ body: { message: 'boom' }, homey })
+
+      expect(mockApp.error).toHaveBeenCalledTimes(1)
+    })
+  })
+
   describe('device retrieval', () => {
     it('should return only device zones without type filter', () => {
       const zones = [

--- a/widgets/ata-group-setting/api.mts
+++ b/widgets/ata-group-setting/api.mts
@@ -75,6 +75,15 @@ const api = {
   }): Promise<Classic.GroupState> => app.getHomeBuildingAtaState(buildingId),
   getLanguage: ({ homey: { i18n } }: { homey: Homey }): string =>
     i18n.getLanguage(),
+  logWebviewBoot: ({
+    body,
+    homey: { app },
+  }: {
+    body: unknown
+    homey: Homey
+  }): void => {
+    app.error('Widget boot failed:', JSON.stringify(body))
+  },
   updateClassicAtaState: async ({
     body,
     homey: { app },

--- a/widgets/ata-group-setting/public/index.html
+++ b/widgets/ata-group-setting/public/index.html
@@ -18,12 +18,26 @@
                     if (globalThis.MELCloudWebview) {
                         globalThis.MELCloudWebview.start(homey)
                     } else if (Date.now() > deadline) {
-                        const message = document.querySelector('#init_error')
-                        if (message) {
-                            message.hidden = false
-                            message.textContent = homey.__('widgets.loadFailed')
+                        // Boot beacon: the bundle never booted — report WHY
+                        // before degrading. A 200 probe with no global means
+                        // the script fetched but failed to parse/run (old
+                        // engine); a probe error means the fetch itself
+                        // fails on this device.
+                        const script = document.querySelector('script[src*="index.js"]')
+                        const report = (probe) => {
+                            homey
+                                .api('POST', '/boot-error', { message: 'The widget bundle did not boot within 10s', name: 'BootTimeout', probe, stack: '', userAgent: navigator.userAgent })
+                                .catch(() => {})
+                            const message = document.querySelector('#init_error')
+                            if (message) {
+                                message.hidden = false
+                                message.textContent = homey.__('widgets.loadFailed')
+                            }
+                            homey.ready()
                         }
-                        homey.ready()
+                        fetch(script ? script.src : 'index.js')
+                            .then((response) => { report('fetch ' + String(response.status)) })
+                            .catch((error) => { report('fetch failed: ' + String(error)) })
                     } else {
                         setTimeout(waitForBundle, 50)
                     }

--- a/widgets/ata-group-setting/widget.compose.json
+++ b/widgets/ata-group-setting/widget.compose.json
@@ -36,6 +36,10 @@
       "method": "GET",
       "path": "/language"
     },
+    "logWebviewBoot": {
+      "method": "POST",
+      "path": "/boot-error"
+    },
     "updateClassicAtaState": {
       "method": "PUT",
       "path": "/classic/zones/:zoneType/:zoneId/ata"

--- a/widgets/charts/api.mts
+++ b/widgets/charts/api.mts
@@ -77,6 +77,15 @@ const api = {
     }),
   getLanguage: ({ homey: { i18n } }: { homey: Homey }): string =>
     i18n.getLanguage(),
+  logWebviewBoot: ({
+    body,
+    homey: { app },
+  }: {
+    body: unknown
+    homey: Homey
+  }): void => {
+    app.error('Widget boot failed:', JSON.stringify(body))
+  },
 }
 
 export default api

--- a/widgets/charts/public/index.html
+++ b/widgets/charts/public/index.html
@@ -18,12 +18,26 @@
                     if (globalThis.MELCloudWebview) {
                         globalThis.MELCloudWebview.start(homey)
                     } else if (Date.now() > deadline) {
-                        const message = document.querySelector('#init_error')
-                        if (message) {
-                            message.hidden = false
-                            message.textContent = homey.__('widgets.loadFailed')
+                        // Boot beacon: the bundle never booted — report WHY
+                        // before degrading. A 200 probe with no global means
+                        // the script fetched but failed to parse/run (old
+                        // engine); a probe error means the fetch itself
+                        // fails on this device.
+                        const script = document.querySelector('script[src*="index.js"]')
+                        const report = (probe) => {
+                            homey
+                                .api('POST', '/boot-error', { message: 'The widget bundle did not boot within 10s', name: 'BootTimeout', probe, stack: '', userAgent: navigator.userAgent })
+                                .catch(() => {})
+                            const message = document.querySelector('#init_error')
+                            if (message) {
+                                message.hidden = false
+                                message.textContent = homey.__('widgets.loadFailed')
+                            }
+                            homey.ready()
                         }
-                        homey.ready()
+                        fetch(script ? script.src : 'index.js')
+                            .then((response) => { report('fetch ' + String(response.status)) })
+                            .catch((error) => { report('fetch failed: ' + String(error)) })
                     } else {
                         setTimeout(waitForBundle, 50)
                     }

--- a/widgets/charts/widget.compose.json
+++ b/widgets/charts/widget.compose.json
@@ -23,6 +23,10 @@
     "getLanguage": {
       "method": "GET",
       "path": "/language"
+    },
+    "logWebviewBoot": {
+      "method": "POST",
+      "path": "/boot-error"
     }
   },
   "name": {


### PR DESCRIPTION
## The smoking gun (user console log, v45.2.6)

```
GET https://…/settings/index.mjs?v=50b46cac → 404 (Not Found)
Uncaught TypeError: Failed to fetch dynamically imported module
```

**Phone webviews cache the HTML itself across app versions.** The affected users run a cached dynamic-import-era HTML (45.x ≤ 45.2.4) against a 45.2.6 app that only ships `index.js` — renaming the bundle turned "stale but working" into "stale and 404 → Loading failed". This is the remaining "still loading failed" cohort; their app-side log shows no webview trace because the page never reaches a route.

## Fix 1 — compat contract: ship both bundle names

`scripts/bundle.mjs` builds every entry twice: `index.js` (IIFE, current `defer` HTML) **and** `index.mjs` (ESM) — a cached HTML's `import('./index.mjs?v=…')` finds the exported `start` again (verified: the built ESM exports `start`; the `?v=` mismatch is irrelevant to serving). Cached users are fixed **without touching their cache**. Doctrine: shipped bundle filenames are never renamed or dropped — documented in CLAUDE.md.

Known narrow gap: an HTML cached from the ~5 h static-module 45.2.5 window expects a self-booting module; it stays on the timeout alert until its cache refreshes (tiny cohort, degraded-not-hung).

## Fix 2 — boot beacon v2 (restores diagnosability)

Removing `/boot-error` in 45.2.6 left us blind exactly here. The poll's timeout fallback now POSTs `userAgent` + a **`fetch` probe of the bundle** to the restored route before degrading: probe error/non-200 = fetch failure (like this 404); probe 200 with no global = parse/runtime crash (pre-es2020 engine). The restored route also catches cached-45.2.4 HTMLs' own error POSTs.

Release 45.2.8 (stacked on #1420/45.2.7). Suite: 538 tests, coverage gate, validate — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
