### PR TITLE
perf: detach the initial energy fetches from the device ready path (45.7.8)

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -736,5 +736,20 @@
     "pl": "Urządzenia pokazują teraz ostrzeżenie, gdy ich raporty energii wielokrotnie się nie powiodą (usuwane przy następnym sukcesie), a każdy raport zapisuje zastosowane wartości.",
     "ru": "Устройства теперь показывают предупреждение, когда их отчёты об энергии повторно завершаются ошибкой (снимается при следующем успехе), а каждый отчёт записывает применённые значения.",
     "sv": "Enheter visar nu en varning när deras energirapporter fortsätter att misslyckas (rensas vid nästa lyckade körning), och varje rapport loggar de tillämpade värdena."
+  },
+  "45.7.8": {
+    "ar": "تشغيل أسرع وأكثر موثوقية على أجهزة Homey القديمة: لم تعد الأجهزة تنتظر أول تقرير طاقة قبل أن تصبح جاهزة.",
+    "da": "Hurtigere og mere pålidelig opstart på ældre Homeys: enheder venter ikke længere på deres første energirapport, før de bliver klar.",
+    "de": "Schnellerer, zuverlässigerer Start auf älteren Homeys: Geräte warten nicht mehr auf ihren ersten Energiebericht, bevor sie bereit sind.",
+    "en": "Faster, more reliable startup on older Homeys: devices no longer wait for their first energy report before becoming ready.",
+    "es": "Arranque más rápido y fiable en Homeys antiguos: los dispositivos ya no esperan su primer informe de energía antes de estar listos.",
+    "fr": "Démarrage plus rapide et plus fiable sur les anciens Homey : les appareils n’attendent plus leur premier rapport d’énergie avant d’être prêts.",
+    "it": "Avvio più rapido e affidabile sui Homey meno recenti: i dispositivi non attendono più il loro primo report energetico prima di essere pronti.",
+    "ko": "구형 Homey에서 더 빠르고 안정적인 시작: 기기가 준비되기 전에 첫 에너지 보고서를 더 이상 기다리지 않습니다.",
+    "nl": "Sneller en betrouwbaarder opstarten op oudere Homeys: apparaten wachten niet langer op hun eerste energierapport voordat ze gereed zijn.",
+    "no": "Raskere og mer pålitelig oppstart på eldre Homey-er: enheter venter ikke lenger på sin første energirapport før de blir klare.",
+    "pl": "Szybsze i bardziej niezawodne uruchamianie na starszych Homey: urządzenia nie czekają już na pierwszy raport energii, zanim będą gotowe.",
+    "ru": "Более быстрый и надёжный запуск на старых Homey: устройства больше не ждут первого отчёта об энергии, прежде чем стать готовыми.",
+    "sv": "Snabbare och mer pålitlig start på äldre Homeys: enheter väntar inte längre på sin första energirapport innan de blir klara."
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -282,5 +282,5 @@
       "värmeåtervinning"
     ]
   },
-  "version": "45.7.7"
+  "version": "45.7.8"
 }

--- a/app.json
+++ b/app.json
@@ -283,7 +283,7 @@
       "värmeåtervinning"
     ]
   },
-  "version": "45.7.7",
+  "version": "45.7.8",
   "flow": {
     "triggers": [
       {

--- a/drivers/base-device.mts
+++ b/drivers/base-device.mts
@@ -8,6 +8,7 @@ import type {
   EnergyReportOperation,
 } from '../types/device.mts'
 import { NotFoundError } from '../lib/errors.mts'
+import { fireAndForget } from '../lib/fire-and-forget.mts'
 import { getErrorMessage } from '../lib/get-error-message.mts'
 import { type Homey, Device } from '../lib/homey.mts'
 import { isTotalEnergyKey } from '../lib/is-total-energy-key.mts'
@@ -316,7 +317,18 @@ export abstract class BaseMELCloudDevice<
     await this.#setCapabilities()
     await this.applyCapabilitiesOptions()
     await this.syncFromDevice()
-    await this.scheduleEnergyReports()
+    // The initial energy fetches are network round-trips: detached so
+    // a slow MELCloud cannot hold Device#onInit past the SDK ready
+    // budget — an Early 2018 Homey with several metered devices hit
+    // `ready_timeout` exactly there. The settings path keeps awaiting
+    // its restarts; only boot is off the critical path.
+    fireAndForget(
+      this.scheduleEnergyReports(),
+      (...args: unknown[]) => {
+        this.error(...args)
+      },
+      'Energy report scheduling failed:',
+    )
   }
 
   #isThermostatModeSupportingOff(): boolean {

--- a/lib/fire-and-forget.mts
+++ b/lib/fire-and-forget.mts
@@ -1,0 +1,13 @@
+// The one sanctioned fire-and-forget seam (melcloud-api's shape):
+// detach already-started work from the caller's critical path, logging
+// a rejection instead of propagating it.
+export const fireAndForget = (
+  promise: Promise<unknown>,
+  logError: (...args: unknown[]) => void,
+  message: string,
+): void => {
+  // eslint-disable-next-line unicorn/prefer-await -- the single fire-and-forget seam: rejections are logged, never propagated
+  promise.catch((error: unknown) => {
+    logError(message, error)
+  })
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "com.melcloud",
-  "version": "45.7.7",
+  "version": "45.7.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "com.melcloud",
-      "version": "45.7.7",
+      "version": "45.7.8",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@olivierzal/melcloud-api": "^42.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.melcloud",
-  "version": "45.7.7",
+  "version": "45.7.8",
   "description": "MELCloud for Homey",
   "homepage": "https://github.com/OlivierZal/com.melcloud/",
   "bugs": {

--- a/tests/unit/classic-device.test.ts
+++ b/tests/unit/classic-device.test.ts
@@ -687,6 +687,53 @@ describe(ClassicMELCloudDevice, () => {
         failure,
       )
     })
+
+    it('should become ready while the initial energy fetch is still pending', async () => {
+      const { promise, resolve }: PromiseWithResolvers<void> =
+        Promise.withResolvers()
+      energyReportStartMock.mockReturnValueOnce(promise)
+      const deviceWithRegular = new TestDevice()
+      Object.defineProperty(deviceWithRegular, 'energyReportRegular', {
+        value: {
+          duration: { hours: 1 },
+          minus: { hours: 1 },
+          mode: 'regular' as const,
+          values: { millisecond: 0, minute: 5, second: 0 },
+        },
+      })
+      setDriver(deviceWithRegular)
+      // Resolves although the initial fetch hangs: device readiness
+      // must not depend on MELCloud latency (Early 2018 Homeys hit the
+      // SDK ready_timeout exactly there).
+      await deviceWithRegular.onInit()
+
+      expect(energyReportStartMock).toHaveBeenCalledTimes(1)
+
+      resolve()
+    })
+
+    it('should log a detached scheduling failure without breaking init', async () => {
+      energyReportStartMock.mockRejectedValueOnce(new Error('fetch down'))
+      const deviceWithRegular = new TestDevice()
+      Object.defineProperty(deviceWithRegular, 'energyReportRegular', {
+        value: {
+          duration: { hours: 1 },
+          minus: { hours: 1 },
+          mode: 'regular' as const,
+          values: { millisecond: 0, minute: 5, second: 0 },
+        },
+      })
+      setDriver(deviceWithRegular)
+      await deviceWithRegular.onInit()
+      // The detached chain settles a couple of microtasks after init.
+      await Promise.resolve()
+      await Promise.resolve()
+
+      expect(deviceWithRegular.error).toHaveBeenCalledWith(
+        'Energy report scheduling failed:',
+        expect.any(Error),
+      )
+    })
   })
 
   describe('synchronization when device is unavailable', () => {


### PR DESCRIPTION
Field crash (v45.7.5, homey2s / Early 2018): ready_timeout at app init. The SDK's 30 s ready budget covers every Device#onInit, and each metered device awaited its first energy report — a MELCloud network round-trip, ×2 for regular + total configs. The 45.6.1 fix (background session resume) removed the app-level network from the ready path; this removes the device-level remainder.

- #init now detaches scheduleEnergyReports() through a new lib/fire-and-forget.mts (melcloud-api's sanctioned seam, rejection logged never thrown). Report creation stays synchronous — only the fetches leave the critical path. The settings path keeps awaiting its restarts.
- Tests pin the contract: onInit resolves while the initial fetch hangs; a detached scheduling failure is logged without breaking init.
- Suite: lint 0, tsc 0, 100 % coverage, homey:validate green.

Ships as v45.7.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)