### PR TITLE
Pin classic typescript to the typescript-eslint-supported line

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,6 +41,14 @@ updates:
         patterns:
           - '@vitest/*'
           - vitest
+    # The classic `typescript` package intentionally trails on the
+    # newest line typescript-eslint supports (its peer range excludes
+    # TS 7); the real compiler is `@typescript/native`. Re-evaluate
+    # when typescript-eslint announces TypeScript 7 support.
+    ignore:
+      - dependency-name: typescript
+        update-types:
+          - version-update:semver-major
     package-ecosystem: npm
     registries:
       - npm-github

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,13 @@ caught real failures that the others miss:
 - `npm run lint` / `npm run lint:fix` — ESLint (needs its 8 GB heap; also
   lints CSS and HTML via the css/html plugins).
 - `npm run typecheck` — `tsc` from `@typescript/native` (TypeScript 7).
+  The classic `typescript` devDependency stays pinned to the newest line
+  typescript-eslint supports (`~6.0.x`; its peer range excludes TS 7):
+  it exists ONLY for typescript-eslint's type-aware linting — and as the
+  Homey CLI's `usesTypeScript` gate, whose mere PRESENCE makes the CLI
+  run `npm run build` at packaging (removing it would ship bundle-less
+  packages again). Dependabot ignores its majors; move the pin when
+  typescript-eslint announces TypeScript 7 support.
 - `npm test` / `npm run test:coverage` — vitest; branches are at 100%,
   keep them there.
 - `npm run build` — esbuild bundles (`scripts/bundle.mjs`) + `tsc`


### PR DESCRIPTION
typescript-eslint 8.64 peers `typescript >=4.8.4 <6.1.0` — 7.0.2 is out of range (extension's Dependabot #1194 proposed it; closed). The real compiler is already `@typescript/native` (TS 7). Adds a Dependabot ignore for classic-typescript majors + CLAUDE.md doctrine — including the second, app-specific reason the package must never be REMOVED either: its presence is the Homey CLI's `usesTypeScript` gate, which triggers `npm run build` at packaging (dropping it would ship bundle-less packages, the #1404 class). Re-evaluate when typescript-eslint announces TypeScript 7 support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)