### PR TITLE
refactor: settle the NaN convention and flatten the holiday-mode coercion (SonarCloud)

### DIFF
--- a/app.mts
+++ b/app.mts
@@ -100,6 +100,20 @@ const chartDaysStart = (days: number, timezone: string): string =>
       .toPlainDateTime()
       .toString()
 
+// The manifest min/max/step only constrain manual input: a flow token
+// dropped into the field can carry anything at runtime. Only numbers
+// and numeric strings are accepted — coercing other types (false,
+// null, '') would silently read as 0 and turn holiday mode off.
+const toDurationDays = (duration: unknown): number => {
+  if (typeof duration === 'number') {
+    return duration
+  }
+  if (typeof duration === 'string' && duration.trim() !== '') {
+    return Number(duration)
+  }
+  return Number.NaN
+}
+
 const formatErrors = (errors: Record<string, readonly string[]>): string =>
   Object.entries(errors)
     .map(([error, messages]) => `${error}: ${messages.join(', ')}`)
@@ -1324,16 +1338,7 @@ export default class MELCloudApp extends App {
         duration: unknown
         zone: DeviceOrZoneData
       }) => {
-        // The manifest min/max/step only constrain manual input: a token
-        // dropped into the field can carry anything at runtime. Only
-        // numbers and numeric strings are accepted — coercing other types
-        // (false, null, '') would silently read as 0 and turn holiday
-        // mode off.
-        const days =
-          typeof duration === 'number' ? duration
-          : typeof duration === 'string' && duration.trim() !== '' ?
-            Number(duration)
-          : NaN
+        const days = toDurationDays(duration)
         if (
           !Number.isSafeInteger(days) ||
           days < HOLIDAY_MODE_OFF_DURATION ||

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -813,6 +813,10 @@ const config = defineConfig([
       'unicorn/prefer-dispose': 'error',
       // Requires Node.js 24 (`Error.isError`).
       'unicorn/prefer-error-is-error': 'off',
+      // Mutually exclusive twin of `prefer-number-properties`'
+      // `checkNaN`: the repo picks `Number.NaN` (SonarCloud S7773 is a
+      // required gate, and it pairs with the mandated `Number.isNaN`).
+      'unicorn/prefer-global-number-constants': 'off',
       'unicorn/prefer-import-meta-properties': 'error',
       // Requires Node.js 24 (`Iterator.concat`).
       'unicorn/prefer-iterator-concat': 'off',
@@ -822,6 +826,15 @@ const config = defineConfig([
         'error',
         {
           checkVaryingBase: true,
+        },
+      ],
+      // Stricter than the v72 default (see `prefer-global-number-constants`
+      // above). Infinity stays free — the WAAPI `iterations: Infinity`
+      // idiom is canonical.
+      'unicorn/prefer-number-properties': [
+        'error',
+        {
+          checkNaN: true,
         },
       ],
       // Requires Node.js 24 (`RegExp.escape`).

--- a/tests/unit/validation.test.ts
+++ b/tests/unit/validation.test.ts
@@ -29,7 +29,7 @@ describe(toNonNegativeInt, () => {
     ['abc', /non-negative integer/v],
     [-1, /non-negative integer/v],
     [1.5, /non-negative integer/v],
-    [NaN, /non-negative integer/v],
+    [Number.NaN, /non-negative integer/v],
     [Infinity, /non-negative integer/v],
   ])('rejects %p', (input, pattern) => {
     expect(() => toNonNegativeInt(input)).toThrow(pattern)


### PR DESCRIPTION
Closes the two open SonarCloud issues, both on the holiday-mode duration coercion in app.mts:

- **S3358** (nested ternary): extracted to a `toDurationDays` early-return helper — same semantics (numbers pass through, non-empty numeric strings coerce, everything else reads `Number.NaN` so the range check rejects it).
- **S7773** (`NaN` → `Number.NaN`): unicorn v72 ships BOTH directions as mutually exclusive twins — `prefer-global-number-constants` (recommended, wants the global) vs `prefer-number-properties`' opt-in `checkNaN` (wants `Number.NaN`). The repo picks `Number.NaN`: SonarCloud is a required gate and it pairs with the already-mandated `Number.isNaN`. The global twin goes to the config ledger with that rationale, `checkNaN: true` enforces the choice henceforth (proven: one usage in app.mts, one in tests, both migrated). `Infinity` stays free — the widget's WAAPI `iterations: Infinity` idiom is canonical and S7773 does not flag it.

Quality-only: no version bump, rides the next release. Suite: lint 0, tsc 0, 100 % coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)