### PR TITLE
perf: detach the per-device IPC tail from the ready path, log boot marks (45.8.1)

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -766,5 +766,20 @@
     "pl": "Odczyty mocy i energii są teraz zawsze dostępne na urządzeniach MELCloud Home (gdy urządzenie je raportuje) — ich ustawienia wyświetlania zostały usunięte.",
     "ru": "Показания мощности и энергии теперь всегда доступны на устройствах MELCloud Home (когда устройство их передаёт) — их настройки отображения удалены.",
     "sv": "Effekt- och energivärden är nu alltid tillgängliga på MELCloud Home-enheter (när enheten rapporterar dem) — deras visningsinställningar är borttagna."
+  },
+  "45.8.1": {
+    "ar": "تشغيل أسرع على أجهزة Homey القديمة: لم تعد جاهزية الأجهزة تنتظر تحديث القيم، وتُسجَّل أوقات بدء التشغيل للتشخيص.",
+    "da": "Hurtigere opstart på ældre Homeys: enhedernes parathed venter ikke længere på værdiopdateringer, og opstartstider logges til diagnosticering.",
+    "de": "Schnellerer Start auf älteren Homeys: die Gerätebereitschaft wartet nicht mehr auf Wertaktualisierungen, und Startzeiten werden für die Diagnose protokolliert.",
+    "en": "Faster startup on older Homeys: device readiness no longer waits for value refreshes, and boot timings are logged for diagnostics.",
+    "es": "Arranque más rápido en Homeys antiguos: la disponibilidad de los dispositivos ya no espera las actualizaciones de valores, y los tiempos de arranque se registran para diagnóstico.",
+    "fr": "Démarrage plus rapide sur les anciens Homey : la disponibilité des appareils n’attend plus le rafraîchissement des valeurs, et les temps de démarrage sont journalisés pour le diagnostic.",
+    "it": "Avvio più rapido sui Homey meno recenti: la disponibilità dei dispositivi non attende più l’aggiornamento dei valori, e i tempi di avvio vengono registrati per la diagnostica.",
+    "ko": "구형 Homey에서 더 빠른 시작: 기기 준비가 더 이상 값 새로 고침을 기다리지 않으며, 진단을 위해 부팅 시간이 기록됩니다.",
+    "nl": "Sneller opstarten op oudere Homeys: apparaatgereedheid wacht niet langer op waardeverversingen, en opstarttijden worden gelogd voor diagnose.",
+    "no": "Raskere oppstart på eldre Homey-er: enhetsberedskap venter ikke lenger på verdier som oppdateres, og oppstartstider logges for diagnostikk.",
+    "pl": "Szybsze uruchamianie na starszych Homey: gotowość urządzeń nie czeka już na odświeżenie wartości, a czasy rozruchu są rejestrowane do diagnostyki.",
+    "ru": "Более быстрый запуск на старых Homey: готовность устройств больше не ждёт обновления значений, а время загрузки записывается для диагностики.",
+    "sv": "Snabbare start på äldre Homeys: enheternas beredskap väntar inte längre på värdeuppdateringar, och starttider loggas för diagnostik."
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -282,5 +282,5 @@
       "värmeåtervinning"
     ]
   },
-  "version": "45.8.0"
+  "version": "45.8.1"
 }

--- a/app.json
+++ b/app.json
@@ -283,7 +283,7 @@
       "värmeåtervinning"
     ]
   },
-  "version": "45.8.0",
+  "version": "45.8.1",
   "flow": {
     "triggers": [
       {

--- a/app.mts
+++ b/app.mts
@@ -57,6 +57,7 @@ import {
 } from './files.mts'
 import { setClassicFacadeManager } from './lib/classic-facade-manager.mts'
 import { NotFoundError } from './lib/errors.mts'
+import { fireAndForget } from './lib/fire-and-forget.mts'
 import { type Homey, App } from './lib/homey.mts'
 import { getTimeZone } from './lib/temporal.mts'
 import { typedFromEntries } from './lib/typed-object.mts'
@@ -410,6 +411,11 @@ export default class MELCloudApp extends App {
   }
 
   public override async onInit(): Promise<void> {
+    // Boot marks: everything before the first line is module require +
+    // SDK handshake, and `ready` lands once every driver and device
+    // initialized — the discriminators for 2018-hardware
+    // `ready_timeout` diagnostics.
+    this.log('Boot: onInit after', process.uptime().toFixed(1), 's')
     const language = this.homey.i18n.getLanguage()
     await this.#initClassicApi({
       language,
@@ -420,6 +426,13 @@ export default class MELCloudApp extends App {
     this.#createNotification(language)
     this.#registerWidgetListeners()
     this.#registerFlowListeners()
+    fireAndForget(
+      this.#logBootReady(),
+      (...args: unknown[]) => {
+        this.error(...args)
+      },
+      'Boot readiness tracking failed:',
+    )
   }
 
   public override async onUninit(): Promise<void> {
@@ -1280,6 +1293,11 @@ export default class MELCloudApp extends App {
       timezone: getTimeZone(this.homey),
     })
     this.#homeFacadeManager = new Home.FacadeManager(this.#homeApi)
+  }
+
+  async #logBootReady(): Promise<void> {
+    await this.homey.ready()
+    this.log('Boot: ready after', process.uptime().toFixed(1), 's')
   }
 
   // User-facing half of melcloud-api's onAuthenticationLost contract:

--- a/drivers/base-device.mts
+++ b/drivers/base-device.mts
@@ -313,21 +313,27 @@ export abstract class BaseMELCloudDevice<
     return this.#deviceFacade
   }
 
-  async #init(): Promise<void> {
-    await this.#setCapabilities()
+  // The per-capability IPC bulk (options reapplication, value sync)
+  // and the network energy fetches: detached from the ready path — an
+  // Early 2018 Homey burns the SDK's 30 s budget on serialized IPC
+  // alone (a v45.7.8 field report still hit `ready_timeout` after the
+  // fetches left). `#setCapabilities` stays awaited: its post-pairing
+  // delta is usually empty and the tag mappings must exist before the
+  // capability listeners fire.
+  async #finishInit(): Promise<void> {
     await this.applyCapabilitiesOptions()
     await this.syncFromDevice()
-    // The initial energy fetches are network round-trips: detached so
-    // a slow MELCloud cannot hold Device#onInit past the SDK ready
-    // budget — an Early 2018 Homey with several metered devices hit
-    // `ready_timeout` exactly there. The settings path keeps awaiting
-    // its restarts; only boot is off the critical path.
+    await this.scheduleEnergyReports()
+  }
+
+  async #init(): Promise<void> {
+    await this.#setCapabilities()
     fireAndForget(
-      this.scheduleEnergyReports(),
+      this.#finishInit(),
       (...args: unknown[]) => {
         this.error(...args)
       },
-      'Energy report scheduling failed:',
+      'Deferred device init failed:',
     )
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "com.melcloud",
-  "version": "45.8.0",
+  "version": "45.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "com.melcloud",
-      "version": "45.8.0",
+      "version": "45.8.1",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@olivierzal/melcloud-api": "^42.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.melcloud",
-  "version": "45.8.0",
+  "version": "45.8.1",
   "description": "MELCloud for Homey",
   "homepage": "https://github.com/OlivierZal/com.melcloud/",
   "bugs": {

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -40,5 +40,13 @@ export const createEnergyReportMock = (): {
     })),
 })
 
+// Drain the microtask chains a detached (fire-and-forget) device init
+// leaves behind: one macrotask turn settles them all when the mocks
+// resolve synchronously.
+export const settleDetached = async (): Promise<void> =>
+  new Promise((resolve) => {
+    setImmediate(resolve)
+  })
+
 export { createMockDeviceClass } from './mock-device-class.ts'
 export { createMockDriverClass } from './mock-driver-class.ts'

--- a/tests/unit/app.test.ts
+++ b/tests/unit/app.test.ts
@@ -18,7 +18,7 @@ import type * as HomeyLib from '../../lib/homey.mts'
 import type { ClassicMELCloudDevice } from '../../types/classic.mts'
 import type { Settings } from '../../types/device-settings.mts'
 import type { ManifestDriver } from '../../types/manifest.mts'
-import { getMockCallArg, mock } from '../helpers.js'
+import { getMockCallArg, mock, settleDetached } from '../helpers.js'
 
 const mockSetFacadeManager = vi.fn<() => void>()
 
@@ -312,29 +312,41 @@ const setupMocks = (): void => {
 
 const createApp = (): InstanceType<typeof MelCloudApp> => {
   const app = new MelCloudApp()
-  Object.defineProperty(app, 'homey', {
-    configurable: true,
-    value: {
-      __: mockTranslate,
-      clock: { getTimezone: mockGetTimezone },
-      dashboards: { getWidget: mockGetWidget },
-      drivers: { getDrivers: mockGetDrivers },
-      flow: {
-        getActionCard: mockGetActionCard,
-        getConditionCard: mockGetConditionCard,
-      },
-      i18n: { getLanguage: mockGetLanguage },
-      manifest: { drivers: mockManifestDrivers, version: '1.0.0' },
-      notifications: { createNotification: mockCreateNotification },
-      ready: mockHomeyReady,
-      setTimeout: mockSetTimeout,
-      settings: {
-        get: mockSettingsGet,
-        set: mockSettingsSet,
-        unset: mockSettingsUnset,
-      },
+  // The mocked App base is a bare Function: give every instance the
+  // log/error methods the boot marks rely on (tests override at will).
+  Object.defineProperties(app, {
+    error: {
+      configurable: true,
+      value: vi.fn<(...args: unknown[]) => void>(),
     },
-    writable: false,
+    homey: {
+      configurable: true,
+      value: {
+        __: mockTranslate,
+        clock: { getTimezone: mockGetTimezone },
+        dashboards: { getWidget: mockGetWidget },
+        drivers: { getDrivers: mockGetDrivers },
+        flow: {
+          getActionCard: mockGetActionCard,
+          getConditionCard: mockGetConditionCard,
+        },
+        i18n: { getLanguage: mockGetLanguage },
+        manifest: { drivers: mockManifestDrivers, version: '1.0.0' },
+        notifications: { createNotification: mockCreateNotification },
+        ready: mockHomeyReady,
+        setTimeout: mockSetTimeout,
+        settings: {
+          get: mockSettingsGet,
+          set: mockSettingsSet,
+          unset: mockSettingsUnset,
+        },
+      },
+      writable: false,
+    },
+    log: {
+      configurable: true,
+      value: vi.fn<(...args: unknown[]) => void>(),
+    },
   })
   return app
 }
@@ -760,6 +772,33 @@ describe('melCloudApp', () => {
 
       expect(mockSetTimeout).toHaveBeenCalledTimes(scheduledCalls)
       expect(mockCreateNotification).toHaveBeenCalledTimes(1)
+    })
+
+    it('should log the boot marks around init and readiness', async () => {
+      await app.onInit()
+      await settleDetached()
+
+      expect(app.log).toHaveBeenCalledWith(
+        'Boot: onInit after',
+        expect.any(String),
+        's',
+      )
+      expect(app.log).toHaveBeenCalledWith(
+        'Boot: ready after',
+        expect.any(String),
+        's',
+      )
+    })
+
+    it('should log a boot readiness tracking failure', async () => {
+      mockHomeyReady.mockRejectedValueOnce(new Error('never ready'))
+      await app.onInit()
+      await settleDetached()
+
+      expect(app.error).toHaveBeenCalledWith(
+        'Boot readiness tracking failed:',
+        expect.any(Error),
+      )
     })
 
     it('should not fetch Home devices itself (the API create contract owns it)', async () => {

--- a/tests/unit/classic-device.test.ts
+++ b/tests/unit/classic-device.test.ts
@@ -24,7 +24,7 @@ import {
   testUninitialisation,
   testWarningManagement,
 } from '../device-descriptors.ts'
-import { type InteropModule, mock } from '../helpers.ts'
+import { type InteropModule, mock, settleDetached } from '../helpers.ts'
 import {
   type TestDeviceType,
   TestDevice,
@@ -624,6 +624,7 @@ describe(ClassicMELCloudDevice, () => {
       })
       setDriver(deviceWithRegular)
       await deviceWithRegular.onInit()
+      await settleDetached()
 
       expect(vi.mocked(EnergyReport).mock.calls.length - callCountBefore).toBe(
         1,
@@ -644,6 +645,7 @@ describe(ClassicMELCloudDevice, () => {
       })
       setDriver(deviceWithTotal)
       await deviceWithTotal.onInit()
+      await settleDetached()
 
       expect(vi.mocked(EnergyReport).mock.calls.length - callCountBefore).toBe(
         1,
@@ -676,6 +678,7 @@ describe(ClassicMELCloudDevice, () => {
       })
       setDriver(deviceWithRegular, driverWithEnergy)
       await deviceWithRegular.onInit()
+      await settleDetached()
       energyReportStartMock.mockRejectedValueOnce(failure)
       await deviceWithRegular.onSettings({
         changedKeys: ['measure_power'],
@@ -706,6 +709,7 @@ describe(ClassicMELCloudDevice, () => {
       // must not depend on MELCloud latency (Early 2018 Homeys hit the
       // SDK ready_timeout exactly there).
       await deviceWithRegular.onInit()
+      await settleDetached()
 
       expect(energyReportStartMock).toHaveBeenCalledTimes(1)
 
@@ -725,12 +729,11 @@ describe(ClassicMELCloudDevice, () => {
       })
       setDriver(deviceWithRegular)
       await deviceWithRegular.onInit()
-      // The detached chain settles a couple of microtasks after init.
-      await Promise.resolve()
-      await Promise.resolve()
+      // The detached chain settles within one macrotask turn.
+      await settleDetached()
 
       expect(deviceWithRegular.error).toHaveBeenCalledWith(
-        'Energy report scheduling failed:',
+        'Deferred device init failed:',
         expect.any(Error),
       )
     })


### PR DESCRIPTION
Follow-up to the v45.7.8 field report: the same Early 2018 Homey still hit `ready_timeout`, so the energy fetches were not the (only) bottleneck. Remaining suspects: module require time (the backend is unbundled — hundreds of files off slow flash) and the serialized per-device IPC.

- **(a)** `#init` now awaits only `#setCapabilities` (post-pairing delta usually empty; tag mappings must exist before capability listeners fire) and detaches the tail — `applyCapabilitiesOptions` (per-capability IPC every boot), `syncFromDevice` (per-capability IPC), `scheduleEnergyReports` — through the single fire-and-forget seam.
- **(b)** Boot marks: `process.uptime()` logged at `App#onInit` start (= require + SDK handshake time) and, detached, when `homey.ready()` lands (= total, delta = driver/device inits). A future diagnostics report from a homey2s will say whether the next lever is bundling the backend.
- Tests: `settleDetached` helper (one macrotask drains the detached chains), report tests re-anchored, boot marks + failure seam pinned. Suite: lint 0, tsc 0, 100 % coverage, `homey:validate` green.

Ships as v45.8.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)