### PR TITLE
Legionella instant-dialect fix + corrected loader causality docs (45.2.10)

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -511,5 +511,20 @@
     "pl": "Naprawia stronę ustawień i widżety, które nie ładowały się po instalacji z App Store.",
     "ru": "Исправлена загрузка страницы настроек и виджетов при установке из App Store.",
     "sv": "Åtgärdar inställningssidan och widgetar som inte laddades vid installation från App Store."
+  },
+  "45.2.10": {
+    "ar": "إصلاح تاريخ آخر دورة ليجيونيلا الذي لم يكن يظهر على أجهزة الهواء-الماء.",
+    "da": "Retter datoen for seneste legionella-cyklus, der ikke blev vist på luft-til-vand-enheder.",
+    "de": "Behebt die fehlende Anzeige des Datums des letzten Legionellen-Zyklus bei Luft-Wasser-Geräten.",
+    "en": "Fixes the last legionella cycle date failing to display on air-to-water devices.",
+    "es": "Corrige la fecha del último ciclo de legionela que no se mostraba en los equipos aire-agua.",
+    "fr": "Corrige la date du dernier cycle anti-légionellose qui ne s'affichait pas sur les appareils air-eau.",
+    "it": "Corregge la data dell'ultimo ciclo antilegionella che non veniva visualizzata sui dispositivi aria-acqua.",
+    "ko": "공기-물 장치에서 마지막 레지오넬라 사이클 날짜가 표시되지 않던 문제를 수정했습니다.",
+    "nl": "Verhelpt de datum van de laatste legionella-cyclus die niet werd weergegeven op lucht-water-apparaten.",
+    "no": "Fikser datoen for siste legionella-syklus som ikke ble vist på luft-til-vann-enheter.",
+    "pl": "Naprawia datę ostatniego cyklu antylegionellowego, która nie wyświetlała się na urządzeniach powietrze-woda.",
+    "ru": "Исправлено отображение даты последнего цикла легионеллы на устройствах воздух-вода.",
+    "sv": "Åtgärdar datumet för den senaste legionellacykeln som inte visades på luft-till-vatten-enheter."
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -274,5 +274,5 @@
       "värmeåtervinning"
     ]
   },
-  "version": "45.2.9"
+  "version": "45.2.10"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,13 +147,17 @@ coverage.
 
 - Webview lifecycle (settings page included): the bundle is a CLASSIC
   IIFE (esbuild `format: 'iife'`, `globalName: MELCloudWebview`), loaded
-  via `<script defer src="index.js">` — NOT an ES module. Only the JS
-  module loader fails: both `import()` and `<script type="module">` stall
-  on a COLD webview open against Homey's local origin (the #1404 spinner
-  — and since the SDK fires `onHomeyReady` only after `load`, a stalled
-  module fetch blocks even that, so nothing runs at all), while classic
-  resource fetches — the stylesheet, a classic `<script src>` — load
-  cold. So each HTML declares the docs' canonical global
+  via `<script defer src="index.js">` — NOT an ES module. What is proven
+  on-device: a STATIC `<script type="module">` stalls the whole boot on
+  a cold open (and since the SDK fires `onHomeyReady` only after `load`,
+  the stalled module fetch blocks even that, so nothing runs at all),
+  while classic scripts — like the stylesheets — load cold. Dynamic
+  `import()` (the docs' canonical form) also works when the bundle
+  exists: its supposed Android fetch failures were #1404's real cause,
+  store packages shipping no bundles at all. The classic form stays
+  because it is strictly more robust — bounded boot plus in-band beacon
+  — not because `import()` is broken. Each HTML declares the docs'
+  canonical global
   `function onHomeyReady(homey)` inline (it must exist at parse time),
   which polls `globalThis.MELCloudWebview` and calls its `start(homey)`
   once the bundle is up. `defer` (not `async`) is the right fit for an
@@ -171,13 +175,15 @@ coverage.
   context, never a comment — with a content hash (`?v=`): phone webviews
   cache assets across app versions. Webview code must stick to es2020-era
   runtime APIs (no `Object.groupBy` & co.): esbuild lowers syntax only,
-  and old iOS engines are real. NEVER load the bundle as an ES module:
-  dynamic `import()` worked on iOS but failed to fetch on Android (the
-  original #1404), and a static `<script type="module">` (45.2.5) spun
-  EVERY webview forever on a cold open (a stalled module fetch also
-  blocks `onHomeyReady`; proven with breadcrumbs over `homey app run`) —
-  both reverted. Classic `defer` is the proven, on-device-cold-verified
-  form. Phone webviews also cache the HTML ITSELF across app versions
+  and old iOS engines are real. Never load the bundle as a STATIC
+  `<script type="module">`: 45.2.5 shipped that and every webview spun
+  forever on a cold open (proven with breadcrumbs over `homey app run`;
+  reverted). Dynamic `import()` is merely unnecessary, not broken — its
+  supposed Android fetch failures were the missing-bundle 404s — but do
+  not churn the loading mechanism again without new on-device evidence:
+  classic `defer` is the cold-verified form and carries the bounded
+  boot plus beacon. Phone webviews also cache the HTML ITSELF across app
+  versions
   (proven in the wild: a cached dynamic-import-era HTML requested
   `index.mjs?v=…` against a 45.2.6 app shipping only `index.js` → 404 →
   "Loading failed"), so shipped bundle filenames are a COMPAT CONTRACT:

--- a/app.json
+++ b/app.json
@@ -275,7 +275,7 @@
       "värmeåtervinning"
     ]
   },
-  "version": "45.2.9",
+  "version": "45.2.10",
   "flow": {
     "triggers": [
       {

--- a/drivers/melcloud_atw/device.mts
+++ b/drivers/melcloud_atw/device.mts
@@ -1,5 +1,4 @@
 import { hasClassicZone2, isClassicAtwFacade } from '@olivierzal/melcloud-api'
-import { Temporal } from 'temporal-polyfill'
 import * as Classic from '@olivierzal/melcloud-api/classic'
 
 import type {
@@ -10,7 +9,7 @@ import type {
 } from '../../types/capabilities.mts'
 import type { EnergyReportConfig } from '../base-report.mts'
 import { KILOWATT_TO_WATT } from '../../lib/constants.mts'
-import { getLocale } from '../../lib/temporal.mts'
+import { getLocale, getTimeZone, toPlainDate } from '../../lib/temporal.mts'
 import { HotWaterMode } from '../../types/atw.mts'
 import {
   type TargetTemperatureFlowCapabilities,
@@ -86,12 +85,17 @@ export default class ClassicMELCloudDeviceAtw extends ClassicMELCloudDevice<
     'alarm_generic.defrost': ({ DefrostMode: mode }) => Boolean(mode),
     hot_water_mode: ({ ForcedHotWaterMode: isForced }) =>
       isForced ? HotWaterMode.forced : HotWaterMode.auto,
+    // MELCloud reports the timestamp either as a UTC instant (Z suffix)
+    // or as a wall-clock time — the same dialect split as the error log.
     legionella: ({ LastLegionellaActivationTime: time }) =>
-      Temporal.PlainDate.from(time).toLocaleString(getLocale(this.homey), {
-        day: 'numeric',
-        month: 'short',
-        weekday: 'short',
-      }),
+      toPlainDate(time, getTimeZone(this.homey)).toLocaleString(
+        getLocale(this.homey),
+        {
+          day: 'numeric',
+          month: 'short',
+          weekday: 'short',
+        },
+      ),
     operational_state: ({ OperationMode: state }) =>
       operationModeStateFromDevice[state],
   }

--- a/lib/temporal.mts
+++ b/lib/temporal.mts
@@ -12,3 +12,26 @@ export const getNow = (homey: Homey.Homey): Temporal.ZonedDateTime =>
 /** BCP-47 locale tag from Homey's i18n manager (e.g. `'en'`, `'fr'`). */
 export const getLocale = (homey: Homey.Homey): string =>
   homey.i18n.getLanguage()
+
+/**
+ * Calendar date of a MELCloud timestamp, which arrives either as a UTC
+ * instant (`Z`/offset suffix) or as a wall-clock time — the same
+ * dialect split as the error log. `Temporal.PlainDate.from` rejects
+ * the instant form outright, so it is projected into the given
+ * timezone first.
+ * @param date - The MELCloud timestamp.
+ * @param timeZone - IANA timezone the instant form is projected into.
+ * @returns The calendar date.
+ */
+export const toPlainDate = (
+  date: string,
+  timeZone: string,
+): Temporal.PlainDate => {
+  try {
+    return Temporal.Instant.from(date)
+      .toZonedDateTimeISO(timeZone)
+      .toPlainDate()
+  } catch {
+    return Temporal.PlainDate.from(date)
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "com.melcloud",
-  "version": "45.2.9",
+  "version": "45.2.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "com.melcloud",
-      "version": "45.2.9",
+      "version": "45.2.10",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@olivierzal/melcloud-api": "^41.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.melcloud",
-  "version": "45.2.9",
+  "version": "45.2.10",
   "description": "MELCloud for Homey",
   "homepage": "https://github.com/OlivierZal/com.melcloud/",
   "bugs": {

--- a/settings/index.html
+++ b/settings/index.html
@@ -6,12 +6,13 @@
         <title>MELCloud Settings</title>
         <script>
             // The page bundle loads as a classic defer script, not an ES
-            // module: module fetches (import()/type=module) stall on a
-            // cold webview open against Homey's local origin (the #1404
-            // spinner), while classic resource fetches — like the
-            // stylesheet — load cold. The poll hands the instance to the
-            // bundle's start once it is up, or ends the overlay if it
-            // never arrives.
+            // module: a static module script stalls the whole boot on a
+            // cold webview open (a stalled module fetch also blocks
+            // onHomeyReady — proven on-device), while classic scripts,
+            // like the stylesheet, load cold. The poll keeps the boot
+            // bounded: it hands the instance to the bundle's start once
+            // it is up, or reports why and ends the overlay if it never
+            // arrives.
             function onHomeyReady(homey) {
                 const deadline = Date.now() + 10000
                 const waitForBundle = () => {

--- a/tests/unit/melcloud-atw-device.test.ts
+++ b/tests/unit/melcloud-atw-device.test.ts
@@ -177,6 +177,23 @@ describe(ClassicMELCloudDeviceAtw, () => {
       expect(result).toBeDefined()
       expect(result).toBeTypeOf('string')
     })
+
+    it('should convert legionella from a UTC instant (Z suffix) too', () => {
+      const {
+        deviceToCapability: { legionella: converter },
+      } = device
+
+      // Regression: MELCloud also sends the instant dialect, which
+      // Temporal.PlainDate.from rejects outright (user report).
+      const result = converter?.(
+        mock<Classic.ListDeviceDataAtw>({
+          LastLegionellaActivationTime: '2026-07-07T13:01:00Z',
+        }),
+      )
+
+      expect(result).toBeDefined()
+      expect(result).toBeTypeOf('string')
+    })
   })
 
   describe('capability-to-device conversions', () => {

--- a/tests/unit/temporal.test.ts
+++ b/tests/unit/temporal.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+
+import { toPlainDate } from '../../lib/temporal.mts'
+
+describe(toPlainDate, () => {
+  it('should project a UTC instant into the timezone before taking the date', () => {
+    expect(toPlainDate('2026-07-07T23:30:00Z', 'Europe/Paris').toString()).toBe(
+      '2026-07-08',
+    )
+  })
+
+  it('should take a wall-clock time as-is', () => {
+    expect(toPlainDate('2026-03-18T10:00:00', 'Europe/Paris').toString()).toBe(
+      '2026-03-18',
+    )
+  })
+
+  it('should accept a bare date', () => {
+    expect(toPlainDate('2026-03-18', 'Europe/Paris').toString()).toBe(
+      '2026-03-18',
+    )
+  })
+})

--- a/widgets/ata-group-setting/public/index.html
+++ b/widgets/ata-group-setting/public/index.html
@@ -5,12 +5,13 @@
         <meta content="width=device-width, initial-scale=1.0" name="viewport">
         <title>Air-to-air device values</title>
         <script>
-            // Classic defer bundle, not an ES module: module fetches
-            // (import()/type=module) stall on a cold webview open
-            // against Homey's local origin (the #1404 spinner), while
-            // classic resource fetches — like the stylesheets — load cold.
-            // The poll hands the instance to the bundle's start once it is
-            // up, or shows the inline error and ends the overlay if it
+            // Classic defer bundle, not an ES module: a static module
+            // script stalls the whole boot on a cold webview open (a
+            // stalled module fetch also blocks onHomeyReady — proven
+            // on-device), while classic scripts, like the stylesheets,
+            // load cold. The poll keeps the boot bounded: it hands the
+            // instance to the bundle's start once it is up, or reports
+            // why, shows the inline error and ends the overlay if it
             // never arrives.
             function onHomeyReady(homey) {
                 const deadline = Date.now() + 10000

--- a/widgets/charts/public/index.html
+++ b/widgets/charts/public/index.html
@@ -5,12 +5,13 @@
         <meta content="width=device-width, initial-scale=1.0" name="viewport">
         <title>MELCloud charts</title>
         <script>
-            // Classic defer bundle, not an ES module: module fetches
-            // (import()/type=module) stall on a cold webview open
-            // against Homey's local origin (the #1404 spinner), while
-            // classic resource fetches — like the stylesheets — load cold.
-            // The poll hands the instance to the bundle's start once it is
-            // up, or shows the inline error and ends the overlay if it
+            // Classic defer bundle, not an ES module: a static module
+            // script stalls the whole boot on a cold webview open (a
+            // stalled module fetch also blocks onHomeyReady — proven
+            // on-device), while classic scripts, like the stylesheets,
+            // load cold. The poll keeps the boot bounded: it hands the
+            // instance to the bundle's start once it is up, or reports
+            // why, shows the inline error and ends the overlay if it
             // never arrives.
             function onHomeyReady(homey) {
                 const deadline = Date.now() + 10000


### PR DESCRIPTION
## Audit follow-up — now that the root cause is known

Post-mortem triage of the #1404 saga separated the real fixes (kept: bounded init, breadcrumbs, perf deferral, polls/auth, beacon, compat, publish pipeline) from the false premises. Two things needed action:

### 1. Real outstanding bug: legionella date crash (user report 355ff3d7)

`Temporal.PlainDate.from('2026-07-07T13:01:00Z')` → RangeError: MELCloud reports `LastLegionellaActivationTime` in **two dialects** (UTC instant with `Z`, or wall-clock) — the same split `parseErrorDate` already handles for the error log. New `lib/temporal.toPlainDate(date, timeZone)` projects the instant into the Homey timezone first, falls back to the wall-clock parse. Regression tests cover both dialects and the timezone-projection edge (`23:30Z` → next day in `Europe/Paris`).

### 2. False causality still written as fact

CLAUDE.md and the three HTML comments claimed dynamic `import()` "fails to fetch on Android" — those failures were the missing-bundle 404s. Corrected to exactly what is proven:
- **Static `<script type="module">` genuinely breaks** (cold-open boot stall, on-device breadcrumb proof — independent of the 404).
- **Dynamic `import()` was merely unnecessary, not broken.**
- The classic `defer` form **stays** — bounded boot + in-band beacon make it strictly more robust than the canonical pattern — and the loading mechanism is not to be churned again without new on-device evidence.

Release 45.2.10. Suite: 546 tests (+4), coverage gates green, validate clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
