### PR TITLE
chore: pick up melcloud-api 41.2.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1065,9 +1065,9 @@
       }
     },
     "node_modules/@olivierzal/melcloud-api": {
-      "version": "41.2.1",
-      "resolved": "https://npm.pkg.github.com/download/@olivierzal/melcloud-api/41.2.1/2ea224a1724105de9d90949158e7ca7912f37839",
-      "integrity": "sha512-7Lsl1YRKxJqBvbSYEUu4P1HzYS/QhpBa/7Zlv3kF6igUJ0DC17gyJW3Jy3DL05//JAixHF6cNylzM9eV1XYnCw==",
+      "version": "41.2.3",
+      "resolved": "https://npm.pkg.github.com/download/@olivierzal/melcloud-api/41.2.3/e0b13bc8121887233c804c647f1e69ba8c0e452a",
+      "integrity": "sha512-Ei2uisXycPNNvbx4LsYFQRK8010VwpotJyEOObn7UxJ/MrwC02EfPJ5Z9gINLpo9Flm7uTmDg+LymwbcX91ugA==",
       "license": "MIT",
       "dependencies": {
         "temporal-polyfill": "^1.0.1",


### PR DESCRIPTION
Rattrapage de course de merge : #1432 a été mergée avant mes deux refreshs de lockfile, qui ont donc atterri sur la branche morte. Refaits ici depuis main pour que **45.6.0 embarque melcloud-api 41.2.3** :

- **41.2.2** — sentinel an-1 en dialecte instant filtré (les lignes « 1 janv. 1 » disparaissent du log au lieu d'afficher « — »),
- **41.2.3** — refus OIDC Home classés `AuthenticationError` (backoff + notification engagés, raison Cognito dans le message — les 2 diagnostics utilisateurs).

Lockfile uniquement (le range `^41.2.0` couvre déjà).

🤖 Generated with [Claude Code](https://claude.com/claude-code)