### PR TITLE
chore(release): 45.7.1 — charts fixes rollup

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -631,5 +631,20 @@
     "pl": "Widżet wykresów obejmuje teraz także urządzenia MELCloud Home i dodaje wykres raportu energii dla wszystkich urządzeń.",
     "ru": "Виджет графиков теперь охватывает и устройства MELCloud Home, а для всех устройств добавлен график отчёта об энергии.",
     "sv": "Diagramwidgeten täcker nu även MELCloud Home-enheter och lägger till ett energirapportdiagram för alla enheter."
+  },
+  "45.7.1": {
+    "ar": "فترات الرسوم البيانية تتبع الأيام التقويمية، وألوان السلاسل متناسقة بين الرسوم، والنطاقات الواسعة تُحمَّل بشكل موثوق.",
+    "da": "Diagramperioder følger kalenderdage, seriefarver er ensartede på tværs af diagrammer, og brede visninger indlæses pålideligt.",
+    "de": "Diagrammzeiträume folgen Kalendertagen, Serienfarben sind diagrammübergreifend einheitlich, und breite Ansichten laden zuverlässig.",
+    "en": "Chart periods follow calendar days, series colors are consistent across charts, and wide views load reliably.",
+    "es": "Los períodos de los gráficos siguen días naturales, los colores de las series son coherentes entre gráficos y las vistas amplias cargan de forma fiable.",
+    "fr": "Les périodes des graphiques suivent les jours calendaires, les couleurs des séries sont cohérentes d'un graphique à l'autre, et les vues larges se chargent de manière fiable.",
+    "it": "I periodi dei grafici seguono i giorni di calendario, i colori delle serie sono coerenti tra i grafici e le viste ampie si caricano in modo affidabile.",
+    "ko": "차트 기간이 달력 일자를 따르고, 시리즈 색상이 차트 간에 일관되며, 넓은 범위도 안정적으로 로드됩니다.",
+    "nl": "Grafiekperiodes volgen kalenderdagen, seriekleuren zijn consistent tussen grafieken, en brede weergaven laden betrouwbaar.",
+    "no": "Diagramperioder følger kalenderdager, seriefarger er konsistente på tvers av diagrammer, og brede visninger lastes pålitelig.",
+    "pl": "Okresy wykresów odpowiadają dniom kalendarzowym, kolory serii są spójne między wykresami, a szerokie widoki ładują się niezawodnie.",
+    "ru": "Периоды графиков соответствуют календарным дням, цвета серий согласованы между графиками, а широкие диапазоны загружаются надёжно.",
+    "sv": "Diagramperioder följer kalenderdagar, seriefärger är konsekventa mellan diagram, och breda vyer laddas tillförlitligt."
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -274,5 +274,5 @@
       "värmeåtervinning"
     ]
   },
-  "version": "45.7.0"
+  "version": "45.7.1"
 }

--- a/app.json
+++ b/app.json
@@ -275,7 +275,7 @@
       "värmeåtervinning"
     ]
   },
-  "version": "45.7.0",
+  "version": "45.7.1",
   "flow": {
     "triggers": [
       {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "com.melcloud",
-  "version": "45.7.0",
+  "version": "45.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "com.melcloud",
-      "version": "45.7.0",
+      "version": "45.7.1",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@olivierzal/melcloud-api": "^42.0.0",
@@ -1065,9 +1065,9 @@
       }
     },
     "node_modules/@olivierzal/melcloud-api": {
-      "version": "42.0.3",
-      "resolved": "https://npm.pkg.github.com/download/@olivierzal/melcloud-api/42.0.3/38ecadd6790d84d8d251bfc4f5feb60dfd6a64b2",
-      "integrity": "sha512-l559FSxSEeSHEV3itpL1sn66qWsT49DfGaEI7BThqkYRlcxgbJ8/C3lgk2iQ6GgTBnB1AgZRfWFcVH/mnl6ObA==",
+      "version": "42.0.5",
+      "resolved": "https://npm.pkg.github.com/download/@olivierzal/melcloud-api/42.0.5/7113b3c280cf59b9d15762142469d5516755200c",
+      "integrity": "sha512-bad5YH0xWsaEpok17cqkV+fpU1k8QVMwn0xCqWg3UXUrU3Dq2Lnkd3tjtZmLjE0LeE2MjCyOJvU+d7EVa+Cx/Q==",
       "license": "MIT",
       "dependencies": {
         "temporal-polyfill": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.melcloud",
-  "version": "45.7.0",
+  "version": "45.7.1",
   "description": "MELCloud for Homey",
   "homepage": "https://github.com/OlivierZal/com.melcloud/",
   "bugs": {

--- a/widgets/charts/public/index.mts
+++ b/widgets/charts/public/index.mts
@@ -904,14 +904,16 @@ class ChartWidget {
     applySelectValue(this.#zoneSelect, getZoneId(id, model))
   }
 
-  // «24 h» exists only where hourly energy buckets do — every report
-  // device except Classic ATW, whose wire never buckets under a day.
+  // «24 h» is the rolling intra-day view every day chart offers —
+  // midnight-anchored windows start near-empty each morning. The one
+  // exception is the Classic ATW report, whose wire never buckets
+  // energy under a day.
   #buildLast24HoursGate(classicAtw: readonly ChartDeviceZone[]): () => boolean {
     const dailyOnlyZones = new Set(
       classicAtw.map(({ id, model }) => getZoneId(id, model)),
     )
     return () =>
-      this.#getChart() === 'report' &&
+      this.#getChart() !== 'report' ||
       !dailyOnlyZones.has(this.#zoneSelect.value)
   }
 


### PR DESCRIPTION
Rolls up the post-45.7.0 on-device feedback into a store patch:

- **Lib 42.0.5** (lockfile): calendar-day energy buckets with date labels, fixed Classic ATA multi-day crash, faithful mode bands/durations (Weekly-truncation workaround), band load budget (bands only on the hourly grid — daily grids inflated them into a solid dark wall and wide fan-outs outlived the widget's 10 s budget; ~9 s per comfort-graph call at the BFF, probed).
- **Widget**: the rolling «24 h» picker entry extends to the temperatures and operation-modes charts — midnight-anchored windows start near-empty each morning (a quiet morning renders a 100 % «Arrêt» pie on «1 jour», live-probed); «24 h» is the intra-day view. Still hidden for the Classic ATW report only (no hourly energy on that wire).
- Version 45.7.1, store changelog ×13.

Suite: 635 tests, 100 % branches, validate publish-level clean. Installed on the Homey.

🤖 Generated with [Claude Code](https://claude.com/claude-code)