### PR TITLE
feat: unify flat zone pickers over two shared sources

### DIFF
--- a/app.mts
+++ b/app.mts
@@ -63,6 +63,14 @@ import { type Homey, App } from './lib/homey.mts'
 import { getTimeZone } from './lib/temporal.mts'
 import { typedFromEntries } from './lib/typed-object.mts'
 import { unwrapResult } from './lib/unwrap-result.mts'
+import { toZoneValueData } from './lib/validation.mts'
+import {
+  getHomeBuildingId,
+  getHomeDeviceId,
+  getZoneId,
+  isHomeBuildingValue,
+  isHomeDeviceValue,
+} from './public/zones.mts'
 import { fanSpeedValues } from './types/ata-erv.mts'
 
 // Locale-aware by-name comparator shared by every zone/building sort.
@@ -127,18 +135,15 @@ const toDurationDays = (duration: unknown): number => {
 }
 
 // Flow-action arguments shared by the holiday-mode cards: `zone` always,
-// `duration`/`time` only on the cards that declare them.
+// `duration`/`time` only on the cards that declare them. The zone carries
+// its `${model}_${id}` option value as `id` — the shape every stored card
+// arg has always had — so run listeners route by parsing it (legacy Flows
+// included) and never need the structured coordinates threaded back.
 interface HolidayModeActionArgs {
-  zone: HolidayModeTarget
+  zone: FlatZoneItem
   duration?: unknown
   time?: unknown
 }
-
-// A holiday-mode flow target: a Classic zone/device (zone coordinates) or a
-// single Home device (its id). Run listeners discriminate on `deviceId`.
-type HolidayModeTarget =
-  | { readonly deviceId: string; readonly id: string; readonly name: string }
-  | (DeviceOrZoneData & { readonly id: string; readonly name: string })
 
 const formatErrors = (errors: Record<string, readonly string[]>): string =>
   Object.entries(errors)
@@ -258,16 +263,42 @@ type ClassicAtaGroupFacade = Pick<
   'getGroup' | 'updateGroupState'
 >
 
-// Devices flat-listed outside their zone tree (chart pickers, device
-// autocompletes) carry their building name, so same-named devices on
-// different buildings stay tellable apart; tree-shaped lists keep the
-// bare name — the hierarchy already locates the device.
-const toFlatDeviceName = (name: string, buildingName?: string): string => {
-  const trimmed = name.trim()
-  return buildingName === undefined ? trimmed : (
-      `${trimmed} (${buildingName.trim()})`
-    )
+// A flat autocomplete/select item: the `${model}_${id}` option value as
+// `id` (unique, and the routing key run listeners parse) plus the display
+// name. Shared by the holiday flow cards and the settings zone selector.
+interface FlatZoneItem {
+  readonly id: string
+  readonly name: string
 }
+
+// A node from either zone source: a Classic zone (carrying its building
+// name since melcloud-api 43.1.0) or a Home building/device (same shape).
+// The single vocabulary every picker draws from.
+type PickerNode = Classic.FlatZone | HomeBuildingZone | HomeDeviceZone
+
+// A flat picker lists every node at one level, so a leaf's bare name can
+// collide with a same-named leaf on another building; suffixing it with its
+// owning building keeps them apart. Building nodes locate themselves and
+// keep the bare name — as do tree-shaped lists, where the hierarchy already
+// places each node. The one suffix rule for every flat surface (holiday
+// flow, chart and group widget pickers).
+const toFlatName = ({ buildingName, model, name }: PickerNode): string => {
+  const trimmed = name.trim()
+  return model === 'buildings' || model === 'homeBuildings' ?
+      trimmed
+    : `${trimmed} (${buildingName.trim()})`
+}
+
+// Flat autocomplete items over the given nodes, name-sorted. The selected
+// item's `id` carries the `${model}_${id}` routing — run listeners parse it,
+// needing no structured coordinates.
+const toFlatZoneItems = (nodes: readonly PickerNode[]): FlatZoneItem[] =>
+  nodes
+    .map((node) => ({
+      id: getZoneId(node.id, node.model),
+      name: toFlatName(node),
+    }))
+    .toSorted(byName)
 
 const filterZonesByName = <T extends { readonly name: string }>(
   zones: readonly T[],
@@ -276,27 +307,6 @@ const filterZonesByName = <T extends { readonly name: string }>(
   const lowerCaseQuery = query.toLowerCase()
   return zones.filter(({ name }) => name.toLowerCase().includes(lowerCaseQuery))
 }
-
-// Flow autocomplete items over the given zones (including single devices,
-// which the holiday mode endpoints also accept). The zone target is
-// carried on the selected item so run listeners need no id parsing.
-const toZoneAutocompleteItems = (
-  zones: readonly Classic.Zone[],
-): (DeviceOrZoneData & { id: string; name: string })[] =>
-  zones.map(({ id, model, name }) => ({
-    id: `${model}_${String(id)}`,
-    name,
-    zoneId: String(id),
-    zoneType: model,
-  }))
-
-// Flow autocomplete items over Home devices: each device is a standalone
-// holiday-mode target, carried by id so run listeners route to the Home
-// batch endpoints without id parsing.
-const toHomeDeviceAutocompleteItems = (
-  zones: readonly HomeDeviceZone[],
-): { deviceId: string; id: string; name: string }[] =>
-  zones.map(({ id, name }) => ({ deviceId: id, id: `homeDevices_${id}`, name }))
 
 // MELCloud reports error timestamps either as UTC instants (Z or offset
 // suffix) or as wall-clock times in the building's timezone.
@@ -537,20 +547,16 @@ export default class MELCloudApp extends App {
     )
   }
 
+  // The chart pickers' Classic vocabulary: the flat device leaves, each
+  // suffixed with its building, drawn from the shared zone source.
   public getClassicDeviceZones(type?: Classic.DeviceType): Classic.Zone[] {
-    const devices =
-      type === undefined ?
-        this.#classicRegistry.getDevices()
-      : this.#classicRegistry.getDevicesByType(type)
-    return devices
-      .map((device) => ({
-        id: device.id,
-        level: 1,
+    return this.getClassicTargets(type)
+      .filter(({ model }) => model === 'devices')
+      .map((node) => ({
+        id: node.id,
+        level: node.level,
         model: 'devices' as const,
-        name: toFlatDeviceName(
-          device.name,
-          this.#classicRegistry.buildings.getById(device.buildingId)?.name,
-        ),
+        name: toFlatName(node),
       }))
       .toSorted(byName)
   }
@@ -654,6 +660,14 @@ export default class MELCloudApp extends App {
     return unwrapResult(
       await this.getClassicFacade('devices', deviceId).getSignalStrength(hour),
     )
+  }
+
+  // The Classic zone source: every zone (buildings, floors, areas, devices)
+  // flattened, each stamped with its owning building name (melcloud-api
+  // 43.1.0), optionally narrowed to one device type. Every flat Classic
+  // picker draws from here with the filters it needs.
+  public getClassicTargets(type?: Classic.DeviceType): Classic.FlatZone[] {
+    return this.#facadeManager.getZones(type === undefined ? {} : { type })
   }
 
   public async getClassicTemperatures({
@@ -824,20 +838,13 @@ export default class MELCloudApp extends App {
     return this.#homeRegistry.getByType(type)
   }
 
-  // The charts widget vocabulary: Home devices as flat selectable
-  // entries (no building nodes), alpha-sorted, both types by default.
+  // The charts widget vocabulary: Home devices as flat selectable entries
+  // (no building nodes), each suffixed with its building, alpha-sorted, both
+  // types by default — the device leaves of the shared Home source.
   public getHomeDeviceZones(type?: Home.DeviceType): HomeDeviceZone[] {
-    const devices =
-      type === undefined ?
-        this.#homeRegistry.getAll()
-      : this.#homeRegistry.getByType(type)
-    return devices
-      .map((device): HomeDeviceZone => ({
-        id: device.id,
-        level: 1,
-        model: 'homeDevices',
-        name: toFlatDeviceName(device.name, device.building.name),
-      }))
+    return this.getHomeTargets(type)
+      .filter((node): node is HomeDeviceZone => node.model === 'homeDevices')
+      .map((node) => ({ ...node, name: toFlatName(node) }))
       .toSorted(byName)
   }
 
@@ -947,6 +954,7 @@ export default class MELCloudApp extends App {
         name: device.building.name,
       }
       building.devices.push({
+        buildingName: device.building.name,
         id: device.id,
         level: 1,
         model: 'homeDevices',
@@ -960,6 +968,7 @@ export default class MELCloudApp extends App {
         ([id, { devices: buildingDevices, name }]): HomeBuildingZone & {
           devices: HomeDeviceZone[]
         } => ({
+          buildingName: name,
           devices: buildingDevices,
           id,
           level: 0,
@@ -1508,6 +1517,25 @@ export default class MELCloudApp extends App {
     this.#homeFacadeManager = new Home.FacadeManager(this.#homeApi)
   }
 
+  // Is holiday mode on for a flat target value? A single Home device, or a
+  // whole Home building (on only when every device agrees), or a Classic
+  // zone/device — routed by parsing the option value.
+  async #isHolidayModeEnabled(value: string): Promise<boolean> {
+    if (isHomeDeviceValue(value)) {
+      return this.getHomeHolidayMode(getHomeDeviceId(value))?.enabled === true
+    }
+    if (isHomeBuildingValue(value)) {
+      return (
+        this.getHomeBuildingHolidayMode(getHomeBuildingId(value)).HMEnabled ===
+        true
+      )
+    }
+    const { HMEnabled: isEnabled } = await this.getClassicHolidayMode(
+      toZoneValueData(value),
+    )
+    return isEnabled
+  }
+
   async #logBootReady(): Promise<void> {
     await this.homey.ready()
     this.log('Boot: ready after', process.uptime().toFixed(1), 's')
@@ -1584,17 +1612,7 @@ export default class MELCloudApp extends App {
       this.#searchHolidayModeTargets(query),
     )
     card.registerRunListener(async (args: HolidayModeActionArgs) => {
-      const settings = toSettings(args)
-      const { zone } = args
-      if ('deviceId' in zone) {
-        await this.updateHomeHolidayMode([zone.deviceId], settings)
-        return
-      }
-      await this.updateClassicHolidayMode({
-        settings,
-        zoneId: zone.zoneId,
-        zoneType: zone.zoneType,
-      })
+      await this.#updateHolidayModeTarget(args.zone.id, toSettings(args))
     })
   }
 
@@ -1603,16 +1621,9 @@ export default class MELCloudApp extends App {
     card.registerArgumentAutocompleteListener('zone', (query) =>
       this.#searchHolidayModeTargets(query),
     )
-    card.registerRunListener(async ({ zone }: { zone: HolidayModeTarget }) => {
-      if ('deviceId' in zone) {
-        return this.getHomeHolidayMode(zone.deviceId)?.enabled === true
-      }
-      const { HMEnabled: isEnabled } = await this.getClassicHolidayMode({
-        zoneId: zone.zoneId,
-        zoneType: zone.zoneType,
-      })
-      return isEnabled
-    })
+    card.registerRunListener(async ({ zone }: { zone: FlatZoneItem }) =>
+      this.#isHolidayModeEnabled(zone.id),
+    )
   }
 
   #registerWidgetListeners(): void {
@@ -1631,40 +1642,29 @@ export default class MELCloudApp extends App {
       )
   }
 
-  // Everything the ATA group widget can target: the Classic zones and
-  // devices, then the Home buildings with their devices (alpha-sorted).
+  // Everything the ATA group widget can target: every Classic zone/device
+  // and every Home building/device, each leaf suffixed with its building
+  // and the whole list drawn from the two shared sources.
   #searchAtaTargets(
     query: string,
   ): (Classic.Zone | HomeBuildingZone | HomeDeviceZone)[] {
-    return [
-      ...this.#searchZones(query, { type: Classic.DeviceType.Ata }),
-      ...filterZonesByName(this.getHomeTargets(Home.DeviceType.Ata), query),
-    ]
-  }
-
-  // Holiday-mode / condition targets: Classic zones and devices, then the
-  // individual Home devices (alpha-sorted). Each selected item carries its
-  // own routing — zone coordinates or a Home device id.
-  #searchHolidayModeTargets(query: string): HolidayModeTarget[] {
-    return [
-      ...toZoneAutocompleteItems(this.#searchZones(query)),
-      ...toHomeDeviceAutocompleteItems(
-        filterZonesByName(this.getHomeDeviceZones(), query),
-      ),
-    ].toSorted(byName)
-  }
-
-  // One zone-search pipeline for the tree-shaped autocomplete surfaces
-  // (flow zones, ATA group targets): registry fetch (instance state),
-  // optional type narrowing, then query filtering.
-  #searchZones(
-    query: string,
-    { type }: { type?: Classic.DeviceType } = {},
-  ): Classic.Zone[] {
-    const zones = this.#facadeManager.getZones(
-      type === undefined ? {} : { type },
+    return filterZonesByName(
+      [
+        ...this.getClassicTargets(Classic.DeviceType.Ata),
+        ...this.getHomeTargets(Home.DeviceType.Ata),
+      ].map((node) => ({ ...node, name: toFlatName(node) })),
+      query,
     )
-    return filterZonesByName(zones, query)
+  }
+
+  // Holiday-mode / condition targets: every Classic zone/device and every
+  // Home building/device, each carrying its `${model}_${id}` routing value
+  // and a building-suffixed display name, name-sorted.
+  #searchHolidayModeTargets(query: string): FlatZoneItem[] {
+    return filterZonesByName(
+      toFlatZoneItems([...this.getClassicTargets(), ...this.getHomeTargets()]),
+      query,
+    )
   }
 
   // Residual credentials on an API without any paired device only get
@@ -1681,5 +1681,27 @@ export default class MELCloudApp extends App {
     this.#sessionLossStates.delete(api)
     this.log('Session lost on', api, 'ignored: no paired device')
     return false
+  }
+
+  // Route a holiday-mode write from a flat target value: a single Home
+  // device, a whole Home building (its devices batched), or a Classic
+  // zone/device — the same value parsing the settings page uses.
+  async #updateHolidayModeTarget(
+    value: string,
+    settings: HolidayModeUpdate,
+  ): Promise<void> {
+    if (isHomeDeviceValue(value)) {
+      await this.updateHomeHolidayMode([getHomeDeviceId(value)], settings)
+    } else if (isHomeBuildingValue(value)) {
+      await this.updateHomeBuildingHolidayMode(
+        getHomeBuildingId(value),
+        settings,
+      )
+    } else {
+      await this.updateClassicHolidayMode({
+        settings,
+        ...toZoneValueData(value),
+      })
+    }
   }
 }

--- a/lib/validation.mts
+++ b/lib/validation.mts
@@ -4,16 +4,16 @@ import type { DeviceOrZoneData, ZoneData } from '../types/zone.mts'
 
 const HOUR_MAX = 23
 
-const zoneTypes = new Set<ZoneData['zoneType']>([
-  'areas',
-  'buildings',
-  'floors',
-])
+const zoneTypes = new Set<string>(['areas', 'buildings', 'floors'])
 
-const deviceOrZoneTypes = new Set<DeviceOrZoneData['zoneType']>([
-  ...zoneTypes,
-  'devices',
-])
+const deviceOrZoneTypes = new Set<string>([...zoneTypes, 'devices'])
+
+const isZoneType = (zoneType: string): zoneType is ZoneData['zoneType'] =>
+  zoneTypes.has(zoneType)
+
+const isDeviceOrZoneType = (
+  zoneType: string,
+): zoneType is DeviceOrZoneData['zoneType'] => deviceOrZoneTypes.has(zoneType)
 
 interface NonNegativeIntOptions {
   readonly field?: string | undefined
@@ -62,12 +62,18 @@ export const toHour = (value: unknown, field?: string): Hour => {
 }
 
 /**
- * Validates URL path params as `ZoneData`. `zoneType` comes straight from the
- * request path and is later used to index the zone registry, so reject
- * anything outside the known zone collections.
+ * Validates a raw `zoneType`/`zoneId` pair (from a request path or a parsed
+ * option value) as `ZoneData`. `zoneType` is later used to index the zone
+ * registry, so reject anything outside the known zone collections.
  */
-export const toZoneData = ({ zoneId, zoneType }: ZoneData): ZoneData => {
-  if (!zoneTypes.has(zoneType)) {
+export const toZoneData = ({
+  zoneId,
+  zoneType,
+}: {
+  readonly zoneId: string
+  readonly zoneType: string
+}): ZoneData => {
+  if (!isZoneType(zoneType)) {
     throw new RangeError(`Invalid zone type: ${zoneType}`)
   }
   return { zoneId, zoneType }
@@ -81,9 +87,26 @@ export const toZoneData = ({ zoneId, zoneType }: ZoneData): ZoneData => {
 export const toDeviceOrZoneData = ({
   zoneId,
   zoneType,
-}: DeviceOrZoneData): DeviceOrZoneData => {
-  if (!deviceOrZoneTypes.has(zoneType)) {
+}: {
+  readonly zoneId: string
+  readonly zoneType: string
+}): DeviceOrZoneData => {
+  if (!isDeviceOrZoneType(zoneType)) {
     throw new RangeError(`Invalid zone type: ${zoneType}`)
   }
   return { zoneId, zoneType }
+}
+
+/**
+ * Splits a `${model}_${id}` zone option value — as carried by every flat
+ * picker item — into validated coordinates. The model is a single word and
+ * the id numeric, so the first underscore separates them; the type is then
+ * guarded exactly like a request path param.
+ */
+export const toZoneValueData = (value: string): DeviceOrZoneData => {
+  const separator = value.indexOf('_')
+  return toDeviceOrZoneData({
+    zoneId: value.slice(separator + 1),
+    zoneType: value.slice(0, separator),
+  })
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "45.9.0",
       "license": "GPL-3.0-only",
       "dependencies": {
-        "@olivierzal/melcloud-api": "^43.0.1",
+        "@olivierzal/melcloud-api": "^43.1.0",
         "source-map-support": "^0.5.21",
         "temporal-polyfill": "^1.0.1"
       },
@@ -1065,9 +1065,9 @@
       }
     },
     "node_modules/@olivierzal/melcloud-api": {
-      "version": "43.0.1",
-      "resolved": "https://npm.pkg.github.com/download/@olivierzal/melcloud-api/43.0.1/addf9f6a2634e9596cdd264d23cb6cb3355f8a35",
-      "integrity": "sha512-RQEr8RnMM9QhYJg+CscS4OiZBE5ZW6qylzCWq2vNJf3dEWPUOVcGK1r6gxmvzEj2JtaiAUwlHn6bGa4Ws6JM5Q==",
+      "version": "43.1.0",
+      "resolved": "https://npm.pkg.github.com/download/@olivierzal/melcloud-api/43.1.0/a214ccda1a0349af3b46b34291386ef63e9c4465",
+      "integrity": "sha512-mFN/UDLtdBwrbG+c4ItLKKMG65tkuLdrvgRGLnDPrCcDGSyIwH+weYc0+cquyVvfTwf0z/C8yyEuXChAjlCK0g==",
       "license": "MIT",
       "dependencies": {
         "temporal-polyfill": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "typecheck": "node ./node_modules/@typescript/native/bin/tsc --noEmit"
   },
   "dependencies": {
-    "@olivierzal/melcloud-api": "^43.0.1",
+    "@olivierzal/melcloud-api": "^43.1.0",
     "source-map-support": "^0.5.21",
     "temporal-polyfill": "^1.0.1"
   },

--- a/settings/index.css
+++ b/settings/index.css
@@ -154,9 +154,34 @@ input.homey-form-checkbox-input:indeterminate
    over the real `--homey-font-size-medium` of 20px; it goes unnoticed
    there because its summary sits alone, not next to a legend). */
 summary.homey-form-legend {
+  align-items: center;
   cursor: pointer;
+  display: flex;
   font-size: var(--homey-font-size-medium);
   font-weight: var(--homey-font-weight-bold);
+  gap: 0.5rem;
+  list-style: none;
+}
+
+/* Match the selects' thin chevron instead of the native disclosure
+   triangle: hide the default marker and draw a leading chevron that points
+   right when collapsed and rotates down — as the selects do — when open. */
+summary.homey-form-legend::-webkit-details-marker {
+  display: none;
+}
+
+summary.homey-form-legend::before {
+  block-size: 0.45em;
+  border-block-start: 0.14em solid currentcolor;
+  border-inline-end: 0.14em solid currentcolor;
+  content: '';
+  inline-size: 0.45em;
+  transform: rotate(45deg);
+  transition: transform 0.15s ease;
+}
+
+details[open] > summary.homey-form-legend::before {
+  transform: rotate(135deg);
 }
 
 /* Destructive twin of the filled sign-in button: the injected sheet

--- a/tests/unit/app.test.ts
+++ b/tests/unit/app.test.ts
@@ -472,11 +472,11 @@ const initWithHolidayModeFacade = async (
   )
 }
 
-// A holiday flow target as the run listeners receive it: a Classic zone or a
-// single Home device (the item the Home autocomplete branch emits).
-type TestHolidayZone =
-  | { deviceId: string; id: string; name: string }
-  | { zoneId: string; zoneType: 'buildings' }
+// A holiday flow target as the run listeners receive it: a flat item whose
+// `id` is the `${model}_${id}` option value the run listeners parse to route.
+interface TestHolidayZone {
+  id: string
+}
 
 const getActionRunListener = (): ((args: {
   duration: unknown
@@ -493,13 +493,9 @@ const getFalseRunListener = (): ((args: {
   zone: TestHolidayZone
 }) => Promise<unknown>) => getMockCallArg(mockActionRegisterRun, 2, 0)
 
-// The Home device the holiday autocomplete branch returns, as its run
-// listener receives it.
-const homeHolidayZone = {
-  deviceId: 'guid-1',
-  id: 'homeDevices_guid-1',
-  name: 'Salon',
-} as const
+// The single Home device the holiday autocomplete branch returns, as its run
+// listener receives it: only the option value survives.
+const homeHolidayZone = { id: 'homeDevices_guid-1' } as const
 
 // Point the Home registry/facade at one ATA device so the Home holiday and
 // frost paths resolve for `guid-1`.
@@ -1661,20 +1657,40 @@ describe('melCloudApp', () => {
 
       expect(app.getHomeTargets(Home.DeviceType.Ata)).toStrictEqual([
         {
+          buildingName: 'Appartement',
           id: 'building-1',
           level: 0,
           model: 'homeBuildings',
           name: 'Appartement',
         },
-        { id: 'device-3', level: 1, model: 'homeDevices', name: 'Woonkamer' },
         {
+          buildingName: 'Appartement',
+          id: 'device-3',
+          level: 1,
+          model: 'homeDevices',
+          name: 'Woonkamer',
+        },
+        {
+          buildingName: 'Verkstan',
           id: 'building-2',
           level: 0,
           model: 'homeBuildings',
           name: 'Verkstan',
         },
-        { id: 'device-1', level: 1, model: 'homeDevices', name: 'Bureau' },
-        { id: 'device-2', level: 1, model: 'homeDevices', name: 'Salon' },
+        {
+          buildingName: 'Verkstan',
+          id: 'device-1',
+          level: 1,
+          model: 'homeDevices',
+          name: 'Bureau',
+        },
+        {
+          buildingName: 'Verkstan',
+          id: 'device-2',
+          level: 1,
+          model: 'homeDevices',
+          name: 'Salon',
+        },
       ])
       expect(mockHomeRegistry.getByType).toHaveBeenCalledWith(
         Home.DeviceType.Ata,
@@ -2129,8 +2145,15 @@ describe('melCloudApp', () => {
       // Same-named devices on different buildings stay tellable apart;
       // wire names are trimmed before suffixing.
       expect(app.getHomeDeviceZones()).toStrictEqual([
-        { id: 'a', level: 1, model: 'homeDevices', name: 'Garage (Verkstan)' },
         {
+          buildingName: 'Verkstan',
+          id: 'a',
+          level: 1,
+          model: 'homeDevices',
+          name: 'Garage (Verkstan)',
+        },
+        {
+          buildingName: 'Vinkenstraat 22',
           id: 'b',
           level: 1,
           model: 'homeDevices',
@@ -2147,6 +2170,7 @@ describe('melCloudApp', () => {
 
       expect(app.getHomeDeviceZones(Home.DeviceType.Atw)).toStrictEqual([
         {
+          buildingName: 'Huis',
           id: 'atw-1',
           level: 1,
           model: 'homeDevices',
@@ -2160,14 +2184,32 @@ describe('melCloudApp', () => {
   })
 
   describe('classic device zones', () => {
-    it('should suffix the building and sort for the flat pickers', async () => {
-      mockApiInstance.registry.getDevices.mockReturnValue([
-        { buildingId: 2, id: 20, name: 'Garage' },
-        { buildingId: 1, id: 10, name: 'Hydrobox' },
+    it('should keep only the device leaves, suffixed and sorted', async () => {
+      // The shared source flattens the whole tree, each zone stamped with its
+      // building; the chart pickers keep just the devices.
+      mockFacadeManagerGetZones.mockReturnValue([
+        {
+          buildingName: 'Casa',
+          id: 1,
+          level: 0,
+          model: 'buildings',
+          name: 'Casa',
+        },
+        {
+          buildingName: 'Verkstan',
+          id: 20,
+          level: 1,
+          model: 'devices',
+          name: 'Garage',
+        },
+        {
+          buildingName: 'Casa',
+          id: 10,
+          level: 1,
+          model: 'devices',
+          name: 'Hydrobox',
+        },
       ])
-      mockApiInstance.registry.buildings.getById.mockImplementation(
-        (id: number) => (id === 1 ? { name: 'Casa' } : { name: 'Verkstan' }),
-      )
       await app.onInit()
 
       expect(app.getClassicDeviceZones()).toStrictEqual([
@@ -2176,19 +2218,24 @@ describe('melCloudApp', () => {
       ])
     })
 
-    it('should keep the bare name when the building is unknown', async () => {
-      mockApiInstance.registry.getDevicesByType.mockReturnValue([
-        { buildingId: 9, id: 30, name: 'Orphan' },
+    it('should narrow the source to a device type when one is given', async () => {
+      mockFacadeManagerGetZones.mockReturnValue([
+        {
+          buildingName: 'Huis',
+          id: 30,
+          level: 1,
+          model: 'devices',
+          name: 'AC',
+        },
       ])
-      mockApiInstance.registry.buildings.getById.mockReturnValue(undefined)
       await app.onInit()
 
       expect(app.getClassicDeviceZones(Classic.DeviceType.Ata)).toStrictEqual([
-        { id: 30, level: 1, model: 'devices', name: 'Orphan' },
+        { id: 30, level: 1, model: 'devices', name: 'AC (Huis)' },
       ])
-      expect(mockApiInstance.registry.getDevicesByType).toHaveBeenCalledWith(
-        Classic.DeviceType.Ata,
-      )
+      expect(mockFacadeManagerGetZones).toHaveBeenCalledWith({
+        type: Classic.DeviceType.Ata,
+      })
     })
   })
 
@@ -2493,17 +2540,25 @@ describe('melCloudApp', () => {
   })
 
   describe('holiday mode flow cards', () => {
-    const zoneArg = { zoneId: '1', zoneType: 'buildings' as const }
+    const zoneArg = { id: 'buildings_1' } as const
 
     describe('zone autocomplete', () => {
-      it('should filter zones by query and carry the zone target', async () => {
+      it('should filter zones by query, suffixing leaves and carrying the value', async () => {
         mockFacadeManagerGetZones.mockReturnValue([
-          mock<Classic.Zone>({ id: 1, model: 'buildings', name: 'Home' }),
-          mock<Classic.Zone>({
+          {
+            buildingName: 'Home',
+            id: 1,
+            level: 0,
+            model: 'buildings',
+            name: 'Home',
+          },
+          {
+            buildingName: 'Home',
             id: 2,
+            level: 1,
             model: 'devices',
             name: 'Living room unit',
-          }),
+          },
         ])
         await app.onInit()
 
@@ -2513,13 +2568,10 @@ describe('melCloudApp', () => {
           1,
         )
 
+        // The item carries only its `${model}_${id}` value and a
+        // building-suffixed display name — the run listener parses the value.
         expect(autocomplete('liv')).toStrictEqual([
-          {
-            id: 'devices_2',
-            name: 'Living room unit',
-            zoneId: '2',
-            zoneType: 'devices',
-          },
+          { id: 'devices_2', name: 'Living room unit (Home)' },
         ])
 
         expect(autocomplete('')).toHaveLength(2)
@@ -2527,7 +2579,13 @@ describe('melCloudApp', () => {
 
       it('should serve the condition card with the same autocomplete', async () => {
         mockFacadeManagerGetZones.mockReturnValue([
-          mock<Classic.Zone>({ id: 1, model: 'buildings', name: 'Home' }),
+          {
+            buildingName: 'Home',
+            id: 1,
+            level: 0,
+            model: 'buildings',
+            name: 'Home',
+          },
         ])
         await app.onInit()
 
@@ -2538,21 +2596,26 @@ describe('melCloudApp', () => {
         )
 
         expect(autocomplete('home')).toStrictEqual([
-          {
-            id: 'buildings_1',
-            name: 'Home',
-            zoneId: '1',
-            zoneType: 'buildings',
-          },
+          { id: 'buildings_1', name: 'Home' },
         ])
       })
 
-      it('should append Home devices, alpha-sorted with the zones', async () => {
+      it('should mix Classic zones with Home buildings and devices, sorted', async () => {
         mockFacadeManagerGetZones.mockReturnValue([
-          mock<Classic.Zone>({ id: 1, model: 'buildings', name: 'Maison' }),
+          {
+            buildingName: 'Maison',
+            id: 1,
+            level: 0,
+            model: 'buildings',
+            name: 'Maison',
+          },
         ])
         mockHomeRegistry.getAll.mockReturnValue([
-          { building: { name: 'Chalet' }, id: 'guid-9', name: 'Salon' },
+          {
+            building: { id: 'chalet-1', name: 'Chalet' },
+            id: 'guid-9',
+            name: 'Salon',
+          },
         ])
         await app.onInit()
 
@@ -2562,20 +2625,12 @@ describe('melCloudApp', () => {
           1,
         )
 
-        // Classic zones and Home devices share one sorted list; the Home
-        // entry carries its device id for routing.
+        // One sorted list: the Classic building, the Home building (a batched
+        // group) and its suffixed device — each keyed by its routing value.
         expect(autocomplete('')).toStrictEqual([
-          {
-            id: 'buildings_1',
-            name: 'Maison',
-            zoneId: '1',
-            zoneType: 'buildings',
-          },
-          {
-            deviceId: 'guid-9',
-            id: 'homeDevices_guid-9',
-            name: 'Salon (Chalet)',
-          },
+          { id: 'homeBuildings_chalet-1', name: 'Chalet' },
+          { id: 'buildings_1', name: 'Maison' },
+          { id: 'homeDevices_guid-9', name: 'Salon (Chalet)' },
         ])
       })
     })
@@ -2646,6 +2701,33 @@ describe('melCloudApp', () => {
           // midnight 3 days out; the single device is sent as a one-item set.
           expect(mockHomeFacadeManagerUpdateHolidayMode).toHaveBeenCalledWith(
             ['guid-1'],
+            {
+              endDate: '2026-07-22T00:00:00',
+              isEnabled: true,
+              startDate: '2026-07-19T08:30:00',
+            },
+          )
+        } finally {
+          vi.mocked(Temporal.Now.plainDateTimeISO).mockRestore()
+        }
+      })
+
+      it('should batch a Home building window across its devices', async () => {
+        vi.spyOn(Temporal.Now, 'plainDateTimeISO').mockReturnValue(
+          Temporal.PlainDateTime.from('2026-07-19T08:30:00'),
+        )
+        try {
+          await app.onInit()
+          stubBuilding({})
+
+          await getActionRunListener()({
+            duration: 3,
+            zone: { id: 'homeBuildings_b1' },
+          })
+
+          // A whole Home building fans the one window out over every device.
+          expect(mockHomeFacadeManagerUpdateHolidayMode).toHaveBeenCalledWith(
+            ['d1', 'd2'],
             {
               endDate: '2026-07-22T00:00:00',
               isEnabled: true,
@@ -2904,6 +2986,32 @@ describe('melCloudApp', () => {
           await expect(run({ zone: homeHolidayZone })).resolves.toBe(shouldBeOn)
         },
       )
+
+      it.each([
+        {
+          holidayById: { d1: { enabled: true }, d2: { enabled: true } },
+          shouldBeOn: true,
+        },
+        // Devices disagree: the building aggregate is "mixed", read as off.
+        {
+          holidayById: { d1: { enabled: true }, d2: { enabled: false } },
+          shouldBeOn: false,
+        },
+      ])(
+        'should mirror a Home building holiday state ($shouldBeOn)',
+        async ({ holidayById, shouldBeOn }) => {
+          await app.onInit()
+          stubBuilding({}, holidayById)
+
+          const run = getMockCallArg<
+            (args: { zone: TestHolidayZone }) => Promise<boolean>
+          >(mockConditionRegisterRun, 0, 0)
+
+          await expect(run({ zone: { id: 'homeBuildings_b1' } })).resolves.toBe(
+            shouldBeOn,
+          )
+        },
+      )
     })
   })
 
@@ -3031,13 +3139,43 @@ describe('melCloudApp', () => {
       await app.onInit()
 
       // Buildings alpha-sorted; each building's devices nested (level 1) and
-      // sorted under it.
+      // sorted under it; every node stamped with its building name.
       expect(app.getHomeTargets()).toStrictEqual([
-        { id: 'b1', level: 0, model: 'homeBuildings', name: 'Alpha' },
-        { id: 'd1', level: 1, model: 'homeDevices', name: 'Xray' },
-        { id: 'd2', level: 1, model: 'homeDevices', name: 'Yankee' },
-        { id: 'b2', level: 0, model: 'homeBuildings', name: 'Bravo' },
-        { id: 'd3', level: 1, model: 'homeDevices', name: 'Zeta' },
+        {
+          buildingName: 'Alpha',
+          id: 'b1',
+          level: 0,
+          model: 'homeBuildings',
+          name: 'Alpha',
+        },
+        {
+          buildingName: 'Alpha',
+          id: 'd1',
+          level: 1,
+          model: 'homeDevices',
+          name: 'Xray',
+        },
+        {
+          buildingName: 'Alpha',
+          id: 'd2',
+          level: 1,
+          model: 'homeDevices',
+          name: 'Yankee',
+        },
+        {
+          buildingName: 'Bravo',
+          id: 'b2',
+          level: 0,
+          model: 'homeBuildings',
+          name: 'Bravo',
+        },
+        {
+          buildingName: 'Bravo',
+          id: 'd3',
+          level: 1,
+          model: 'homeDevices',
+          name: 'Zeta',
+        },
       ])
     })
   })
@@ -3155,25 +3293,43 @@ describe('melCloudApp', () => {
     it('should serve matching classic zones, classic devices and home devices to the ata-group-setting widget', async () => {
       const { mockRegisterAta } = setupWidgetListeners()
       mockFacadeManagerGetZones.mockReturnValue([
-        { model: 'buildings', name: 'Building 1' },
-        { model: 'buildings', name: 'Office' },
-        { model: 'devices', name: 'Building unit' },
+        {
+          buildingName: 'Building 1',
+          id: 1,
+          level: 0,
+          model: 'buildings',
+          name: 'Building 1',
+        },
+        {
+          buildingName: 'Office',
+          id: 2,
+          level: 0,
+          model: 'buildings',
+          name: 'Office',
+        },
+        {
+          buildingName: 'Building 1',
+          id: 10,
+          level: 1,
+          model: 'devices',
+          name: 'Building unit',
+        },
       ])
       // Unsorted on purpose: home targets must come back alpha-sorted
-      // (buildings, then their devices), appended after the classic ones.
+      // (building, then its devices), appended after the classic ones.
       mockHomeRegistry.getByType.mockReturnValue([
         {
-          building: { id: 'account-1', name: 'Buildings' },
+          building: { id: 'account-1', name: 'Maison' },
           id: 'home-2',
           name: 'Building two',
         },
         {
-          building: { id: 'account-1', name: 'Buildings' },
+          building: { id: 'account-1', name: 'Maison' },
           id: 'home-1',
           name: 'Building one',
         },
         {
-          building: { id: 'account-1', name: 'Buildings' },
+          building: { id: 'account-1', name: 'Maison' },
           id: 'home-3',
           name: 'Bedroom',
         },
@@ -3187,17 +3343,37 @@ describe('melCloudApp', () => {
       )
       const result = ataCallback('build')
 
+      // Classic zones then Home building/devices; leaves suffixed with their
+      // building, buildings kept bare; the query matches the suffixed names.
       expect(result).toStrictEqual([
-        { model: 'buildings', name: 'Building 1' },
-        { model: 'devices', name: 'Building unit' },
         {
-          id: 'account-1',
+          buildingName: 'Building 1',
+          id: 1,
           level: 0,
-          model: 'homeBuildings',
-          name: 'Buildings',
+          model: 'buildings',
+          name: 'Building 1',
         },
-        { id: 'home-1', level: 1, model: 'homeDevices', name: 'Building one' },
-        { id: 'home-2', level: 1, model: 'homeDevices', name: 'Building two' },
+        {
+          buildingName: 'Building 1',
+          id: 10,
+          level: 1,
+          model: 'devices',
+          name: 'Building unit (Building 1)',
+        },
+        {
+          buildingName: 'Maison',
+          id: 'home-1',
+          level: 1,
+          model: 'homeDevices',
+          name: 'Building one (Maison)',
+        },
+        {
+          buildingName: 'Maison',
+          id: 'home-2',
+          level: 1,
+          model: 'homeDevices',
+          name: 'Building two (Maison)',
+        },
       ])
       expect(mockFacadeManagerGetZones).toHaveBeenCalledWith({
         type: Classic.DeviceType.Ata,
@@ -3206,15 +3382,28 @@ describe('melCloudApp', () => {
 
     it('should serve building-suffixed device zones to the charts widget', async () => {
       const { mockRegisterCharts } = setupWidgetListeners()
-      mockApiInstance.registry.getDevices.mockReturnValue([
-        { buildingId: 1, id: 10, name: 'Device 1' },
-        { buildingId: 1, id: 11, name: 'Device 2' },
+      mockFacadeManagerGetZones.mockReturnValue([
+        {
+          buildingName: 'Casa',
+          id: 10,
+          level: 1,
+          model: 'devices',
+          name: 'Device 1',
+        },
+        {
+          buildingName: 'Casa',
+          id: 11,
+          level: 1,
+          model: 'devices',
+          name: 'Device 2',
+        },
       ])
-      mockApiInstance.registry.buildings.getById.mockReturnValue({
-        name: 'Casa',
-      })
       mockHomeRegistry.getAll.mockReturnValue([
-        { building: { name: 'Antwerpen' }, id: 'guid-1', name: 'Device 1' },
+        {
+          building: { id: 'antwerp-1', name: 'Antwerpen' },
+          id: 'guid-1',
+          name: 'Device 1',
+        },
       ])
       await app.onInit()
 
@@ -3229,6 +3418,7 @@ describe('melCloudApp', () => {
       // before the Classic one); the query matches the suffixed names.
       expect(result).toStrictEqual([
         {
+          buildingName: 'Antwerpen',
           id: 'guid-1',
           level: 1,
           model: 'homeDevices',

--- a/tests/unit/validation.test.ts
+++ b/tests/unit/validation.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import type { DeviceOrZoneData, ZoneData } from '../../types/zone.mts'
 import {
   toDeviceOrZoneData,
   toHour,
   toNonNegativeInt,
   toZoneData,
+  toZoneValueData,
 } from '../../lib/validation.mts'
 
 describe(toNonNegativeInt, () => {
@@ -77,12 +77,9 @@ describe(toZoneData, () => {
   it.each(['devices', 'constructor', ''])(
     'rejects %p coming from the URL',
     (zoneType) => {
-      expect(() =>
-        toZoneData({
-          zoneId: '1',
-          zoneType: zoneType as ZoneData['zoneType'],
-        }),
-      ).toThrow(/Invalid zone type/v)
+      expect(() => toZoneData({ zoneId: '1', zoneType })).toThrow(
+        /Invalid zone type/v,
+      )
     },
   )
 })
@@ -99,11 +96,25 @@ describe(toDeviceOrZoneData, () => {
   )
 
   it.each(['constructor', ''])('rejects %p coming from the URL', (zoneType) => {
-    expect(() =>
-      toDeviceOrZoneData({
-        zoneId: '1',
-        zoneType: zoneType as DeviceOrZoneData['zoneType'],
-      }),
-    ).toThrow(/Invalid zone type/v)
+    expect(() => toDeviceOrZoneData({ zoneId: '1', zoneType })).toThrow(
+      /Invalid zone type/v,
+    )
+  })
+})
+
+describe(toZoneValueData, () => {
+  it.each([
+    ['areas_100', { zoneId: '100', zoneType: 'areas' }],
+    ['buildings_1', { zoneId: '1', zoneType: 'buildings' }],
+    ['devices_2001', { zoneId: '2001', zoneType: 'devices' }],
+    ['floors_10', { zoneId: '10', zoneType: 'floors' }],
+  ] as const)('splits %p into coordinates', (value, expected) => {
+    expect(toZoneValueData(value)).toStrictEqual(expected)
+  })
+
+  it('rejects a value whose model is not a zone collection', () => {
+    expect(() => toZoneValueData('homeDevices_abc')).toThrow(
+      /Invalid zone type/v,
+    )
   })
 })

--- a/types/zone.mts
+++ b/types/zone.mts
@@ -20,7 +20,11 @@ export interface DeviceOrZoneData {
 // group) is a selectable root entry, its devices one level below. The
 // models are camelCase because option values split `${model}_${id}` at
 // the FIRST underscore — a Home id may itself contain underscores.
+// `buildingName` mirrors `Classic.FlatZone`: it names the owning building
+// (a building carries its own) so a flat picker can suffix leaves and keep
+// same-named devices on different buildings apart.
 export interface HomeBuildingZone {
+  readonly buildingName: string
   readonly id: string
   readonly level: 0
   readonly model: 'homeBuildings'
@@ -28,6 +32,7 @@ export interface HomeBuildingZone {
 }
 
 export interface HomeDeviceZone {
+  readonly buildingName: string
   readonly id: string
   readonly level: 1
   readonly model: 'homeDevices'


### PR DESCRIPTION
## What

Unifies every **flat** zone picker (holiday-mode flow cards, chart + ATA-group widget autocompletes) onto **two shared sources** and one suffix rule, and fully migrates the holiday flow — fixing the reported flow regression and the two follow-up asks.

- **Two sources**, both carrying `buildingName` (melcloud-api **43.1.0** `FlatZone` on the Classic side; Home nodes stamped in `getHomeTargets`): `getClassicTargets(type?)` and `getHomeTargets(type?)`. Every flat picker draws from these with the filters it needs.
- **One suffix rule** `toFlatName` — factors the `(building)` suffix (previously duplicated between the charts pickers and `toFlatDeviceName`); buildings stay bare, leaves get `Name (Building)`.
- **Holiday flow fully migrated**: items now carry only their `${model}_${id}` option value; run listeners parse it (via the same `isHomeDeviceValue`/`isHomeBuildingValue` helpers the settings page uses). Because stored card args have *always* carried that `id`, **existing Flows keep working**. This:
  - restores **every Classic zone** (not just devices) to the flow with a `(building)` suffix — the reported regression;
  - adds **Home buildings** as batched holiday targets (a building fans its window/read across its devices);
  - drops the `HolidayModeTarget` discriminated union.
- `toDeviceOrZoneData` now guards a raw string `zoneType`, so one validator serves both a request path and a parsed picker value (`toZoneValueData`) — no cast.

The **tree** surfaces (settings selector, ATA in-widget select) already share `getClassicBuildings` + `getHomeTargets` and stay tree-shaped (deliberate — they were asked to be trees). The widget webviews are untouched: their item types are unchanged; only the display names gain the consistent building suffix.

## Notes

- Stacked on #1462 (chevron); base retargets to `main` once that merges.
- No app-version bump here — the store release (version + `.homeychangelog.json` + tag) will be a coordinated step after #1462 and this land.

## Test
Full suite green: format, lint, typecheck, `test:coverage` (100%, 725 tests), build, `homey validate --level publish`. On-device verification of all four pickers pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)