### PR TITLE
feat: settings polish round 2 — homeyCallback, per-group fieldsets, credential hints (45.7.5)

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -691,5 +691,20 @@
     "pl": "Poprawki: konto Home z samymi urządzeniami ATW pokazuje swoje urządzenia w ustawieniach, kolory serii temperatur zadanych stref, data „od\" w dzienniku błędów i tłumaczenia widżetów w 13 językach.",
     "ru": "Исправления: учётная запись Home только с устройствами ATW показывает свои устройства в настройках, цвета серий заданной температуры зон, дата «с» в журнале ошибок и переводы виджетов на 13 языков.",
     "sv": "Rättelser: ett Home-konto med enbart ATW-enheter visar sina enheter i inställningarna, färger för zonbörvärdesserier, \"sedan\"-datumet i felloggen och widgetöversättningar på 13 språk."
+  },
+  "45.7.5": {
+    "ar": "تحسينات صفحة الإعدادات: مجموعات خيارات أصلية لكل مجموعة، وتلميحات مدير كلمات المرور لحقول الاعتماد.",
+    "da": "Forbedringer af indstillingssiden: korrekte grupper pr. sektion og adgangskodeadministrator-hint til loginfelterne.",
+    "de": "Verbesserungen der Einstellungsseite: korrekte Gruppen pro Abschnitt und Passwortmanager-Hinweise für die Anmeldefelder.",
+    "en": "Settings page refinements: proper per-group sections and password-manager hints on the credential fields.",
+    "es": "Mejoras de la página de ajustes: secciones correctas por grupo y sugerencias del gestor de contraseñas en los campos de acceso.",
+    "fr": "Améliorations de la page de réglages : sections correctes par groupe et aides du gestionnaire de mots de passe sur les champs d'identifiants.",
+    "it": "Miglioramenti della pagina delle impostazioni: sezioni corrette per gruppo e suggerimenti del gestore password sui campi delle credenziali.",
+    "ko": "설정 페이지 개선: 그룹별 올바른 섹션 및 자격 증명 필드의 비밀번호 관리자 힌트.",
+    "nl": "Verbeteringen aan de instellingenpagina: correcte secties per groep en wachtwoordmanager-hints voor de inlogvelden.",
+    "no": "Forbedringer av innstillingssiden: riktige seksjoner per gruppe og passordbehandler-hint for påloggingsfeltene.",
+    "pl": "Ulepszenia strony ustawień: poprawne sekcje dla każdej grupy i podpowiedzi menedżera haseł w polach logowania.",
+    "ru": "Улучшения страницы настроек: корректные секции по группам и подсказки менеджера паролей в полях учётных данных.",
+    "sv": "Förbättringar av inställningssidan: korrekta sektioner per grupp och lösenordshanterartips för inloggningsfälten."
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -282,5 +282,5 @@
       "värmeåtervinning"
     ]
   },
-  "version": "45.7.4"
+  "version": "45.7.5"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,9 +163,12 @@ coverage.
   stamps the PACKAGED `.homeybuild` page copies — only inside an
   attribute/import context, never a comment — with a content hash
   (`?v=`): phone webviews cache assets across app versions; the source
-  HTML stays unstamped. Webview code must stick to es2020-era
-  runtime APIs (no `Object.groupBy` & co.): esbuild lowers syntax only,
-  and old iOS engines are real. Never load the bundle as a STATIC
+  HTML stays unstamped. Webview runtime-API floor: es2023 array
+  methods are accepted (`toSorted`/`toReversed` — the lint mandates
+  them and they ship today), but nothing newer — no iterator helpers
+  (`.entries().map()`, 2025-era), no `Object.groupBy` & co.: esbuild
+  lowers syntax only, and old iOS engines are real. Never load the
+  bundle as a STATIC
   `<script type="module">`: 45.2.5 shipped that and every webview spun
   forever on a cold open (proven with breadcrumbs over `homey app run`;
   reverted). Dynamic `import()` is merely unnecessary, not broken — its

--- a/app.json
+++ b/app.json
@@ -283,7 +283,7 @@
       "värmeåtervinning"
     ]
   },
-  "version": "45.7.4",
+  "version": "45.7.5",
   "flow": {
     "triggers": [
       {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "com.melcloud",
-  "version": "45.7.4",
+  "version": "45.7.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "com.melcloud",
-      "version": "45.7.4",
+      "version": "45.7.5",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@olivierzal/melcloud-api": "^42.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.melcloud",
-  "version": "45.7.4",
+  "version": "45.7.5",
   "description": "MELCloud for Homey",
   "homepage": "https://github.com/OlivierZal/com.melcloud/",
   "bugs": {

--- a/settings/index.mts
+++ b/settings/index.mts
@@ -38,23 +38,24 @@ import { getZoneId, getZoneName, getZonePath } from '../public/zones.mts'
 
 // ── Helpers ──
 
-// Wraps Homey's callback-based settings API in a Promise for async/await usage
-const createCallback =
-  <T,>(
-    resolve: (value: T) => void,
-    reject: (reason: Error) => void,
-  ): ((error: Error | null, data: T) => void) =>
-  (error, data) => {
-    if (error !== null) {
-      reject(error)
-      return
-    }
-    resolve(data)
-  }
+// Promisifies any error-first Homey settings callback (the extension's
+// idiom, aligned here so the two apps share one promisification form).
+const homeyCallback = async <T,>(
+  call: (callback: (error: Error | null, result: T) => void) => void,
+): Promise<T> =>
+  new Promise((resolve, reject) => {
+    call((error, result) => {
+      if (error !== null) {
+        reject(error)
+        return
+      }
+      resolve(result)
+    })
+  })
 
 const homeyApiGet = async <T,>(homey: Homey, path: string): Promise<T> =>
-  new Promise((resolve, reject) => {
-    homey.api('GET', path, createCallback(resolve, reject))
+  homeyCallback((callback) => {
+    homey.api('GET', path, callback)
   })
 
 const homeyApiPost = async <T,>(
@@ -62,8 +63,8 @@ const homeyApiPost = async <T,>(
   path: string,
   body: unknown,
 ): Promise<T> =>
-  new Promise((resolve, reject) => {
-    homey.api('POST', path, body, createCallback(resolve, reject))
+  homeyCallback((callback) => {
+    homey.api('POST', path, body, callback)
   })
 
 const homeyApiPut = async <T,>(
@@ -71,19 +72,66 @@ const homeyApiPut = async <T,>(
   path: string,
   body: unknown,
 ): Promise<T> =>
-  new Promise((resolve, reject) => {
-    homey.api('PUT', path, body, createCallback(resolve, reject))
+  homeyCallback((callback) => {
+    homey.api('PUT', path, body, callback)
   })
 
 const homeyApiDelete = async (homey: Homey, path: string): Promise<void> =>
-  new Promise((resolve, reject) => {
-    homey.api('DELETE', path, createCallback(resolve, reject))
+  homeyCallback((callback) => {
+    homey.api('DELETE', path, callback)
   })
 
 const homeyConfirm = async (homey: Homey, message: string): Promise<boolean> =>
-  new Promise((resolve, reject) => {
-    homey.confirm(message, null, createCallback(resolve, reject))
+  homeyCallback((callback) => {
+    homey.confirm(message, null, callback)
   })
+
+interface CheckboxGroup {
+  readonly label: string
+  readonly settings: DriverSetting[]
+}
+
+const openGroup = (groups: CheckboxGroup[], label: string): DriverSetting[] => {
+  const settings: DriverSetting[] = []
+  groups.push({ label, settings })
+  return settings
+}
+
+// Checkbox settings grouped by consecutive group label (a repeated
+// label later in the list deliberately opens a new group, matching the
+// manifest order).
+const groupCheckboxSettings = (
+  driverSetting: readonly DriverSetting[],
+): CheckboxGroup[] => {
+  const checkboxes = driverSetting.filter(({ type }) => type === 'checkbox')
+  const groups: CheckboxGroup[] = []
+  let current: DriverSetting[] = []
+  let currentLabel: string | null = null
+  for (const setting of checkboxes) {
+    if ((setting.groupLabel ?? '') !== currentLabel) {
+      currentLabel = setting.groupLabel ?? ''
+      current = openGroup(groups, currentLabel)
+    }
+    current.push(setting)
+  }
+  return groups
+}
+
+// Password-manager and keyboard hints: the username is an email
+// address, so iOS auto-capitalization and autocorrect only get in the
+// way.
+const applyCredentialHints = (
+  input: HTMLInputElement,
+  credentialKey: keyof LoginCredentials,
+): void => {
+  if (credentialKey === 'password') {
+    input.autocomplete = 'current-password'
+    return
+  }
+  input.autocomplete = 'username'
+  input.autocapitalize = 'none'
+  input.spellcheck = false
+}
 
 // ── DOM helpers ──
 
@@ -562,6 +610,7 @@ class AuthManager {
     if (loginSetting !== undefined) {
       const { id, placeholder, title, type } = loginSetting
       const formControl = createInput({ id, placeholder, type })
+      applyCredentialHints(formControl, credentialKey)
       appendFormControl(this.#loginSection, { formControl, title })
       return formControl
     }
@@ -736,11 +785,30 @@ class DeviceSettingsManager {
     return settings
   }
 
-  #createCheckboxSet(driverSetting: DriverSetting[]): HTMLFieldSetElement {
+  // One fieldset per checkbox group, its (single) legend as first
+  // child: several legends in one fieldset are invalid HTML and screen
+  // readers name the whole set after the first one only.
+  #createCheckboxSet(
+    label: string,
+    settings: DriverSetting[],
+  ): HTMLFieldSetElement {
     const checkboxSet = document.createElement('fieldset')
     checkboxSet.classList.add('homey-form-checkbox-set')
-    this.#createDriverSettingControls(driverSetting, checkboxSet)
+    if (label !== '') {
+      createLegend(checkboxSet, label)
+    }
+    for (const { driverId, id, title } of settings) {
+      const formControl = createCheckbox(id, driverId)
+      appendFormControl(checkboxSet, { formControl, title }, false)
+      this.#updateDriverSetting(formControl)
+    }
     return checkboxSet
+  }
+
+  #createCheckboxSets(driverSetting: DriverSetting[]): HTMLFieldSetElement[] {
+    return groupCheckboxSettings(driverSetting).map(({ label, settings }) =>
+      this.#createCheckboxSet(label, settings),
+    )
   }
 
   #createCommonSettingControls(
@@ -767,32 +835,6 @@ class DeviceSettingsManager {
     ])
   }
 
-  #createDriverSettingControls(
-    driverSetting: DriverSetting[],
-    fieldSet: HTMLFieldSetElement,
-  ): void {
-    let previousGroupLabel = ''
-    for (const {
-      driverId,
-      groupLabel = '',
-      id,
-      title,
-      type,
-    } of driverSetting) {
-      if (type !== 'checkbox') {
-        continue
-      }
-
-      if (groupLabel !== previousGroupLabel) {
-        previousGroupLabel = groupLabel
-        createLegend(fieldSet, groupLabel)
-      }
-      const formControl = createCheckbox(id, driverId)
-      appendFormControl(fieldSet, { formControl, title }, false)
-      this.#updateDriverSetting(formControl)
-    }
-  }
-
   // One section per driver that has devices, built from the driver's own
   // settings — legend is the driver's manifest name, so adding a driver
   // needs no markup. The buttons' snake_case ids match what the apply and
@@ -807,12 +849,14 @@ class DeviceSettingsManager {
       return
     }
     const { controls, section } = createSectionShell(firstSetting.driverLabel)
-    const checkboxSet = this.#createCheckboxSet(driverSetting)
-    controls.append(checkboxSet)
+    const checkboxSets = this.#createCheckboxSets(driverSetting)
+    controls.append(...checkboxSets)
     section.append(createSettingsButtonRow(this.#homey, toSectionId(driverId)))
     getDiv('device_settings').append(section)
     this.#addSettingsEventListeners(
-      [...checkboxSet.querySelectorAll('input')],
+      checkboxSets.flatMap((checkboxSet) => [
+        ...checkboxSet.querySelectorAll('input'),
+      ]),
       driverId,
     )
   }
@@ -1476,17 +1520,16 @@ class SettingsApp {
     )
   }
 
+  /** @alerts Falls back to an empty settings object on error. */
   static async #fetchHomeySettings(homey: Homey): Promise<HomeySettings> {
-    return new Promise((resolve) => {
-      homey.get(async (error: Error | null, settings: HomeySettings) => {
-        if (error !== null) {
-          await homey.alert(error.message)
-          resolve({})
-          return
-        }
-        resolve(settings)
+    try {
+      return await homeyCallback((callback) => {
+        homey.get(callback)
       })
-    })
+    } catch (error) {
+      await homey.alert(getErrorMessage(error))
+      return {}
+    }
   }
 
   static async #setDocumentLanguage(homey: Homey): Promise<void> {


### PR DESCRIPTION
The audit proposals left to Olivier's call, now greenlit ("Fais tout ça"):

- **One promisification idiom across both apps**: the generic `homeyCallback` (the extension's form) replaces `createCallback` + the five per-verb `new Promise` bodies and the ad-hoc executor in `#fetchHomeySettings`.
- **Valid group markup**: each driver-settings checkbox group now gets its own `fieldset.homey-form-checkbox-set` with its single `legend` as first child — several legends in one fieldset are invalid HTML, and screen readers named the whole set after the first one only. Grouping semantics unchanged (consecutive `groupLabel` runs, manifest order).
- **Credential field hints**: `autocomplete="username"/"current-password"`, plus `autocapitalize="none"`/`spellcheck=false` on the email field, so password managers engage and iOS keyboards stop fighting the address.
- **CLAUDE.md**: the webview runtime floor now says what the code ships — es2023 array methods accepted (lint mandates `toSorted`), iterator helpers (2025-era) and newer banned.

Suite: 640 tests, 100 % branches, lint 0, publish-level validate, build clean. Webview-touching → installed on the Homey for the cold-open pass; ships as 45.7.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)