### PR TITLE
feat: label the Classic device types [Classic], mirroring [Home] (45.8.2)

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -781,5 +781,20 @@
     "pl": "Szybsze uruchamianie na starszych Homey: gotowość urządzeń nie czeka już na odświeżenie wartości, a czasy rozruchu są rejestrowane do diagnostyki.",
     "ru": "Более быстрый запуск на старых Homey: готовность устройств больше не ждёт обновления значений, а время загрузки записывается для диагностики.",
     "sv": "Snabbare start på äldre Homeys: enheternas beredskap väntar inte längre på värdeuppdateringar, och starttider loggas för diagnostik."
+  },
+  "45.8.2": {
+    "ar": "وضوح أكبر: أنواع أجهزة MELCloud Classic تحمل الآن البادئة [Classic]، على غرار [Home].",
+    "da": "Tydeligere afgrænsning: MELCloud Classic-enhedstyper er nu mærket [Classic], ligesom [Home].",
+    "de": "Klarere Abgrenzung: MELCloud-Classic-Gerätetypen tragen jetzt das Präfix [Classic], spiegelbildlich zu [Home].",
+    "en": "Clearer scope: MELCloud Classic device types are now labelled [Classic], mirroring [Home].",
+    "es": "Ámbito más claro: los tipos de dispositivos de MELCloud Classic ahora llevan la etiqueta [Classic], reflejando [Home].",
+    "fr": "Périmètre plus clair : les types d’appareils MELCloud Classic portent désormais le préfixe [Classic], en miroir de [Home].",
+    "it": "Ambito più chiaro: i tipi di dispositivi MELCloud Classic ora portano l’etichetta [Classic], in specchio con [Home].",
+    "ko": "더 명확한 구분: MELCloud Classic 기기 유형에 이제 [Home]과 대칭으로 [Classic] 접두사가 붙습니다.",
+    "nl": "Duidelijkere afbakening: MELCloud Classic-apparaattypen zijn nu gelabeld met [Classic], in spiegelbeeld van [Home].",
+    "no": "Tydeligere avgrensning: MELCloud Classic-enhetstyper er nå merket [Classic], i speil av [Home].",
+    "pl": "Wyraźniejszy zakres: typy urządzeń MELCloud Classic mają teraz prefiks [Classic], lustrzanie do [Home].",
+    "ru": "Более чёткое разграничение: типы устройств MELCloud Classic теперь помечены [Classic], зеркально [Home].",
+    "sv": "Tydligare avgränsning: MELCloud Classic-enhetstyper är nu märkta [Classic], som en spegel av [Home]."
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -282,5 +282,5 @@
       "värmeåtervinning"
     ]
   },
-  "version": "45.8.1"
+  "version": "45.8.2"
 }

--- a/app.json
+++ b/app.json
@@ -283,7 +283,7 @@
       "värmeåtervinning"
     ]
   },
-  "version": "45.8.1",
+  "version": "45.8.2",
   "flow": {
     "triggers": [
       {
@@ -6626,19 +6626,19 @@
         "measure_signal_strength"
       ],
       "name": {
-        "ar": "مضخة حرارية هواء-هواء",
-        "da": "Luft-til-luft varmepumpe",
-        "de": "Luft-Luft-Wärmepumpe",
-        "en": "Air-to-air heat pump",
-        "es": "Bomba de calor aire-aire",
-        "fr": "Pompe à chaleur air-air",
-        "it": "Pompa di calore aria-aria",
-        "ko": "공기-공기 히트펌프",
-        "nl": "Lucht-lucht warmtepomp",
-        "no": "Luft-til-luft varmepumpe",
-        "pl": "Pompa ciepła powietrze-powietrze",
-        "ru": "Воздушный тепловой насос",
-        "sv": "Luft-till-luft värmepump"
+        "ar": "[Classic] مضخة حرارية هواء-هواء",
+        "da": "[Classic] Luft-til-luft varmepumpe",
+        "de": "[Classic] Luft-Luft-Wärmepumpe",
+        "en": "[Classic] Air-to-air heat pump",
+        "es": "[Classic] Bomba de calor aire-aire",
+        "fr": "[Classic] Pompe à chaleur air-air",
+        "it": "[Classic] Pompa di calore aria-aria",
+        "ko": "[Classic] 공기-공기 히트펌프",
+        "nl": "[Classic] Lucht-lucht warmtepomp",
+        "no": "[Classic] Luft-til-luft varmepumpe",
+        "pl": "[Classic] Pompa ciepła powietrze-powietrze",
+        "ru": "[Classic] Воздушный тепловой насос",
+        "sv": "[Classic] Luft-till-luft värmepump"
       },
       "id": "melcloud",
       "settings": [
@@ -8953,19 +8953,19 @@
         "measure_signal_strength"
       ],
       "name": {
-        "ar": "مضخة حرارية هواء-ماء",
-        "da": "Luft-til-vand varmepumpe",
-        "de": "Luft-Wasser-Wärmepumpe",
-        "en": "Air-to-water heat pump",
-        "es": "Bomba de calor aire-agua",
-        "fr": "Pompe à chaleur air-eau",
-        "it": "Pompa di calore aria-acqua",
-        "ko": "공기-물 히트펌프",
-        "nl": "Lucht-water warmtepomp",
-        "no": "Luft-til-vann varmepumpe",
-        "pl": "Pompa ciepła powietrze-woda",
-        "ru": "Воздушно-водяной тепловой насос",
-        "sv": "Luft-till-vatten värmepump"
+        "ar": "[Classic] مضخة حرارية هواء-ماء",
+        "da": "[Classic] Luft-til-vand varmepumpe",
+        "de": "[Classic] Luft-Wasser-Wärmepumpe",
+        "en": "[Classic] Air-to-water heat pump",
+        "es": "[Classic] Bomba de calor aire-agua",
+        "fr": "[Classic] Pompe à chaleur air-eau",
+        "it": "[Classic] Pompa di calore aria-acqua",
+        "ko": "[Classic] 공기-물 히트펌프",
+        "nl": "[Classic] Lucht-water warmtepomp",
+        "no": "[Classic] Luft-til-vann varmepumpe",
+        "pl": "[Classic] Pompa ciepła powietrze-woda",
+        "ru": "[Classic] Воздушно-водяной тепловой насос",
+        "sv": "[Classic] Luft-till-vatten värmepump"
       },
       "id": "melcloud_atw",
       "settings": [
@@ -11056,19 +11056,19 @@
         "measure_signal_strength"
       ],
       "name": {
-        "ar": "مبادل حراري مع استرداد الطاقة (ERV)",
-        "da": "Ventilator med varmegenvinding (ERV)",
-        "de": "Lüftungsgerät mit Wärmerückgewinnung (ERV)",
-        "en": "Energy recovery ventilator (ERV)",
-        "es": "Ventilador con recuperación de calor (ERV)",
-        "fr": "Ventilateur avec récupération de chaleur (ERV)",
-        "it": "Ventilatore con recupero di calore (ERV)",
-        "ko": "에너지 회수 환기장치 (ERV)",
-        "nl": "Ventilator met warmteterugwinning (WTW)",
-        "no": "Ventilator med varmegjenvinning (ERV)",
-        "pl": "Wentylator z odzyskiem ciepła (ERV)",
-        "ru": "Вентиляция с рекуперацией энергии (ERV)",
-        "sv": "Ventilator med värmeåtervinning (ERV)"
+        "ar": "[Classic] مبادل حراري مع استرداد الطاقة (ERV)",
+        "da": "[Classic] Ventilator med varmegenvinding (ERV)",
+        "de": "[Classic] Lüftungsgerät mit Wärmerückgewinnung (ERV)",
+        "en": "[Classic] Energy recovery ventilator (ERV)",
+        "es": "[Classic] Ventilador con recuperación de calor (ERV)",
+        "fr": "[Classic] Ventilateur avec récupération de chaleur (ERV)",
+        "it": "[Classic] Ventilatore con recupero di calore (ERV)",
+        "ko": "[Classic] 에너지 회수 환기장치 (ERV)",
+        "nl": "[Classic] Ventilator met warmteterugwinning (WTW)",
+        "no": "[Classic] Ventilator med varmegjenvinning (ERV)",
+        "pl": "[Classic] Wentylator z odzyskiem ciepła (ERV)",
+        "ru": "[Classic] Вентиляция с рекуперацией энергии (ERV)",
+        "sv": "[Classic] Ventilator med värmeåtervinning (ERV)"
       },
       "id": "melcloud_erv",
       "settings": [

--- a/drivers/melcloud/driver.compose.json
+++ b/drivers/melcloud/driver.compose.json
@@ -460,18 +460,18 @@
     }
   },
   "name": {
-    "ar": "مضخة حرارية هواء-هواء",
-    "da": "Luft-til-luft varmepumpe",
-    "de": "Luft-Luft-Wärmepumpe",
-    "en": "Air-to-air heat pump",
-    "es": "Bomba de calor aire-aire",
-    "fr": "Pompe à chaleur air-air",
-    "it": "Pompa di calore aria-aria",
-    "ko": "공기-공기 히트펌프",
-    "nl": "Lucht-lucht warmtepomp",
-    "no": "Luft-til-luft varmepumpe",
-    "pl": "Pompa ciepła powietrze-powietrze",
-    "ru": "Воздушный тепловой насос",
-    "sv": "Luft-till-luft värmepump"
+    "ar": "[Classic] مضخة حرارية هواء-هواء",
+    "da": "[Classic] Luft-til-luft varmepumpe",
+    "de": "[Classic] Luft-Luft-Wärmepumpe",
+    "en": "[Classic] Air-to-air heat pump",
+    "es": "[Classic] Bomba de calor aire-aire",
+    "fr": "[Classic] Pompe à chaleur air-air",
+    "it": "[Classic] Pompa di calore aria-aria",
+    "ko": "[Classic] 공기-공기 히트펌프",
+    "nl": "[Classic] Lucht-lucht warmtepomp",
+    "no": "[Classic] Luft-til-luft varmepumpe",
+    "pl": "[Classic] Pompa ciepła powietrze-powietrze",
+    "ru": "[Classic] Воздушный тепловой насос",
+    "sv": "[Classic] Luft-till-luft värmepump"
   }
 }

--- a/drivers/melcloud_atw/driver.compose.json
+++ b/drivers/melcloud_atw/driver.compose.json
@@ -849,18 +849,18 @@
     }
   },
   "name": {
-    "ar": "مضخة حرارية هواء-ماء",
-    "da": "Luft-til-vand varmepumpe",
-    "de": "Luft-Wasser-Wärmepumpe",
-    "en": "Air-to-water heat pump",
-    "es": "Bomba de calor aire-agua",
-    "fr": "Pompe à chaleur air-eau",
-    "it": "Pompa di calore aria-acqua",
-    "ko": "공기-물 히트펌프",
-    "nl": "Lucht-water warmtepomp",
-    "no": "Luft-til-vann varmepumpe",
-    "pl": "Pompa ciepła powietrze-woda",
-    "ru": "Воздушно-водяной тепловой насос",
-    "sv": "Luft-till-vatten värmepump"
+    "ar": "[Classic] مضخة حرارية هواء-ماء",
+    "da": "[Classic] Luft-til-vand varmepumpe",
+    "de": "[Classic] Luft-Wasser-Wärmepumpe",
+    "en": "[Classic] Air-to-water heat pump",
+    "es": "[Classic] Bomba de calor aire-agua",
+    "fr": "[Classic] Pompe à chaleur air-eau",
+    "it": "[Classic] Pompa di calore aria-acqua",
+    "ko": "[Classic] 공기-물 히트펌프",
+    "nl": "[Classic] Lucht-water warmtepomp",
+    "no": "[Classic] Luft-til-vann varmepumpe",
+    "pl": "[Classic] Pompa ciepła powietrze-woda",
+    "ru": "[Classic] Воздушно-водяной тепловой насос",
+    "sv": "[Classic] Luft-till-vatten värmepump"
   }
 }

--- a/drivers/melcloud_erv/driver.compose.json
+++ b/drivers/melcloud_erv/driver.compose.json
@@ -89,18 +89,18 @@
     }
   },
   "name": {
-    "ar": "مبادل حراري مع استرداد الطاقة (ERV)",
-    "da": "Ventilator med varmegenvinding (ERV)",
-    "de": "Lüftungsgerät mit Wärmerückgewinnung (ERV)",
-    "en": "Energy recovery ventilator (ERV)",
-    "es": "Ventilador con recuperación de calor (ERV)",
-    "fr": "Ventilateur avec récupération de chaleur (ERV)",
-    "it": "Ventilatore con recupero di calore (ERV)",
-    "ko": "에너지 회수 환기장치 (ERV)",
-    "nl": "Ventilator met warmteterugwinning (WTW)",
-    "no": "Ventilator med varmegjenvinning (ERV)",
-    "pl": "Wentylator z odzyskiem ciepła (ERV)",
-    "ru": "Вентиляция с рекуперацией энергии (ERV)",
-    "sv": "Ventilator med värmeåtervinning (ERV)"
+    "ar": "[Classic] مبادل حراري مع استرداد الطاقة (ERV)",
+    "da": "[Classic] Ventilator med varmegenvinding (ERV)",
+    "de": "[Classic] Lüftungsgerät mit Wärmerückgewinnung (ERV)",
+    "en": "[Classic] Energy recovery ventilator (ERV)",
+    "es": "[Classic] Ventilador con recuperación de calor (ERV)",
+    "fr": "[Classic] Ventilateur avec récupération de chaleur (ERV)",
+    "it": "[Classic] Ventilatore con recupero di calore (ERV)",
+    "ko": "[Classic] 에너지 회수 환기장치 (ERV)",
+    "nl": "[Classic] Ventilator met warmteterugwinning (WTW)",
+    "no": "[Classic] Ventilator med varmegjenvinning (ERV)",
+    "pl": "[Classic] Wentylator z odzyskiem ciepła (ERV)",
+    "ru": "[Classic] Вентиляция с рекуперацией энергии (ERV)",
+    "sv": "[Classic] Ventilator med värmeåtervinning (ERV)"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "com.melcloud",
-  "version": "45.8.1",
+  "version": "45.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "com.melcloud",
-      "version": "45.8.1",
+      "version": "45.8.2",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@olivierzal/melcloud-api": "^42.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.melcloud",
-  "version": "45.8.1",
+  "version": "45.8.2",
   "description": "MELCloud for Homey",
   "homepage": "https://github.com/OlivierZal/com.melcloud/",
   "bugs": {


### PR DESCRIPTION
Field observation: with the Home energy settings gone from the app settings page, the remaining per-driver sections read as bare 'Air-to-air heat pump' / 'Air-to-water heat pump' — nothing said they were Classic-scoped. The three Classic drivers now carry the `[Classic]` prefix ×13 locales, symmetric with `[Home]` (and with the lib's log labels). Driver ids untouched — display names only, so pairing lists and settings legends disambiguate, and nothing breaks for paired devices.

Ships as v45.8.2. Suite: lint 0, tsc 0, 100 % coverage, `homey:validate` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)