### PR TITLE
feat: let each air-to-air group widget disable its animations (45.4.0)

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -556,5 +556,20 @@
     "pl": "Otrzymuj powiadomienie, gdy konto MELCloud wymaga ponownego logowania; próby są wstrzymywane, gdy MELCloud je ogranicza.",
     "ru": "Получайте уведомление, когда учётной записи MELCloud требуется повторный вход; попытки входа приостанавливаются при ограничениях MELCloud.",
     "sv": "Få en avisering när ditt MELCloud-konto behöver en ny inloggning, och inloggningsförsök pausas när MELCloud begränsar dem."
+  },
+  "45.4.0": {
+    "ar": "أصبحت أداة مجموعة الهواء-هواء تتضمن إعداد الرسوم المتحركة لإيقاف المؤثرات المرئية.",
+    "da": "Luft-til-luft-gruppewidgetten har nu en animationsindstilling, så du kan slå de visuelle effekter fra.",
+    "de": "Das Luft-Luft-Gruppen-Widget hat jetzt eine Animationseinstellung, mit der sich die visuellen Effekte abschalten lassen.",
+    "en": "The air-to-air group widget now has an Animations setting, so you can turn the visual effects off.",
+    "es": "El widget de grupo aire-aire ahora tiene un ajuste de animaciones para desactivar los efectos visuales.",
+    "fr": "Le widget de groupe air-air propose désormais un réglage Animations pour désactiver les effets visuels.",
+    "it": "Il widget del gruppo aria-aria ora ha un'impostazione per le animazioni, così puoi disattivare gli effetti visivi.",
+    "ko": "공기-공기 그룹 위젯에 애니메이션 설정이 추가되어 시각 효과를 끌 수 있습니다.",
+    "nl": "De lucht-lucht-groepswidget heeft nu een animatie-instelling, zodat je de visuele effecten kunt uitschakelen.",
+    "no": "Luft-til-luft-gruppewidgeten har nå en animasjonsinnstilling, slik at du kan slå av de visuelle effektene.",
+    "pl": "Widżet grupy powietrze-powietrze ma teraz ustawienie animacji, dzięki któremu można wyłączyć efekty wizualne.",
+    "ru": "У виджета группы «воздух-воздух» появилась настройка анимации, позволяющая отключить визуальные эффекты.",
+    "sv": "Luft-till-luft-gruppwidgeten har nu en animationsinställning så att du kan stänga av de visuella effekterna."
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -274,5 +274,5 @@
       "värmeåtervinning"
     ]
   },
-  "version": "45.3.0"
+  "version": "45.4.0"
 }

--- a/app.json
+++ b/app.json
@@ -275,7 +275,7 @@
       "värmeåtervinning"
     ]
   },
-  "version": "45.3.0",
+  "version": "45.4.0",
   "flow": {
     "triggers": [
       {
@@ -10607,6 +10607,20 @@
             "sv": "Standardzon eller -enhet"
           },
           "type": "autocomplete"
+        },
+        {
+          "id": "animations",
+          "title": {
+            "da": "Animationer",
+            "en": "Animations",
+            "es": "Animaciones",
+            "fr": "Animations",
+            "nl": "Animaties",
+            "no": "Animasjoner",
+            "sv": "Animationer"
+          },
+          "type": "checkbox",
+          "value": true
         }
       ],
       "transparent": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "com.melcloud",
-  "version": "45.3.0",
+  "version": "45.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "com.melcloud",
-      "version": "45.3.0",
+      "version": "45.4.0",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@olivierzal/melcloud-api": "^41.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.melcloud",
-  "version": "45.3.0",
+  "version": "45.4.0",
   "description": "MELCloud for Homey",
   "homepage": "https://github.com/OlivierZal/com.melcloud/",
   "bugs": {

--- a/types/widgets.mts
+++ b/types/widgets.mts
@@ -9,6 +9,9 @@ import type { HomeBuildingZone, HomeDeviceZone } from './zone.mts'
 export const DAYS_MAX = 365
 
 export interface AtaGroupSettingWidgetSettings extends BaseSettings {
+  // Explicit false is the only opt-out: instances placed before this setting
+  // existed report null and must keep animating.
+  readonly animations: boolean | null
   // Classic zone collections and devices, plus the Home buildings
   // (account-level groups) and their devices.
   readonly default_zone: Classic.Zone | HomeBuildingZone | HomeDeviceZone | null

--- a/widgets/ata-group-setting/public/animation.mts
+++ b/widgets/ata-group-setting/public/animation.mts
@@ -6,7 +6,10 @@ import {
 } from '@olivierzal/melcloud-api/constants'
 
 import type { GroupAtaStates } from '../../../types/classic-ata.mts'
-import type { GetAtaOptions } from '../../../types/widgets.mts'
+import type {
+  GetAtaOptions,
+  AtaGroupSettingWidgetSettings as HomeySettings,
+} from '../../../types/widgets.mts'
 import { getSelect } from '../../../public/dom.mts'
 import {
   type Homey,
@@ -111,6 +114,11 @@ const resolveMemberScene = (
   modes: readonly number[],
 ): ReadonlySet<SceneElement> =>
   new Set(modes.flatMap((mode) => MODE_SCENES[mode] ?? []))
+
+// Explicit false is the only opt-out: instances placed before this setting
+// existed report null and must keep animating.
+const areAnimationsEnabled = (homey: Homey<HomeySettings>): boolean =>
+  homey.getSettings().animations !== false
 
 // Queried lazily so module evaluation stays side-effect-free, and so each
 // animation pass reads the current OS preference.
@@ -433,7 +441,7 @@ export class AnimationController {
 
   #generation = 0
 
-  readonly #homey: Homey
+  readonly #homey: Homey<HomeySettings>
 
   #isFireActive = false
 
@@ -445,7 +453,10 @@ export class AnimationController {
 
   #sunShine: Animation | null = null
 
-  public constructor(homey: Homey, animationElement: HTMLDivElement) {
+  public constructor(
+    homey: Homey<HomeySettings>,
+    animationElement: HTMLDivElement,
+  ) {
     this.#homey = homey
     this.#animation = animationElement
     this.#animationMapping = createAnimationMapping()
@@ -743,7 +754,11 @@ export class AnimationController {
     state: Classic.GroupState,
   ): Promise<ReadonlySet<SceneElement> | null> {
     const { isSomethingOn, newMode } = parseStateParams(state)
-    if (!isSomethingOn || prefersReducedMotion()) {
+    if (
+      !isSomethingOn ||
+      !areAnimationsEnabled(this.#homey) ||
+      prefersReducedMotion()
+    ) {
       return new Set()
     }
     if (newMode !== CLASSIC_OPERATION_MODE_MIXED) {

--- a/widgets/ata-group-setting/widget.compose.json
+++ b/widgets/ata-group-setting/widget.compose.json
@@ -75,6 +75,20 @@
         "sv": "Standardzon eller -enhet"
       },
       "type": "autocomplete"
+    },
+    {
+      "id": "animations",
+      "title": {
+        "da": "Animationer",
+        "en": "Animations",
+        "es": "Animaciones",
+        "fr": "Animations",
+        "nl": "Animaties",
+        "no": "Animasjoner",
+        "sv": "Animationer"
+      },
+      "type": "checkbox",
+      "value": true
     }
   ],
   "transparent": true


### PR DESCRIPTION
## User request

Add a **“Disable animations”** option to the `ata-group-setting` widget.

## Design

- **Per-widget setting, not app-wide**: an `animations` **checkbox in `widget.compose.json`** (default **checked**), so each dashboard instance decides for itself — same surface and locale set (×7) as the sibling `default_zone`.
- **Positive boolean** (`animations: true` = animate) per repo naming doctrine; unticking it is the requested “disable”.
- **Gate co-located with `prefers-reduced-motion`** in `#resolveScene`: the setting joins the existing condition that resolves to the **empty scene**, so `#reset` tears down any running scene and *every* apply path is covered — state updates **and** the `visibilitychange` replay of `#lastState`. No new code path, no orchestration change.
- **Null-safe opt-out**: `readonly animations: boolean | null` — instances placed **before** this setting existed report `null` and must keep animating, so only explicit `false` disables (`!== false`).
- `AnimationController` now types its `Homey` handle with the widget's settings (`Homey<AtaGroupSettingWidgetSettings>`), read per pass like the OS preference.

## Release

45.4.0, changelog ×13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)