### PR TITLE
chore(release): 45.7.2 — persisted login backoff

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -646,5 +646,20 @@
     "pl": "Okresy wykresów odpowiadają dniom kalendarzowym, kolory serii są spójne między wykresami, a szerokie widoki ładują się niezawodnie.",
     "ru": "Периоды графиков соответствуют календарным дням, цвета серий согласованы между графиками, а широкие диапазоны загружаются надёжно.",
     "sv": "Diagramperioder följer kalenderdagar, seriefärger är konsekventa mellan diagram, och breda vyer laddas tillförlitligt."
+  },
+  "45.7.2": {
+    "ar": "يُحترم الآن إيقاف تسجيل الدخول المؤقت بعد رفض بيانات الاعتماد حتى بعد إعادة تشغيل التطبيق.",
+    "da": "Login-pausen efter afviste legitimationsoplysninger respekteres nu også efter en genstart af appen.",
+    "de": "Die Anmeldepause nach abgelehnten Zugangsdaten wird nun auch nach einem App-Neustart eingehalten.",
+    "en": "The sign-in pause after rejected credentials is now respected across app restarts.",
+    "es": "La pausa de inicio de sesión tras credenciales rechazadas ahora se respeta incluso tras reiniciar la aplicación.",
+    "fr": "La pause de connexion après des identifiants rejetés est désormais respectée même après un redémarrage de l'app.",
+    "it": "La pausa di accesso dopo credenziali rifiutate ora viene rispettata anche dopo un riavvio dell'app.",
+    "ko": "거부된 자격 증명 후의 로그인 일시 중지가 이제 앱 재시작 후에도 유지됩니다.",
+    "nl": "De aanmeldpauze na geweigerde inloggegevens wordt nu ook na een herstart van de app gerespecteerd.",
+    "no": "Påloggingspausen etter avviste påloggingsopplysninger respekteres nå også etter en omstart av appen.",
+    "pl": "Pauza logowania po odrzuconych danych uwierzytelniających jest teraz zachowywana także po ponownym uruchomieniu aplikacji.",
+    "ru": "Пауза входа после отклонённых учётных данных теперь соблюдается и после перезапуска приложения.",
+    "sv": "Inloggningspausen efter avvisade autentiseringsuppgifter respekteras nu även efter en omstart av appen."
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -274,5 +274,5 @@
       "värmeåtervinning"
     ]
   },
-  "version": "45.7.1"
+  "version": "45.7.2"
 }

--- a/app.json
+++ b/app.json
@@ -275,7 +275,7 @@
       "värmeåtervinning"
     ]
   },
-  "version": "45.7.1",
+  "version": "45.7.2",
   "flow": {
     "triggers": [
       {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "com.melcloud",
-  "version": "45.7.1",
+  "version": "45.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "com.melcloud",
-      "version": "45.7.1",
+      "version": "45.7.2",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@olivierzal/melcloud-api": "^42.0.0",
@@ -1065,9 +1065,9 @@
       }
     },
     "node_modules/@olivierzal/melcloud-api": {
-      "version": "42.0.5",
-      "resolved": "https://npm.pkg.github.com/download/@olivierzal/melcloud-api/42.0.5/7113b3c280cf59b9d15762142469d5516755200c",
-      "integrity": "sha512-bad5YH0xWsaEpok17cqkV+fpU1k8QVMwn0xCqWg3UXUrU3Dq2Lnkd3tjtZmLjE0LeE2MjCyOJvU+d7EVa+Cx/Q==",
+      "version": "42.0.6",
+      "resolved": "https://npm.pkg.github.com/download/@olivierzal/melcloud-api/42.0.6/a28340138a252b2b4461dcd9cc0e17ac9ac5f655",
+      "integrity": "sha512-rZCkLtORHoHYJkrRf82cC3pLSnfZKLHaTx89JkiQ6R6a0DGff3ENxO5z3HLXcTb5MccyR2KcyKydGkjd/ppcPQ==",
       "license": "MIT",
       "dependencies": {
         "temporal-polyfill": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.melcloud",
-  "version": "45.7.1",
+  "version": "45.7.2",
   "description": "MELCloud for Homey",
   "homepage": "https://github.com/OlivierZal/com.melcloud/",
   "bugs": {


### PR DESCRIPTION
Ships melcloud-api 42.0.6 (lockfile): the automatic login backoff now persists its deadline through the setting store, so app restarts respect the pause — a store diagnostic (v45.6.1) showed four rejected Cognito sign-ins within 70 seconds across restarts, each fresh instance re-attempting despite the announced 15-minute pause. Classic and Home gates stay fully independent (the app's per-API key prefixing covers the new key), and the user-facing session-lost notification still fires on every failed boot resume.

Version 45.7.2, store changelog ×13. Suite: 635 tests, 100 % branches, validate publish-level clean. Installed on the Homey.

🤖 Generated with [Claude Code](https://claude.com/claude-code)