### PR TITLE
Release 45.2.11 — first store publish through the .homeybuild pipeline

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -526,5 +526,20 @@
     "pl": "Naprawia datę ostatniego cyklu antylegionellowego, która nie wyświetlała się na urządzeniach powietrze-woda.",
     "ru": "Исправлено отображение даты последнего цикла легионеллы на устройствах воздух-вода.",
     "sv": "Åtgärdar datumet för den senaste legionellacykeln som inte visades på luft-till-vatten-enheter."
+  },
+  "45.2.11": {
+    "ar": "إصدار صيانة: تحسينات داخلية في تجميع التطبيق.",
+    "da": "Vedligeholdelsesudgivelse: interne forbedringer af app-pakningen.",
+    "de": "Wartungsversion: interne Verbesserungen der App-Paketierung.",
+    "en": "Maintenance release: internal packaging improvements.",
+    "es": "Versión de mantenimiento: mejoras internas del empaquetado.",
+    "fr": "Version de maintenance : améliorations internes de l'empaquetage.",
+    "it": "Versione di manutenzione: miglioramenti interni del packaging.",
+    "ko": "유지 보수 릴리스: 내부 패키징 개선.",
+    "nl": "Onderhoudsrelease: interne verbeteringen van de verpakking.",
+    "no": "Vedlikeholdsutgivelse: interne forbedringer av pakkingen.",
+    "pl": "Wydanie serwisowe: wewnętrzne ulepszenia pakowania.",
+    "ru": "Сервисный выпуск: внутренние улучшения сборки пакета.",
+    "sv": "Underhållsversion: interna förbättringar av paketeringen."
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -274,5 +274,5 @@
       "värmeåtervinning"
     ]
   },
-  "version": "45.2.10"
+  "version": "45.2.11"
 }

--- a/app.json
+++ b/app.json
@@ -275,7 +275,7 @@
       "värmeåtervinning"
     ]
   },
-  "version": "45.2.10",
+  "version": "45.2.11",
   "flow": {
     "triggers": [
       {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "com.melcloud",
-  "version": "45.2.10",
+  "version": "45.2.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "com.melcloud",
-      "version": "45.2.10",
+      "version": "45.2.11",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@olivierzal/melcloud-api": "^41.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.melcloud",
-  "version": "45.2.10",
+  "version": "45.2.11",
   "description": "MELCloud for Homey",
   "homepage": "https://github.com/OlivierZal/com.melcloud/",
   "bugs": {


### PR DESCRIPTION
Maintenance bump, no functional changes: exercises the Design-2 packaging (#1424 — bundle emission into `.homeybuild`, package-time `?v=` stamping) through a real store publish, guarded by the post-pack assert (6 bundles + stamped HTML). Expected publish log: esbuild output inside the action's CLI build, assert green, archive ≈ 1 950 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)