### PR TITLE
fix: instant boot and clean shutdown for the API clients (45.6.1)

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -601,5 +601,20 @@
     "pl": "Historia błędów w ustawieniach aplikacji łączy teraz urządzenia Classic i Home, posortowana chronologicznie.",
     "ru": "История ошибок в настройках приложения теперь объединяет устройства Classic и Home в хронологическом порядке.",
     "sv": "Felhistoriken i appinställningarna samlar nu Classic- och Home-enheter, kronologiskt sorterade."
+  },
+  "45.6.1": {
+    "ar": "أصبح التطبيق يبدأ فوراً حتى عندما يستجيب MELCloud ببطء — إصلاح مهلات بدء التشغيل على أجهزة Homey الأقدم.",
+    "da": "Appen starter nu med det samme, selv når MELCloud svarer langsomt — det retter opstarts-timeouts på ældre Homeys.",
+    "de": "Die App startet jetzt sofort, auch wenn MELCloud langsam antwortet — behebt Start-Timeouts auf älteren Homeys.",
+    "en": "The app now starts instantly even when MELCloud responds slowly — fixing startup timeouts on older Homeys.",
+    "es": "La app ahora se inicia al instante aunque MELCloud responda lento — corrige los tiempos de espera de arranque en Homeys antiguos.",
+    "fr": "L'app démarre désormais instantanément même quand MELCloud répond lentement — corrige les délais d'attente au démarrage sur les anciens Homey.",
+    "it": "L'app ora si avvia istantaneamente anche quando MELCloud risponde lentamente — risolve i timeout di avvio sui Homey meno recenti.",
+    "ko": "MELCloud 응답이 느려도 앱이 즉시 시작됩니다 — 구형 Homey의 시작 시간 초과 문제를 해결합니다.",
+    "nl": "De app start nu direct, ook wanneer MELCloud traag reageert — dit verhelpt opstart-time-outs op oudere Homeys.",
+    "no": "Appen starter nå umiddelbart selv når MELCloud svarer tregt — retter oppstarts-tidsavbrudd på eldre Homeyer.",
+    "pl": "Aplikacja uruchamia się teraz natychmiast, nawet gdy MELCloud odpowiada wolno — naprawia przekroczenia czasu uruchamiania na starszych Homey.",
+    "ru": "Приложение теперь запускается мгновенно, даже если MELCloud отвечает медленно — исправляет тайм-ауты запуска на старых Homey.",
+    "sv": "Appen startar nu direkt även när MELCloud svarar långsamt — åtgärdar starttimeouts på äldre Homey-enheter."
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -274,5 +274,5 @@
       "värmeåtervinning"
     ]
   },
-  "version": "45.6.0"
+  "version": "45.6.1"
 }

--- a/app.json
+++ b/app.json
@@ -275,7 +275,7 @@
       "värmeåtervinning"
     ]
   },
-  "version": "45.6.0",
+  "version": "45.6.1",
   "flow": {
     "triggers": [
       {

--- a/app.mts
+++ b/app.mts
@@ -339,6 +339,11 @@ export default class MELCloudApp extends App {
     return this.#homeApi
   }
 
+  // One shutdown signal for both API clients: onUninit aborts it so
+  // in-flight requests cannot outlive the app instance (the SDK's
+  // post-destroy accesses came from exactly those danglers).
+  readonly #abortController = new AbortController()
+
   #classicApi!: Classic.API
 
   #facadeManager!: Classic.FacadeManager
@@ -369,6 +374,7 @@ export default class MELCloudApp extends App {
   }
 
   public override async onUninit(): Promise<void> {
+    this.#abortController.abort()
     this.#classicApi.clearSync()
     this.#homeApi.clearSync()
     await Promise.resolve()
@@ -1000,6 +1006,7 @@ export default class MELCloudApp extends App {
   }): Promise<void> {
     this.#classicApi = await Classic.API.create({
       ...config,
+      abortSignal: this.#abortController.signal,
       events: {
         onSyncComplete: this.#onSync,
         onAuthenticationLost: () => {
@@ -1008,6 +1015,7 @@ export default class MELCloudApp extends App {
       },
       logger: this.#createLogger(),
       settingManager: this.#createSettingManager(),
+      shouldResumeSessionInBackground: true,
     })
     this.#facadeManager = new Classic.FacadeManager(
       this.#classicApi,
@@ -1018,14 +1026,19 @@ export default class MELCloudApp extends App {
 
   // Mirrors #initClassicApi: create + facade wiring, no fetch. The
   // boot-time registry contract lives in melcloud-api, identically for
-  // both APIs — `create()` populates the registry and arms the auto-sync
-  // whenever a session or credentials are available, `authenticate()`
-  // enforces a post-auth sync, and no credentials means total silence.
+  // both APIs — the session restore runs in the BACKGROUND
+  // (`shouldResumeSessionInBackground`), so `create()` returns
+  // immediately and `onInit` stays within the SDK's 30-second ready
+  // budget on slow devices and networks; the restore then populates the
+  // registry and arms the auto-sync whenever a session or credentials
+  // are available, `authenticate()` enforces a post-auth sync, and no
+  // credentials means total silence.
   // An app-side `list()` here would duplicate that fetch when
   // authenticated and, for a Classic-only user, 401 — and keep 401ing
   // every cycle, since `runSyncCycle` reschedules from its `finally`.
   async #initHomeApi(): Promise<void> {
     this.#homeApi = await Home.API.create({
+      abortSignal: this.#abortController.signal,
       events: {
         onSyncComplete: this.#onSync,
         onAuthenticationLost: () => {
@@ -1034,6 +1047,7 @@ export default class MELCloudApp extends App {
       },
       logger: this.#createLogger(),
       settingManager: this.#createSettingManager('home'),
+      shouldResumeSessionInBackground: true,
     })
     this.#homeFacadeManager = new Home.FacadeManager(this.#homeApi)
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "com.melcloud",
-  "version": "45.6.0",
+  "version": "45.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "com.melcloud",
-      "version": "45.6.0",
+      "version": "45.6.1",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@olivierzal/melcloud-api": "^41.2.0",
@@ -1065,9 +1065,9 @@
       }
     },
     "node_modules/@olivierzal/melcloud-api": {
-      "version": "41.2.3",
-      "resolved": "https://npm.pkg.github.com/download/@olivierzal/melcloud-api/41.2.3/e0b13bc8121887233c804c647f1e69ba8c0e452a",
-      "integrity": "sha512-Ei2uisXycPNNvbx4LsYFQRK8010VwpotJyEOObn7UxJ/MrwC02EfPJ5Z9gINLpo9Flm7uTmDg+LymwbcX91ugA==",
+      "version": "41.3.0",
+      "resolved": "https://npm.pkg.github.com/download/@olivierzal/melcloud-api/41.3.0/0331c66aa33899dbc5de33015dad4bd976190079",
+      "integrity": "sha512-lrE6LOrbJYzymdnx2t6ZWuCdqg8gvhGDUMKTnR5loutv0YSg59GQKF4OeZjRNTScLXO50eQvQeu9QFHwPKpl3g==",
       "license": "MIT",
       "dependencies": {
         "temporal-polyfill": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.melcloud",
-  "version": "45.6.0",
+  "version": "45.6.1",
   "description": "MELCloud for Homey",
   "homepage": "https://github.com/OlivierZal/com.melcloud/",
   "bugs": {

--- a/tests/unit/app.test.ts
+++ b/tests/unit/app.test.ts
@@ -474,13 +474,16 @@ describe('melCloudApp', () => {
 
       expect(mockCreate).toHaveBeenCalledWith(
         expect.objectContaining({
+          abortSignal: expect.any(AbortSignal) as unknown,
           language: 'en',
           locale: 'en',
+          shouldResumeSessionInBackground: true,
           timezone: 'Europe/Paris',
         }),
       )
       expect(mockHomeCreate).toHaveBeenCalledWith(
         expect.objectContaining({
+          abortSignal: expect.any(AbortSignal) as unknown,
           logger: expect.objectContaining({
             error: expect.any(Function) as unknown,
             log: expect.any(Function) as unknown,
@@ -489,6 +492,7 @@ describe('melCloudApp', () => {
             get: expect.any(Function) as unknown,
             set: expect.any(Function) as unknown,
           }),
+          shouldResumeSessionInBackground: true,
         }),
       )
       expect(Classic.FacadeManager).toHaveBeenCalledTimes(1)
@@ -590,6 +594,21 @@ describe('melCloudApp', () => {
 
       expect(mockApiInstance.clearSync).toHaveBeenCalledTimes(1)
       expect(mockHomeApiInstance.clearSync).toHaveBeenCalledTimes(1)
+    })
+
+    it('should abort the shutdown signal shared with the API clients', async () => {
+      await app.onInit()
+      const signal = getMockCallArg<{ abortSignal: AbortSignal }>(
+        mockCreate,
+        0,
+        0,
+      ).abortSignal
+
+      expect(signal.aborted).toBe(false)
+
+      await app.onUninit()
+
+      expect(signal.aborted).toBe(true)
     })
   })
 


### PR DESCRIPTION
## Diagnostic `ready_timeout` (Homey Early 2018, v45.4.0) — les deux volets

### 1. Boot instantané
`onInit` attendait les deux `create()` — restauration de session incluse (probe + login complet, chaîne OIDC Cognito côté Home, sous policies de retry) : > 30 s possibles sur Homey lent + réseau lent → `ready_timeout`. Les deux clients passent `shouldResumeSessionInBackground: true` (melcloud-api **41.3.0**) : `create()` rend la main immédiatement, la restauration part en arrière-plan avec le contrat lifecycle inchangé (auto-sync, `onAuthenticationLost`, backoff). `onInit` se résout en millisecondes sur tous les appareils.

### 2. Arrêt propre (le manque relevé par l'audit des hooks)
L'erreur collatérale « app instance has been destroyed » venait des requêtes en vol survivant au teardown — l'option `abortSignal` documentée par la lib n'était pas câblée. Un `AbortController` unique alimente les deux clients et `onUninit` l'`abort()` : plus rien ne traîne après la mort de l'app.

Tests : les deux configs vérifiées (option + signal), et le signal capturé est bien `aborted` après `onUninit`. Lockfile → 41.3.0. Release 45.6.1, changelog ×13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)