### PR TITLE
refactor: neutralize the login placeholders to a single ASCII value

### DIFF
--- a/.homeycompose/drivers/templates/defaults.json
+++ b/.homeycompose/drivers/templates/defaults.json
@@ -775,21 +775,7 @@
           "ru": "Пароль",
           "sv": "Lösenord"
         },
-        "passwordPlaceholder": {
-          "ar": "P4ssw0rd",
-          "da": "P4ssw0rd",
-          "de": "P4ssw0rd",
-          "en": "P4ssw0rd",
-          "es": "P4ssw0rd",
-          "fr": "P4ssw0rd",
-          "it": "P4ssw0rd",
-          "ko": "P4ssw0rd",
-          "nl": "P4ssw0rd",
-          "no": "P4ssw0rd",
-          "pl": "P4ssw0rd",
-          "ru": "P4ssw0rd",
-          "sv": "P4ssw0rd"
-        },
+        "passwordPlaceholder": "P4ssw0rd",
         "usernameLabel": {
           "ar": "اسم المستخدم",
           "da": "Brugernavn",
@@ -805,21 +791,7 @@
           "ru": "Имя пользователя",
           "sv": "Användarnamn"
         },
-        "usernamePlaceholder": {
-          "ar": "user@domain.com",
-          "da": "bruger@domain.dk",
-          "de": "benutzer@domain.de",
-          "en": "user@domain.com",
-          "es": "usuario@domain.es",
-          "fr": "utilisateur@domain.fr",
-          "it": "utente@domain.it",
-          "ko": "user@domain.com",
-          "nl": "gebruiker@domain.nl",
-          "no": "bruker@domain.no",
-          "pl": "uzytkownik@domain.pl",
-          "ru": "user@domain.com",
-          "sv": "anvandare@domain.se"
-        }
+        "usernamePlaceholder": "name@example.com"
       },
       "template": "login_credentials"
     },
@@ -855,21 +827,7 @@
           "ru": "Пароль",
           "sv": "Lösenord"
         },
-        "passwordPlaceholder": {
-          "ar": "P4ssw0rd",
-          "da": "P4ssw0rd",
-          "de": "P4ssw0rd",
-          "en": "P4ssw0rd",
-          "es": "P4ssw0rd",
-          "fr": "P4ssw0rd",
-          "it": "P4ssw0rd",
-          "ko": "P4ssw0rd",
-          "nl": "P4ssw0rd",
-          "no": "P4ssw0rd",
-          "pl": "P4ssw0rd",
-          "ru": "P4ssw0rd",
-          "sv": "P4ssw0rd"
-        },
+        "passwordPlaceholder": "P4ssw0rd",
         "usernameLabel": {
           "ar": "اسم المستخدم",
           "da": "Brugernavn",
@@ -885,21 +843,7 @@
           "ru": "Имя пользователя",
           "sv": "Användarnamn"
         },
-        "usernamePlaceholder": {
-          "ar": "user@domain.com",
-          "da": "bruger@domain.dk",
-          "de": "benutzer@domain.de",
-          "en": "user@domain.com",
-          "es": "usuario@domain.es",
-          "fr": "utilisateur@domain.fr",
-          "it": "utente@domain.it",
-          "ko": "user@domain.com",
-          "nl": "gebruiker@domain.nl",
-          "no": "bruker@domain.no",
-          "pl": "uzytkownik@domain.pl",
-          "ru": "user@domain.com",
-          "sv": "anvandare@domain.se"
-        }
+        "usernamePlaceholder": "name@example.com"
       },
       "template": "login_credentials"
     }

--- a/.homeycompose/drivers/templates/defaults.json
+++ b/.homeycompose/drivers/templates/defaults.json
@@ -775,7 +775,6 @@
           "ru": "Пароль",
           "sv": "Lösenord"
         },
-        "passwordPlaceholder": "P4ssw0rd",
         "usernameLabel": {
           "ar": "اسم المستخدم",
           "da": "Brugernavn",
@@ -827,7 +826,6 @@
           "ru": "Пароль",
           "sv": "Lösenord"
         },
-        "passwordPlaceholder": "P4ssw0rd",
         "usernameLabel": {
           "ar": "اسم المستخدم",
           "da": "Brugernavn",

--- a/app.json
+++ b/app.json
@@ -4174,7 +4174,6 @@
               "ru": "Пароль",
               "sv": "Lösenord"
             },
-            "passwordPlaceholder": "P4ssw0rd",
             "usernameLabel": {
               "ar": "اسم المستخدم",
               "da": "Brugernavn",
@@ -4226,7 +4225,6 @@
               "ru": "Пароль",
               "sv": "Lösenord"
             },
-            "passwordPlaceholder": "P4ssw0rd",
             "usernameLabel": {
               "ar": "اسم المستخدم",
               "da": "Brugernavn",
@@ -5136,7 +5134,6 @@
               "ru": "Пароль",
               "sv": "Lösenord"
             },
-            "passwordPlaceholder": "P4ssw0rd",
             "usernameLabel": {
               "ar": "اسم المستخدم",
               "da": "Brugernavn",
@@ -5188,7 +5185,6 @@
               "ru": "Пароль",
               "sv": "Lösenord"
             },
-            "passwordPlaceholder": "P4ssw0rd",
             "usernameLabel": {
               "ar": "اسم المستخدم",
               "da": "Brugernavn",
@@ -6529,7 +6525,6 @@
               "ru": "Пароль",
               "sv": "Lösenord"
             },
-            "passwordPlaceholder": "P4ssw0rd",
             "usernameLabel": {
               "ar": "اسم المستخدم",
               "da": "Brugernavn",
@@ -6581,7 +6576,6 @@
               "ru": "Пароль",
               "sv": "Lösenord"
             },
-            "passwordPlaceholder": "P4ssw0rd",
             "usernameLabel": {
               "ar": "اسم المستخدم",
               "da": "Brugernavn",
@@ -8768,7 +8762,6 @@
               "ru": "Пароль",
               "sv": "Lösenord"
             },
-            "passwordPlaceholder": "P4ssw0rd",
             "usernameLabel": {
               "ar": "اسم المستخدم",
               "da": "Brugernavn",
@@ -8820,7 +8813,6 @@
               "ru": "Пароль",
               "sv": "Lösenord"
             },
-            "passwordPlaceholder": "P4ssw0rd",
             "usernameLabel": {
               "ar": "اسم المستخدم",
               "da": "Brugernavn",
@@ -10871,7 +10863,6 @@
               "ru": "Пароль",
               "sv": "Lösenord"
             },
-            "passwordPlaceholder": "P4ssw0rd",
             "usernameLabel": {
               "ar": "اسم المستخدم",
               "da": "Brugernavn",
@@ -10923,7 +10914,6 @@
               "ru": "Пароль",
               "sv": "Lösenord"
             },
-            "passwordPlaceholder": "P4ssw0rd",
             "usernameLabel": {
               "ar": "اسم المستخدم",
               "da": "Brugernavn",

--- a/app.json
+++ b/app.json
@@ -4174,21 +4174,7 @@
               "ru": "Пароль",
               "sv": "Lösenord"
             },
-            "passwordPlaceholder": {
-              "ar": "P4ssw0rd",
-              "da": "P4ssw0rd",
-              "de": "P4ssw0rd",
-              "en": "P4ssw0rd",
-              "es": "P4ssw0rd",
-              "fr": "P4ssw0rd",
-              "it": "P4ssw0rd",
-              "ko": "P4ssw0rd",
-              "nl": "P4ssw0rd",
-              "no": "P4ssw0rd",
-              "pl": "P4ssw0rd",
-              "ru": "P4ssw0rd",
-              "sv": "P4ssw0rd"
-            },
+            "passwordPlaceholder": "P4ssw0rd",
             "usernameLabel": {
               "ar": "اسم المستخدم",
               "da": "Brugernavn",
@@ -4204,21 +4190,7 @@
               "ru": "Имя пользователя",
               "sv": "Användarnamn"
             },
-            "usernamePlaceholder": {
-              "ar": "user@domain.com",
-              "da": "bruger@domain.dk",
-              "de": "benutzer@domain.de",
-              "en": "user@domain.com",
-              "es": "usuario@domain.es",
-              "fr": "utilisateur@domain.fr",
-              "it": "utente@domain.it",
-              "ko": "user@domain.com",
-              "nl": "gebruiker@domain.nl",
-              "no": "bruker@domain.no",
-              "pl": "uzytkownik@domain.pl",
-              "ru": "user@domain.com",
-              "sv": "anvandare@domain.se"
-            }
+            "usernamePlaceholder": "name@example.com"
           },
           "template": "login_credentials"
         },
@@ -4254,21 +4226,7 @@
               "ru": "Пароль",
               "sv": "Lösenord"
             },
-            "passwordPlaceholder": {
-              "ar": "P4ssw0rd",
-              "da": "P4ssw0rd",
-              "de": "P4ssw0rd",
-              "en": "P4ssw0rd",
-              "es": "P4ssw0rd",
-              "fr": "P4ssw0rd",
-              "it": "P4ssw0rd",
-              "ko": "P4ssw0rd",
-              "nl": "P4ssw0rd",
-              "no": "P4ssw0rd",
-              "pl": "P4ssw0rd",
-              "ru": "P4ssw0rd",
-              "sv": "P4ssw0rd"
-            },
+            "passwordPlaceholder": "P4ssw0rd",
             "usernameLabel": {
               "ar": "اسم المستخدم",
               "da": "Brugernavn",
@@ -4284,21 +4242,7 @@
               "ru": "Имя пользователя",
               "sv": "Användarnamn"
             },
-            "usernamePlaceholder": {
-              "ar": "user@domain.com",
-              "da": "bruger@domain.dk",
-              "de": "benutzer@domain.de",
-              "en": "user@domain.com",
-              "es": "usuario@domain.es",
-              "fr": "utilisateur@domain.fr",
-              "it": "utente@domain.it",
-              "ko": "user@domain.com",
-              "nl": "gebruiker@domain.nl",
-              "no": "bruker@domain.no",
-              "pl": "uzytkownik@domain.pl",
-              "ru": "user@domain.com",
-              "sv": "anvandare@domain.se"
-            }
+            "usernamePlaceholder": "name@example.com"
           },
           "template": "login_credentials"
         }
@@ -5192,21 +5136,7 @@
               "ru": "Пароль",
               "sv": "Lösenord"
             },
-            "passwordPlaceholder": {
-              "ar": "P4ssw0rd",
-              "da": "P4ssw0rd",
-              "de": "P4ssw0rd",
-              "en": "P4ssw0rd",
-              "es": "P4ssw0rd",
-              "fr": "P4ssw0rd",
-              "it": "P4ssw0rd",
-              "ko": "P4ssw0rd",
-              "nl": "P4ssw0rd",
-              "no": "P4ssw0rd",
-              "pl": "P4ssw0rd",
-              "ru": "P4ssw0rd",
-              "sv": "P4ssw0rd"
-            },
+            "passwordPlaceholder": "P4ssw0rd",
             "usernameLabel": {
               "ar": "اسم المستخدم",
               "da": "Brugernavn",
@@ -5222,21 +5152,7 @@
               "ru": "Имя пользователя",
               "sv": "Användarnamn"
             },
-            "usernamePlaceholder": {
-              "ar": "user@domain.com",
-              "da": "bruger@domain.dk",
-              "de": "benutzer@domain.de",
-              "en": "user@domain.com",
-              "es": "usuario@domain.es",
-              "fr": "utilisateur@domain.fr",
-              "it": "utente@domain.it",
-              "ko": "user@domain.com",
-              "nl": "gebruiker@domain.nl",
-              "no": "bruker@domain.no",
-              "pl": "uzytkownik@domain.pl",
-              "ru": "user@domain.com",
-              "sv": "anvandare@domain.se"
-            }
+            "usernamePlaceholder": "name@example.com"
           },
           "template": "login_credentials"
         },
@@ -5272,21 +5188,7 @@
               "ru": "Пароль",
               "sv": "Lösenord"
             },
-            "passwordPlaceholder": {
-              "ar": "P4ssw0rd",
-              "da": "P4ssw0rd",
-              "de": "P4ssw0rd",
-              "en": "P4ssw0rd",
-              "es": "P4ssw0rd",
-              "fr": "P4ssw0rd",
-              "it": "P4ssw0rd",
-              "ko": "P4ssw0rd",
-              "nl": "P4ssw0rd",
-              "no": "P4ssw0rd",
-              "pl": "P4ssw0rd",
-              "ru": "P4ssw0rd",
-              "sv": "P4ssw0rd"
-            },
+            "passwordPlaceholder": "P4ssw0rd",
             "usernameLabel": {
               "ar": "اسم المستخدم",
               "da": "Brugernavn",
@@ -5302,21 +5204,7 @@
               "ru": "Имя пользователя",
               "sv": "Användarnamn"
             },
-            "usernamePlaceholder": {
-              "ar": "user@domain.com",
-              "da": "bruger@domain.dk",
-              "de": "benutzer@domain.de",
-              "en": "user@domain.com",
-              "es": "usuario@domain.es",
-              "fr": "utilisateur@domain.fr",
-              "it": "utente@domain.it",
-              "ko": "user@domain.com",
-              "nl": "gebruiker@domain.nl",
-              "no": "bruker@domain.no",
-              "pl": "uzytkownik@domain.pl",
-              "ru": "user@domain.com",
-              "sv": "anvandare@domain.se"
-            }
+            "usernamePlaceholder": "name@example.com"
           },
           "template": "login_credentials"
         }
@@ -6641,21 +6529,7 @@
               "ru": "Пароль",
               "sv": "Lösenord"
             },
-            "passwordPlaceholder": {
-              "ar": "P4ssw0rd",
-              "da": "P4ssw0rd",
-              "de": "P4ssw0rd",
-              "en": "P4ssw0rd",
-              "es": "P4ssw0rd",
-              "fr": "P4ssw0rd",
-              "it": "P4ssw0rd",
-              "ko": "P4ssw0rd",
-              "nl": "P4ssw0rd",
-              "no": "P4ssw0rd",
-              "pl": "P4ssw0rd",
-              "ru": "P4ssw0rd",
-              "sv": "P4ssw0rd"
-            },
+            "passwordPlaceholder": "P4ssw0rd",
             "usernameLabel": {
               "ar": "اسم المستخدم",
               "da": "Brugernavn",
@@ -6671,21 +6545,7 @@
               "ru": "Имя пользователя",
               "sv": "Användarnamn"
             },
-            "usernamePlaceholder": {
-              "ar": "user@domain.com",
-              "da": "bruger@domain.dk",
-              "de": "benutzer@domain.de",
-              "en": "user@domain.com",
-              "es": "usuario@domain.es",
-              "fr": "utilisateur@domain.fr",
-              "it": "utente@domain.it",
-              "ko": "user@domain.com",
-              "nl": "gebruiker@domain.nl",
-              "no": "bruker@domain.no",
-              "pl": "uzytkownik@domain.pl",
-              "ru": "user@domain.com",
-              "sv": "anvandare@domain.se"
-            }
+            "usernamePlaceholder": "name@example.com"
           },
           "template": "login_credentials"
         },
@@ -6721,21 +6581,7 @@
               "ru": "Пароль",
               "sv": "Lösenord"
             },
-            "passwordPlaceholder": {
-              "ar": "P4ssw0rd",
-              "da": "P4ssw0rd",
-              "de": "P4ssw0rd",
-              "en": "P4ssw0rd",
-              "es": "P4ssw0rd",
-              "fr": "P4ssw0rd",
-              "it": "P4ssw0rd",
-              "ko": "P4ssw0rd",
-              "nl": "P4ssw0rd",
-              "no": "P4ssw0rd",
-              "pl": "P4ssw0rd",
-              "ru": "P4ssw0rd",
-              "sv": "P4ssw0rd"
-            },
+            "passwordPlaceholder": "P4ssw0rd",
             "usernameLabel": {
               "ar": "اسم المستخدم",
               "da": "Brugernavn",
@@ -6751,21 +6597,7 @@
               "ru": "Имя пользователя",
               "sv": "Användarnamn"
             },
-            "usernamePlaceholder": {
-              "ar": "user@domain.com",
-              "da": "bruger@domain.dk",
-              "de": "benutzer@domain.de",
-              "en": "user@domain.com",
-              "es": "usuario@domain.es",
-              "fr": "utilisateur@domain.fr",
-              "it": "utente@domain.it",
-              "ko": "user@domain.com",
-              "nl": "gebruiker@domain.nl",
-              "no": "bruker@domain.no",
-              "pl": "uzytkownik@domain.pl",
-              "ru": "user@domain.com",
-              "sv": "anvandare@domain.se"
-            }
+            "usernamePlaceholder": "name@example.com"
           },
           "template": "login_credentials"
         }
@@ -8936,21 +8768,7 @@
               "ru": "Пароль",
               "sv": "Lösenord"
             },
-            "passwordPlaceholder": {
-              "ar": "P4ssw0rd",
-              "da": "P4ssw0rd",
-              "de": "P4ssw0rd",
-              "en": "P4ssw0rd",
-              "es": "P4ssw0rd",
-              "fr": "P4ssw0rd",
-              "it": "P4ssw0rd",
-              "ko": "P4ssw0rd",
-              "nl": "P4ssw0rd",
-              "no": "P4ssw0rd",
-              "pl": "P4ssw0rd",
-              "ru": "P4ssw0rd",
-              "sv": "P4ssw0rd"
-            },
+            "passwordPlaceholder": "P4ssw0rd",
             "usernameLabel": {
               "ar": "اسم المستخدم",
               "da": "Brugernavn",
@@ -8966,21 +8784,7 @@
               "ru": "Имя пользователя",
               "sv": "Användarnamn"
             },
-            "usernamePlaceholder": {
-              "ar": "user@domain.com",
-              "da": "bruger@domain.dk",
-              "de": "benutzer@domain.de",
-              "en": "user@domain.com",
-              "es": "usuario@domain.es",
-              "fr": "utilisateur@domain.fr",
-              "it": "utente@domain.it",
-              "ko": "user@domain.com",
-              "nl": "gebruiker@domain.nl",
-              "no": "bruker@domain.no",
-              "pl": "uzytkownik@domain.pl",
-              "ru": "user@domain.com",
-              "sv": "anvandare@domain.se"
-            }
+            "usernamePlaceholder": "name@example.com"
           },
           "template": "login_credentials"
         },
@@ -9016,21 +8820,7 @@
               "ru": "Пароль",
               "sv": "Lösenord"
             },
-            "passwordPlaceholder": {
-              "ar": "P4ssw0rd",
-              "da": "P4ssw0rd",
-              "de": "P4ssw0rd",
-              "en": "P4ssw0rd",
-              "es": "P4ssw0rd",
-              "fr": "P4ssw0rd",
-              "it": "P4ssw0rd",
-              "ko": "P4ssw0rd",
-              "nl": "P4ssw0rd",
-              "no": "P4ssw0rd",
-              "pl": "P4ssw0rd",
-              "ru": "P4ssw0rd",
-              "sv": "P4ssw0rd"
-            },
+            "passwordPlaceholder": "P4ssw0rd",
             "usernameLabel": {
               "ar": "اسم المستخدم",
               "da": "Brugernavn",
@@ -9046,21 +8836,7 @@
               "ru": "Имя пользователя",
               "sv": "Användarnamn"
             },
-            "usernamePlaceholder": {
-              "ar": "user@domain.com",
-              "da": "bruger@domain.dk",
-              "de": "benutzer@domain.de",
-              "en": "user@domain.com",
-              "es": "usuario@domain.es",
-              "fr": "utilisateur@domain.fr",
-              "it": "utente@domain.it",
-              "ko": "user@domain.com",
-              "nl": "gebruiker@domain.nl",
-              "no": "bruker@domain.no",
-              "pl": "uzytkownik@domain.pl",
-              "ru": "user@domain.com",
-              "sv": "anvandare@domain.se"
-            }
+            "usernamePlaceholder": "name@example.com"
           },
           "template": "login_credentials"
         }
@@ -11095,21 +10871,7 @@
               "ru": "Пароль",
               "sv": "Lösenord"
             },
-            "passwordPlaceholder": {
-              "ar": "P4ssw0rd",
-              "da": "P4ssw0rd",
-              "de": "P4ssw0rd",
-              "en": "P4ssw0rd",
-              "es": "P4ssw0rd",
-              "fr": "P4ssw0rd",
-              "it": "P4ssw0rd",
-              "ko": "P4ssw0rd",
-              "nl": "P4ssw0rd",
-              "no": "P4ssw0rd",
-              "pl": "P4ssw0rd",
-              "ru": "P4ssw0rd",
-              "sv": "P4ssw0rd"
-            },
+            "passwordPlaceholder": "P4ssw0rd",
             "usernameLabel": {
               "ar": "اسم المستخدم",
               "da": "Brugernavn",
@@ -11125,21 +10887,7 @@
               "ru": "Имя пользователя",
               "sv": "Användarnamn"
             },
-            "usernamePlaceholder": {
-              "ar": "user@domain.com",
-              "da": "bruger@domain.dk",
-              "de": "benutzer@domain.de",
-              "en": "user@domain.com",
-              "es": "usuario@domain.es",
-              "fr": "utilisateur@domain.fr",
-              "it": "utente@domain.it",
-              "ko": "user@domain.com",
-              "nl": "gebruiker@domain.nl",
-              "no": "bruker@domain.no",
-              "pl": "uzytkownik@domain.pl",
-              "ru": "user@domain.com",
-              "sv": "anvandare@domain.se"
-            }
+            "usernamePlaceholder": "name@example.com"
           },
           "template": "login_credentials"
         },
@@ -11175,21 +10923,7 @@
               "ru": "Пароль",
               "sv": "Lösenord"
             },
-            "passwordPlaceholder": {
-              "ar": "P4ssw0rd",
-              "da": "P4ssw0rd",
-              "de": "P4ssw0rd",
-              "en": "P4ssw0rd",
-              "es": "P4ssw0rd",
-              "fr": "P4ssw0rd",
-              "it": "P4ssw0rd",
-              "ko": "P4ssw0rd",
-              "nl": "P4ssw0rd",
-              "no": "P4ssw0rd",
-              "pl": "P4ssw0rd",
-              "ru": "P4ssw0rd",
-              "sv": "P4ssw0rd"
-            },
+            "passwordPlaceholder": "P4ssw0rd",
             "usernameLabel": {
               "ar": "اسم المستخدم",
               "da": "Brugernavn",
@@ -11205,21 +10939,7 @@
               "ru": "Имя пользователя",
               "sv": "Användarnamn"
             },
-            "usernamePlaceholder": {
-              "ar": "user@domain.com",
-              "da": "bruger@domain.dk",
-              "de": "benutzer@domain.de",
-              "en": "user@domain.com",
-              "es": "usuario@domain.es",
-              "fr": "utilisateur@domain.fr",
-              "it": "utente@domain.it",
-              "ko": "user@domain.com",
-              "nl": "gebruiker@domain.nl",
-              "no": "bruker@domain.no",
-              "pl": "uzytkownik@domain.pl",
-              "ru": "user@domain.com",
-              "sv": "anvandare@domain.se"
-            }
+            "usernamePlaceholder": "name@example.com"
           },
           "template": "login_credentials"
         }

--- a/app.mts
+++ b/app.mts
@@ -153,8 +153,11 @@ const mergeDeviceSettings = (
   }
 }
 
-const localize = (strings: LocalizedStrings, language: string): string =>
-  strings[language] ?? strings.en
+const localize = (
+  strings: string | LocalizedStrings,
+  language: string,
+): string =>
+  typeof strings === 'string' ? strings : (strings[language] ?? strings.en)
 
 const getDriverSettings = (
   { id: driverId, name, settings }: ManifestDriver,

--- a/tests/unit/app.test.ts
+++ b/tests/unit/app.test.ts
@@ -236,9 +236,9 @@ const mockManifestDrivers: ManifestDriver[] = [
         id: 'login',
         options: {
           passwordLabel: { en: 'Password' },
-          passwordPlaceholder: { en: 'Your password' },
+          passwordPlaceholder: 'Your password',
           usernameLabel: { en: 'Email', nl: 'E-mail' },
-          usernamePlaceholder: { en: 'Your email' },
+          usernamePlaceholder: 'Your email',
         },
       },
     ],
@@ -1131,7 +1131,7 @@ describe('melCloudApp', () => {
       expect(setting?.title).toBe('Setting 1')
     })
 
-    it('should fall back to English login labels and placeholders', async () => {
+    it('should fall back to English login labels and keep plain placeholders', async () => {
       mockGetLanguage.mockReturnValue('fr')
       app = createApp()
       await app.onInit()
@@ -2732,9 +2732,9 @@ describe('melCloudApp', () => {
                 id: 'login' as const,
                 options: {
                   passwordLabel: { en: 'Password' },
-                  passwordPlaceholder: { en: 'Enter password' },
+                  passwordPlaceholder: 'Enter password',
                   usernameLabel: { en: 'Username' },
-                  usernamePlaceholder: { en: 'Enter username' },
+                  usernamePlaceholder: 'Enter username',
                 },
               },
             ],
@@ -2742,9 +2742,9 @@ describe('melCloudApp', () => {
               id: 'login' as const,
               options: {
                 passwordLabel: { en: 'Password' },
-                passwordPlaceholder: { en: 'Enter password' },
+                passwordPlaceholder: 'Enter password',
                 usernameLabel: { en: 'Username' },
-                usernamePlaceholder: { en: 'Enter username' },
+                usernamePlaceholder: 'Enter username',
               },
             },
           ),

--- a/types/manifest.mts
+++ b/types/manifest.mts
@@ -27,9 +27,12 @@ export interface LoginSetting extends PairSetting {
   readonly id: 'login'
   readonly options: {
     readonly passwordLabel: LocalizedStrings
-    readonly passwordPlaceholder: LocalizedStrings
+    // Placeholders are neutral ASCII (an email/password is ASCII), so they
+    // carry a single value rather than per-locale strings — the label holds
+    // the localization.
+    readonly passwordPlaceholder: string
     readonly usernameLabel: LocalizedStrings
-    readonly usernamePlaceholder: LocalizedStrings
+    readonly usernamePlaceholder: string
   }
 }
 

--- a/types/manifest.mts
+++ b/types/manifest.mts
@@ -27,12 +27,13 @@ export interface LoginSetting extends PairSetting {
   readonly id: 'login'
   readonly options: {
     readonly passwordLabel: LocalizedStrings
-    // Placeholders are neutral ASCII (an email/password is ASCII), so they
-    // carry a single value rather than per-locale strings — the label holds
-    // the localization.
-    readonly passwordPlaceholder: string
     readonly usernameLabel: LocalizedStrings
     readonly usernamePlaceholder: string
+    // A password has no format to illustrate and the label already names the
+    // field, so it carries no placeholder. The username placeholder is a
+    // single neutral ASCII example (an email is ASCII), not per-locale
+    // strings — the labels hold the localization.
+    readonly passwordPlaceholder?: string
   }
 }
 


### PR DESCRIPTION
## What

Rethinks the login **placeholders** (username + password), in both the **pair** and **repair** login options:

| field | before | after |
|---|---|---|
| username | per-locale email (`utilisateur@domain.fr`, …) | **`name@example.com`** — one neutral ASCII value, every language |
| password | per-locale (13× `P4ssw0rd`) | **removed** — no placeholder |

## Why

**Username** — an email is ASCII (the domain must be ASCII/punycode; Arabic/Cyrillic and even accented Latin aren't valid). Localizing the example string models invalid addresses and implies non-ASCII input. Best practice: a neutral ASCII example on the RFC 2606 reserved `example.com` (the old `domain.com` is a *real* domain). It's genuinely useful here because the label says "Username" but the value is an email. A single value needs no locale tags → plain string.

**Password** — a password has no format to illustrate and the "Password" label already names the field, so the placeholder only restated the obvious. As a plain string, `"passwordPlaceholder": "P4ssw0rd"` also tripped SonarCloud's hardcoded-credential detector (false positive), so it's removed entirely.

Localization stays on the **labels** (incl. native scripts: `اسم المستخدم`, `Имя пользователя`, `사용자 이름`).

## Code impact

- `localize()` accepts `string | LocalizedStrings` (a plain string passes through).
- `LoginSetting.usernamePlaceholder: string`; `passwordPlaceholder?: string` (optional).
- `settings/index` unaffected (consumes the post-`localize` plain string; handles an undefined placeholder).
- Tests updated; 100% coverage kept.

No version bump: rides in the still-unreleased 45.9.0. Supersedes #1459.

🤖 Generated with [Claude Code](https://claude.com/claude-code)