### PR TITLE
chore: localize "domain" in the login username placeholders

### DIFF
--- a/.homeycompose/drivers/templates/defaults.json
+++ b/.homeycompose/drivers/templates/defaults.json
@@ -807,18 +807,18 @@
         },
         "usernamePlaceholder": {
           "ar": "user@domain.com",
-          "da": "bruger@domain.dk",
-          "de": "benutzer@domain.de",
+          "da": "bruger@domæne.dk",
+          "de": "benutzer@domäne.de",
           "en": "user@domain.com",
-          "es": "usuario@domain.es",
-          "fr": "utilisateur@domain.fr",
-          "it": "utente@domain.it",
+          "es": "usuario@dominio.es",
+          "fr": "utilisateur@domaine.fr",
+          "it": "utente@dominio.it",
           "ko": "user@domain.com",
-          "nl": "gebruiker@domain.nl",
-          "no": "bruker@domain.no",
-          "pl": "uzytkownik@domain.pl",
+          "nl": "gebruiker@domein.nl",
+          "no": "bruker@domene.no",
+          "pl": "uzytkownik@domena.pl",
           "ru": "user@domain.com",
-          "sv": "anvandare@domain.se"
+          "sv": "anvandare@domän.se"
         }
       },
       "template": "login_credentials"
@@ -887,18 +887,18 @@
         },
         "usernamePlaceholder": {
           "ar": "user@domain.com",
-          "da": "bruger@domain.dk",
-          "de": "benutzer@domain.de",
+          "da": "bruger@domæne.dk",
+          "de": "benutzer@domäne.de",
           "en": "user@domain.com",
-          "es": "usuario@domain.es",
-          "fr": "utilisateur@domain.fr",
-          "it": "utente@domain.it",
+          "es": "usuario@dominio.es",
+          "fr": "utilisateur@domaine.fr",
+          "it": "utente@dominio.it",
           "ko": "user@domain.com",
-          "nl": "gebruiker@domain.nl",
-          "no": "bruker@domain.no",
-          "pl": "uzytkownik@domain.pl",
+          "nl": "gebruiker@domein.nl",
+          "no": "bruker@domene.no",
+          "pl": "uzytkownik@domena.pl",
           "ru": "user@domain.com",
-          "sv": "anvandare@domain.se"
+          "sv": "anvandare@domän.se"
         }
       },
       "template": "login_credentials"

--- a/app.json
+++ b/app.json
@@ -4206,18 +4206,18 @@
             },
             "usernamePlaceholder": {
               "ar": "user@domain.com",
-              "da": "bruger@domain.dk",
-              "de": "benutzer@domain.de",
+              "da": "bruger@domæne.dk",
+              "de": "benutzer@domäne.de",
               "en": "user@domain.com",
-              "es": "usuario@domain.es",
-              "fr": "utilisateur@domain.fr",
-              "it": "utente@domain.it",
+              "es": "usuario@dominio.es",
+              "fr": "utilisateur@domaine.fr",
+              "it": "utente@dominio.it",
               "ko": "user@domain.com",
-              "nl": "gebruiker@domain.nl",
-              "no": "bruker@domain.no",
-              "pl": "uzytkownik@domain.pl",
+              "nl": "gebruiker@domein.nl",
+              "no": "bruker@domene.no",
+              "pl": "uzytkownik@domena.pl",
               "ru": "user@domain.com",
-              "sv": "anvandare@domain.se"
+              "sv": "anvandare@domän.se"
             }
           },
           "template": "login_credentials"
@@ -4286,18 +4286,18 @@
             },
             "usernamePlaceholder": {
               "ar": "user@domain.com",
-              "da": "bruger@domain.dk",
-              "de": "benutzer@domain.de",
+              "da": "bruger@domæne.dk",
+              "de": "benutzer@domäne.de",
               "en": "user@domain.com",
-              "es": "usuario@domain.es",
-              "fr": "utilisateur@domain.fr",
-              "it": "utente@domain.it",
+              "es": "usuario@dominio.es",
+              "fr": "utilisateur@domaine.fr",
+              "it": "utente@dominio.it",
               "ko": "user@domain.com",
-              "nl": "gebruiker@domain.nl",
-              "no": "bruker@domain.no",
-              "pl": "uzytkownik@domain.pl",
+              "nl": "gebruiker@domein.nl",
+              "no": "bruker@domene.no",
+              "pl": "uzytkownik@domena.pl",
               "ru": "user@domain.com",
-              "sv": "anvandare@domain.se"
+              "sv": "anvandare@domän.se"
             }
           },
           "template": "login_credentials"
@@ -5224,18 +5224,18 @@
             },
             "usernamePlaceholder": {
               "ar": "user@domain.com",
-              "da": "bruger@domain.dk",
-              "de": "benutzer@domain.de",
+              "da": "bruger@domæne.dk",
+              "de": "benutzer@domäne.de",
               "en": "user@domain.com",
-              "es": "usuario@domain.es",
-              "fr": "utilisateur@domain.fr",
-              "it": "utente@domain.it",
+              "es": "usuario@dominio.es",
+              "fr": "utilisateur@domaine.fr",
+              "it": "utente@dominio.it",
               "ko": "user@domain.com",
-              "nl": "gebruiker@domain.nl",
-              "no": "bruker@domain.no",
-              "pl": "uzytkownik@domain.pl",
+              "nl": "gebruiker@domein.nl",
+              "no": "bruker@domene.no",
+              "pl": "uzytkownik@domena.pl",
               "ru": "user@domain.com",
-              "sv": "anvandare@domain.se"
+              "sv": "anvandare@domän.se"
             }
           },
           "template": "login_credentials"
@@ -5304,18 +5304,18 @@
             },
             "usernamePlaceholder": {
               "ar": "user@domain.com",
-              "da": "bruger@domain.dk",
-              "de": "benutzer@domain.de",
+              "da": "bruger@domæne.dk",
+              "de": "benutzer@domäne.de",
               "en": "user@domain.com",
-              "es": "usuario@domain.es",
-              "fr": "utilisateur@domain.fr",
-              "it": "utente@domain.it",
+              "es": "usuario@dominio.es",
+              "fr": "utilisateur@domaine.fr",
+              "it": "utente@dominio.it",
               "ko": "user@domain.com",
-              "nl": "gebruiker@domain.nl",
-              "no": "bruker@domain.no",
-              "pl": "uzytkownik@domain.pl",
+              "nl": "gebruiker@domein.nl",
+              "no": "bruker@domene.no",
+              "pl": "uzytkownik@domena.pl",
               "ru": "user@domain.com",
-              "sv": "anvandare@domain.se"
+              "sv": "anvandare@domän.se"
             }
           },
           "template": "login_credentials"
@@ -6673,18 +6673,18 @@
             },
             "usernamePlaceholder": {
               "ar": "user@domain.com",
-              "da": "bruger@domain.dk",
-              "de": "benutzer@domain.de",
+              "da": "bruger@domæne.dk",
+              "de": "benutzer@domäne.de",
               "en": "user@domain.com",
-              "es": "usuario@domain.es",
-              "fr": "utilisateur@domain.fr",
-              "it": "utente@domain.it",
+              "es": "usuario@dominio.es",
+              "fr": "utilisateur@domaine.fr",
+              "it": "utente@dominio.it",
               "ko": "user@domain.com",
-              "nl": "gebruiker@domain.nl",
-              "no": "bruker@domain.no",
-              "pl": "uzytkownik@domain.pl",
+              "nl": "gebruiker@domein.nl",
+              "no": "bruker@domene.no",
+              "pl": "uzytkownik@domena.pl",
               "ru": "user@domain.com",
-              "sv": "anvandare@domain.se"
+              "sv": "anvandare@domän.se"
             }
           },
           "template": "login_credentials"
@@ -6753,18 +6753,18 @@
             },
             "usernamePlaceholder": {
               "ar": "user@domain.com",
-              "da": "bruger@domain.dk",
-              "de": "benutzer@domain.de",
+              "da": "bruger@domæne.dk",
+              "de": "benutzer@domäne.de",
               "en": "user@domain.com",
-              "es": "usuario@domain.es",
-              "fr": "utilisateur@domain.fr",
-              "it": "utente@domain.it",
+              "es": "usuario@dominio.es",
+              "fr": "utilisateur@domaine.fr",
+              "it": "utente@dominio.it",
               "ko": "user@domain.com",
-              "nl": "gebruiker@domain.nl",
-              "no": "bruker@domain.no",
-              "pl": "uzytkownik@domain.pl",
+              "nl": "gebruiker@domein.nl",
+              "no": "bruker@domene.no",
+              "pl": "uzytkownik@domena.pl",
               "ru": "user@domain.com",
-              "sv": "anvandare@domain.se"
+              "sv": "anvandare@domän.se"
             }
           },
           "template": "login_credentials"
@@ -8968,18 +8968,18 @@
             },
             "usernamePlaceholder": {
               "ar": "user@domain.com",
-              "da": "bruger@domain.dk",
-              "de": "benutzer@domain.de",
+              "da": "bruger@domæne.dk",
+              "de": "benutzer@domäne.de",
               "en": "user@domain.com",
-              "es": "usuario@domain.es",
-              "fr": "utilisateur@domain.fr",
-              "it": "utente@domain.it",
+              "es": "usuario@dominio.es",
+              "fr": "utilisateur@domaine.fr",
+              "it": "utente@dominio.it",
               "ko": "user@domain.com",
-              "nl": "gebruiker@domain.nl",
-              "no": "bruker@domain.no",
-              "pl": "uzytkownik@domain.pl",
+              "nl": "gebruiker@domein.nl",
+              "no": "bruker@domene.no",
+              "pl": "uzytkownik@domena.pl",
               "ru": "user@domain.com",
-              "sv": "anvandare@domain.se"
+              "sv": "anvandare@domän.se"
             }
           },
           "template": "login_credentials"
@@ -9048,18 +9048,18 @@
             },
             "usernamePlaceholder": {
               "ar": "user@domain.com",
-              "da": "bruger@domain.dk",
-              "de": "benutzer@domain.de",
+              "da": "bruger@domæne.dk",
+              "de": "benutzer@domäne.de",
               "en": "user@domain.com",
-              "es": "usuario@domain.es",
-              "fr": "utilisateur@domain.fr",
-              "it": "utente@domain.it",
+              "es": "usuario@dominio.es",
+              "fr": "utilisateur@domaine.fr",
+              "it": "utente@dominio.it",
               "ko": "user@domain.com",
-              "nl": "gebruiker@domain.nl",
-              "no": "bruker@domain.no",
-              "pl": "uzytkownik@domain.pl",
+              "nl": "gebruiker@domein.nl",
+              "no": "bruker@domene.no",
+              "pl": "uzytkownik@domena.pl",
               "ru": "user@domain.com",
-              "sv": "anvandare@domain.se"
+              "sv": "anvandare@domän.se"
             }
           },
           "template": "login_credentials"
@@ -11127,18 +11127,18 @@
             },
             "usernamePlaceholder": {
               "ar": "user@domain.com",
-              "da": "bruger@domain.dk",
-              "de": "benutzer@domain.de",
+              "da": "bruger@domæne.dk",
+              "de": "benutzer@domäne.de",
               "en": "user@domain.com",
-              "es": "usuario@domain.es",
-              "fr": "utilisateur@domain.fr",
-              "it": "utente@domain.it",
+              "es": "usuario@dominio.es",
+              "fr": "utilisateur@domaine.fr",
+              "it": "utente@dominio.it",
               "ko": "user@domain.com",
-              "nl": "gebruiker@domain.nl",
-              "no": "bruker@domain.no",
-              "pl": "uzytkownik@domain.pl",
+              "nl": "gebruiker@domein.nl",
+              "no": "bruker@domene.no",
+              "pl": "uzytkownik@domena.pl",
               "ru": "user@domain.com",
-              "sv": "anvandare@domain.se"
+              "sv": "anvandare@domän.se"
             }
           },
           "template": "login_credentials"
@@ -11207,18 +11207,18 @@
             },
             "usernamePlaceholder": {
               "ar": "user@domain.com",
-              "da": "bruger@domain.dk",
-              "de": "benutzer@domain.de",
+              "da": "bruger@domæne.dk",
+              "de": "benutzer@domäne.de",
               "en": "user@domain.com",
-              "es": "usuario@domain.es",
-              "fr": "utilisateur@domain.fr",
-              "it": "utente@domain.it",
+              "es": "usuario@dominio.es",
+              "fr": "utilisateur@domaine.fr",
+              "it": "utente@dominio.it",
               "ko": "user@domain.com",
-              "nl": "gebruiker@domain.nl",
-              "no": "bruker@domain.no",
-              "pl": "uzytkownik@domain.pl",
+              "nl": "gebruiker@domein.nl",
+              "no": "bruker@domene.no",
+              "pl": "uzytkownik@domena.pl",
               "ru": "user@domain.com",
-              "sv": "anvandare@domain.se"
+              "sv": "anvandare@domän.se"
             }
           },
           "template": "login_credentials"


### PR DESCRIPTION
## What

The login **username placeholder** already localizes the local-part and the TLD (e.g. `utilisateur@domain.fr`, `benutzer@domain.de`) but kept the English word **"domain"**. This localizes it too, in the nine languages that translate the placeholder:

| | before | after |
|---|---|---|
| fr | utilisateur@**domain**.fr | utilisateur@**domaine**.fr |
| de | benutzer@**domain**.de | benutzer@**domäne**.de |
| es | usuario@**domain**.es | usuario@**dominio**.es |
| it | utente@**domain**.it | utente@**dominio**.it |
| nl | gebruiker@**domain**.nl | gebruiker@**domein**.nl |
| no | bruker@**domain**.no | bruker@**domene**.no |
| da | bruger@**domain**.dk | bruger@**domæne**.dk |
| sv | anvandare@**domain**.se | anvandare@**domän**.se |
| pl | uzytkownik@**domain**.pl | uzytkownik@**domena**.pl |

`en`, `ar`, `ko`, `ru` keep `user@domain.com` — they localize no part of the placeholder, so "domain" stays too.

Applies to all five driver login pairs via the shared `defaults.json` template. No version bump: rides in the still-unreleased 45.9.0.

## Note

The `sv` and `pl` local-parts are ASCII-folded (`anvandare`, `uzytkownik`) while the new domain words carry diacritics (`domän`) / are already ASCII (`domena`). I left the local-parts untouched; happy to un-fold them for full per-locale consistency if you'd like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)