### PR TITLE
feat: dirty-gate the Apply buttons in settings and the ATA group widget

### DIFF
--- a/settings/index.mts
+++ b/settings/index.mts
@@ -215,20 +215,6 @@ const withDisablingButton = async (
   }
 }
 
-const withDisablingButtonPair = async (
-  id: string,
-  action: () => Promise<void>,
-): Promise<void> => {
-  disableButton(`apply_${id}`)
-  disableButton(`refresh_${id}`)
-  try {
-    await action()
-  } finally {
-    disableButton(`apply_${id}`, false)
-    disableButton(`refresh_${id}`, false)
-  }
-}
-
 const hide = (element: HTMLDivElement, isHidden = true): void => {
   element.hidden = isHidden
 }
@@ -469,6 +455,73 @@ const getSubzones = (
   ...('areas' in zone ? zone.areas : []),
   ...('floors' in zone ? zone.floors : []),
 ]
+
+// Per-section dirty-gating state: `saved` holds the serialization of the
+// zone values last loaded into the panel, `busy` marks a request in
+// flight. Apply is enabled only when the current form diverges from
+// `saved` AND nothing is busy; Refresh is gated by `busy` alone.
+interface DirtyGate {
+  readonly applyId: string
+  readonly busy: { value: boolean }
+  readonly refreshId: string
+  readonly saved: { value: string }
+  readonly serialize: () => string
+}
+
+// Apply is enabled only when the form diverges from the last-loaded values
+// AND no request is in flight — the native `disabled` also blocks keyboard
+// activation mid-request and is announced by screen readers.
+const updateDirty = (gate: DirtyGate): void => {
+  disableButton(
+    gate.applyId,
+    gate.busy.value || gate.serialize() === gate.saved.value,
+  )
+}
+
+// Recompute a section's dirty state on every input it exposes, so Apply
+// reflects unsaved edits. `input` covers live typing in the number/date
+// fields; `change` covers the selects and the final commit (and, since
+// `serialize` reads the whole section, any field a cascade handler mutated).
+const wireDirtyRecompute = (
+  elements: HTMLValueElement[],
+  gate: DirtyGate,
+): void => {
+  for (const element of elements) {
+    for (const eventName of ['change', 'input']) {
+      element.addEventListener(eventName, () => {
+        updateDirty(gate)
+      })
+    }
+  }
+}
+
+// Take the current form as the pristine baseline — called on load, on every
+// repopulate, and after a successful apply — then re-evaluate Apply.
+const snapshotSavedState = (gate: DirtyGate): void => {
+  gate.saved.value = gate.serialize()
+  updateDirty(gate)
+}
+
+// Refresh is gated by `busy` alone (never dirty), matching the section's
+// disable-during-request behavior; Apply folds the busy flag into its dirty
+// check so a mid-request edit cannot re-enable it.
+const setButtonsBusy = (gate: DirtyGate, areBusy: boolean): void => {
+  gate.busy.value = areBusy
+  disableButton(gate.refreshId, areBusy)
+  updateDirty(gate)
+}
+
+const withBusyButtons = async (
+  gate: DirtyGate,
+  action: () => Promise<void>,
+): Promise<void> => {
+  setButtonsBusy(gate, true)
+  try {
+    await action()
+  } finally {
+    setButtonsBusy(gate, false)
+  }
+}
 
 // Panel values, where a field may be `null` to mean "mixed" across a Home
 // building's devices — rendered indeterminate (blank).
@@ -1213,11 +1266,15 @@ class ErrorLogManager {
 
 // ── ZoneSettingsManager ──
 class ZoneSettingsManager {
+  readonly #frostProtectionDirtyGate: DirtyGate
+
   readonly #frostProtectionEnabled: HTMLSelectElement
 
   readonly #frostProtectionMaxTemperature: HTMLInputElement
 
   readonly #frostProtectionMinTemperature: HTMLInputElement
+
+  readonly #holidayModeDirtyGate: DirtyGate
 
   readonly #holidayModeEnabled: HTMLSelectElement
 
@@ -1240,6 +1297,30 @@ class ZoneSettingsManager {
     this.#frostProtectionMaxTemperature = initFrostProtectionMax()
     this.#holidayModeStartDate = getInput('start_date')
     this.#holidayModeEndDate = getInput('end_date')
+    this.#frostProtectionDirtyGate = {
+      applyId: 'apply_frost_protection',
+      busy: { value: false },
+      refreshId: 'refresh_frost_protection',
+      saved: { value: '' },
+      serialize: (): string =>
+        JSON.stringify([
+          this.#frostProtectionEnabled.value,
+          this.#frostProtectionMinTemperature.value,
+          this.#frostProtectionMaxTemperature.value,
+        ]),
+    }
+    this.#holidayModeDirtyGate = {
+      applyId: 'apply_holiday_mode',
+      busy: { value: false },
+      refreshId: 'refresh_holiday_mode',
+      saved: { value: '' },
+      serialize: (): string =>
+        JSON.stringify([
+          this.#holidayModeEnabled.value,
+          this.#holidayModeStartDate.value,
+          this.#holidayModeEndDate.value,
+        ]),
+    }
   }
 
   public addEventListeners(): void {
@@ -1248,6 +1329,14 @@ class ZoneSettingsManager {
     })
     this.#addHolidayModeEventListeners()
     this.#addFrostProtectionEventListeners()
+    // Registered last so a section's dirty recompute runs after any
+    // cascade handler (a date edit toggling enabled, enabled clearing the
+    // dates): the recompute serializes the whole section, capturing those.
+    this.#addDirtyRecomputeListeners()
+    // Baseline before the first (fire-and-forget) load lands, so Apply
+    // starts pristine (disabled) instead of spuriously enabled.
+    snapshotSavedState(this.#frostProtectionDirtyGate)
+    snapshotSavedState(this.#holidayModeDirtyGate)
   }
 
   /** @silent Falls back to default values on error. */
@@ -1266,6 +1355,9 @@ class ZoneSettingsManager {
       this.#frostProtectionMinTemperature.value = String(min ?? '')
       this.#frostProtectionMaxTemperature.value = String(max ?? '')
     }
+    // Populating the panel re-baselines it: the freshly loaded (or saved)
+    // values become the pristine state, so Apply drops back to disabled.
+    snapshotSavedState(this.#frostProtectionDirtyGate)
   }
 
   public displayHolidayModeData(): void {
@@ -1284,6 +1376,9 @@ class ZoneSettingsManager {
         isEnabled === true ? (startDate ?? '') : ''
       this.#holidayModeEndDate.value = isEnabled === true ? (endDate ?? '') : ''
     }
+    // Populating the panel re-baselines it: the freshly loaded (or saved)
+    // values become the pristine state, so Apply drops back to disabled.
+    snapshotSavedState(this.#holidayModeDirtyGate)
   }
 
   /** @silent Falls back to default values on error. */
@@ -1391,6 +1486,25 @@ class ZoneSettingsManager {
     })
   }
 
+  #addDirtyRecomputeListeners(): void {
+    wireDirtyRecompute(
+      [
+        this.#frostProtectionEnabled,
+        this.#frostProtectionMinTemperature,
+        this.#frostProtectionMaxTemperature,
+      ],
+      this.#frostProtectionDirtyGate,
+    )
+    wireDirtyRecompute(
+      [
+        this.#holidayModeEnabled,
+        this.#holidayModeStartDate,
+        this.#holidayModeEndDate,
+      ],
+      this.#holidayModeDirtyGate,
+    )
+  }
+
   #addFrostProtectionEventListeners(): void {
     for (const element of [
       this.#frostProtectionMinTemperature,
@@ -1459,7 +1573,7 @@ class ZoneSettingsManager {
     id,
     path,
   }: ZoneSettingDescriptor): Promise<void> {
-    await withDisablingButtonPair(id, async () => {
+    await withBusyButtons(this.#gateFor(id), async () => {
       try {
         this.#updateZoneMapping(await this.#getZoneSettingData(path))
         display()
@@ -1467,6 +1581,12 @@ class ZoneSettingsManager {
         // Non-critical: UI falls back to default values
       }
     })
+  }
+
+  #gateFor(id: 'frost_protection' | 'holiday_mode'): DirtyGate {
+    return id === 'frost_protection' ?
+        this.#frostProtectionDirtyGate
+      : this.#holidayModeDirtyGate
   }
 
   #getFPMinAndMax(): { max: number; min: number } {
@@ -1550,7 +1670,7 @@ class ZoneSettingsManager {
     query: Classic.FrostProtectionQuery | HolidayModeUpdate,
     zoneSettings: Partial<Classic.ZoneSettings>,
   ): Promise<void> {
-    await withDisablingButtonPair(id, async () => {
+    await withBusyButtons(this.#gateFor(id), async () => {
       try {
         await homeyApiPut<unknown>(
           this.#homey,

--- a/settings/index.mts
+++ b/settings/index.mts
@@ -523,6 +523,19 @@ const withBusyButtons = async (
   }
 }
 
+// Serialize a device-settings section's controls as a pure form snapshot for
+// its DirtyGate — the same value-only shape the frost/holiday gates use. A
+// checkbox contributes its checked state plus its indeterminate ("mixed
+// across devices") flag; every other control contributes its value.
+const serializeSettingElements = (elements: HTMLValueElement[]): string =>
+  JSON.stringify(
+    elements.map((element) =>
+      element instanceof HTMLInputElement && element.type === 'checkbox' ?
+        [element.checked, element.indeterminate]
+      : element.value,
+    ),
+  )
+
 // Panel values, where a field may be `null` to mean "mixed" across a Home
 // building's devices — rendered indeterminate (blank).
 type MixableZoneSettings = {
@@ -751,6 +764,12 @@ class DeviceSettingsManager {
 
   #deviceSettings: Partial<DeviceSettings> = {}
 
+  // One DirtyGate per device-settings section, keyed by section id
+  // (`common` or a driver's `toSectionId`). The per-driver gates are added
+  // as their sections are appended, so a common apply — which writes every
+  // driver — can reach and lock them all for the round-trip.
+  readonly #dirtyGates = new Map<string, DirtyGate>()
+
   readonly #homey: Homey
 
   readonly #settingsCommon: HTMLDivElement
@@ -788,44 +807,6 @@ class DeviceSettingsManager {
     }
   }
 
-  #addApplySettingsEventListener(
-    elements: HTMLValueElement[],
-    driverId?: string,
-  ): void {
-    const settings = `settings_${toSectionId(driverId ?? 'common')}`
-    const button = getButton(`apply_${settings}`)
-    button.addEventListener('click', () => {
-      fireAndForget(this.#submitDeviceSettings(elements, driverId))
-    })
-  }
-
-  #addRefreshSettingsEventListener(
-    elements: HTMLValueElement[],
-    driverId?: string,
-  ): void {
-    const settings = `settings_${toSectionId(driverId ?? 'common')}`
-    const button = getButton(`refresh_${settings}`)
-    button.addEventListener('click', () => {
-      if (driverId !== undefined) {
-        this.#syncDriverSettings(
-          elements.filter((element) => element instanceof HTMLInputElement),
-        )
-        return
-      }
-      this.#syncCommonSettings(
-        elements.filter((element) => element instanceof HTMLSelectElement),
-      )
-    })
-  }
-
-  #addSettingsEventListeners(
-    elements: HTMLValueElement[],
-    driverId?: string,
-  ): void {
-    this.#addApplySettingsEventListener(elements, driverId)
-    this.#addRefreshSettingsEventListener(elements, driverId)
-  }
-
   #alertNoChanges(elements: HTMLValueElement[], driverId?: string): void {
     if (driverId === undefined) {
       this.#syncCommonSettings(
@@ -844,7 +825,7 @@ class DeviceSettingsManager {
     controls.append(...checkboxSets)
     section.append(createSettingsButtonRow(this.#homey, toSectionId(driverId)))
     getDiv('device_settings').append(section)
-    this.#addSettingsEventListeners(
+    this.#registerSettingsSection(
       checkboxSets.flatMap((checkboxSet) => [
         ...checkboxSet.querySelectorAll('input'),
       ]),
@@ -928,7 +909,7 @@ class DeviceSettingsManager {
       appendFormControl(this.#settingsCommon, { formControl, title })
       this.#updateCommonSetting(formControl)
     }
-    this.#addSettingsEventListeners([
+    this.#registerSettingsSection([
       ...this.#settingsCommon.querySelectorAll('select'),
     ])
   }
@@ -974,24 +955,6 @@ class DeviceSettingsManager {
     }
   }
 
-  #disableButtons(id: string, isDisabled = true): void {
-    const isCommon = id.endsWith('common')
-    // Plain suffix swap — a regex would be lowered by the es2020 esbuild
-    // target to a runtime RegExp construction on every call.
-    const driverIdPrefix = id.slice(0, -'common'.length)
-    for (const action of ['apply', 'refresh']) {
-      disableButton(`${action}_${id}`, isDisabled)
-      if (isCommon) {
-        for (const driverId of Object.keys(this.#deviceSettings)) {
-          disableButton(
-            `${action}_${driverIdPrefix}${toSectionId(driverId)}`,
-            isDisabled,
-          )
-        }
-      }
-    }
-  }
-
   #parseFormValue(element: HTMLValueElement): Settings[keyof Settings] {
     if (element.value !== '') {
       if (element.type === 'checkbox') {
@@ -1011,6 +974,62 @@ class DeviceSettingsManager {
       return Number.isFinite(numberValue) ? numberValue : element.value
     }
     return null
+  }
+
+  // Re-sync a section's controls from the cached device settings (client-side,
+  // no round-trip), then re-baseline its gate so Apply drops back to disabled.
+  #refreshSettings(
+    gate: DirtyGate,
+    elements: HTMLValueElement[],
+    driverId?: string,
+  ): void {
+    this.#syncSettings(elements, driverId)
+    snapshotSavedState(gate)
+  }
+
+  // Build and wire one device-settings section's DirtyGate (the common one
+  // when `driverId` is omitted, else a driver's), keyed by section id in
+  // `#dirtyGates`. Snapshots the freshly populated controls as the pristine
+  // baseline, so Apply starts disabled until an edit diverges from it.
+  #registerSettingsSection(
+    elements: HTMLValueElement[],
+    driverId?: string,
+  ): void {
+    const sectionId = toSectionId(driverId ?? 'common')
+    const gate: DirtyGate = {
+      applyId: `apply_settings_${sectionId}`,
+      busy: { value: false },
+      refreshId: `refresh_settings_${sectionId}`,
+      saved: { value: '' },
+      serialize: () => serializeSettingElements(elements),
+    }
+    this.#dirtyGates.set(sectionId, gate)
+    wireDirtyRecompute(elements, gate)
+    snapshotSavedState(gate)
+    getButton(gate.applyId).addEventListener('click', () => {
+      fireAndForget(this.#submitDeviceSettings(gate, elements, driverId))
+    })
+    getButton(gate.refreshId).addEventListener('click', () => {
+      this.#refreshSettings(gate, elements, driverId)
+    })
+  }
+
+  // Toggle a section's busy state on its gate(s): the common section fans
+  // out to every registered gate (its apply writes all drivers), a driver
+  // section touches only its own. Iterates the map directly — an old-engine
+  // webview has no `Iterator#toArray`.
+  #setSectionBusy(
+    gate: DirtyGate,
+    driverId: string | undefined,
+    areBusy: boolean,
+  ): void {
+    if (driverId === undefined) {
+      for (const sectionGate of this.#dirtyGates.values()) {
+        setButtonsBusy(sectionGate, areBusy)
+      }
+      return
+    }
+    setButtonsBusy(gate, areBusy)
   }
 
   #setSetting(settings: Settings, element: HTMLValueElement): void {
@@ -1048,23 +1067,28 @@ class DeviceSettingsManager {
   }
 
   async #submitDeviceSettings(
+    gate: DirtyGate,
     elements: HTMLValueElement[],
     driverId?: string,
   ): Promise<void> {
     const body = this.#buildSettingsBody(elements)
     if (Object.keys(body).length === 0) {
+      // Safety net: the Apply button is disabled while the section is
+      // pristine, so this is reached only when a dirty edit nets no
+      // update (a blank select, a re-toggled checkbox). Re-baseline so
+      // Apply drops back to disabled.
       this.#alertNoChanges(elements, driverId)
+      snapshotSavedState(gate)
       return
     }
-    const settingsId = `settings_${toSectionId(driverId ?? 'common')}`
-    this.#disableButtons(settingsId)
-    try {
-      await this.#applyDeviceSettings(body, driverId)
-    } catch (error) {
-      await this.#homey.alert(getErrorMessage(error))
-    } finally {
-      this.#disableButtons(settingsId, false)
-    }
+    await this.#withSectionBusy(gate, driverId, async () => {
+      try {
+        await this.#applyDeviceSettings(body, driverId)
+        snapshotSavedState(gate)
+      } catch (error) {
+        await this.#homey.alert(getErrorMessage(error))
+      }
+    })
   }
 
   #syncCommonSettings(elements: HTMLSelectElement[]): void {
@@ -1077,6 +1101,20 @@ class DeviceSettingsManager {
     for (const element of elements) {
       this.#updateDriverSetting(element)
     }
+  }
+
+  // Dispatch a refresh to the right per-type sync: the common section holds
+  // selects, a driver section holds checkbox inputs.
+  #syncSettings(elements: HTMLValueElement[], driverId?: string): void {
+    if (driverId === undefined) {
+      this.#syncCommonSettings(
+        elements.filter((element) => element instanceof HTMLSelectElement),
+      )
+      return
+    }
+    this.#syncDriverSettings(
+      elements.filter((element) => element instanceof HTMLInputElement),
+    )
   }
 
   #updateCommonSetting(element: HTMLSelectElement): void {
@@ -1125,6 +1163,23 @@ class DeviceSettingsManager {
         },
         { once: true },
       )
+    }
+  }
+
+  // Run a section's apply with its buttons busy-locked, unlocking in a
+  // `finally`. A per-driver apply locks only its own gate; a common apply
+  // writes every driver, so it locks every section's gate for the round-trip
+  // (preventing a concurrent submit against the settings it will overwrite).
+  async #withSectionBusy(
+    gate: DirtyGate,
+    driverId: string | undefined,
+    action: () => Promise<void>,
+  ): Promise<void> {
+    this.#setSectionBusy(gate, driverId, true)
+    try {
+      await action()
+    } finally {
+      this.#setSectionBusy(gate, driverId, false)
     }
   }
 }

--- a/widgets/ata-group-setting/public/ata-values.mts
+++ b/widgets/ata-group-setting/public/ata-values.mts
@@ -13,6 +13,7 @@ import {
   booleanStrings,
   configureNumericInput,
   createOption,
+  getButton,
   getSelect,
 } from '../../../public/dom.mts'
 import {
@@ -172,13 +173,28 @@ const getAtaStatePath = (value: string): string => {
 // ── AtaValueManager class ──
 
 export class AtaValueManager {
+  readonly #applyButton: HTMLButtonElement
+
   #ataCapabilities: [keyof Classic.GroupState, DriverCapabilitiesOptions][] = []
 
   readonly #ataValues: HTMLDivElement
 
+  // Bumped whenever a save claims the busy state; only the claim holding
+  // the current value may release it (see `#withBusy`).
+  #busyGeneration = 0
+
   #defaultAtaValues: Partial<Record<keyof Classic.GroupState, null>> = {}
 
   readonly #homey: Homey
+
+  // A save (PUT) is in flight: greys Update and Refresh until it settles.
+  #isBusy = false
+
+  readonly #refreshButton: HTMLButtonElement
+
+  // Serialized snapshot of the form as of the last save/(re)load: Update
+  // is dirty-gated against it, so it greys out until an edit diverges.
+  #savedState = ''
 
   readonly #zone: HTMLSelectElement
 
@@ -193,6 +209,11 @@ export class AtaValueManager {
     this.#homey = homey
     this.#ataValues = ataValuesElement
     this.#zone = zoneElement
+    this.#applyButton = getButton('apply_values_melcloud')
+    this.#refreshButton = getButton('refresh_values_melcloud')
+    // Establish the pristine baseline up front: Update starts greyed even
+    // when no zone resolves and the first fetch never runs.
+    this.#resetSavedState()
   }
 
   public applyDefaultZone(
@@ -214,15 +235,22 @@ export class AtaValueManager {
 
   public createAtaFormControls(): void {
     for (const [id, { title, type, values }] of this.#ataCapabilities) {
-      appendFormControl(this.#ataValues, {
-        formControl: this.#createAtaControl({ id, type, values }),
-        title,
+      const formControl = this.#createAtaControl({ id, type, values })
+      // Every control feeds the dirty check so Update tracks edits live:
+      // `input` catches typing in the numeric field, `change` the selects.
+      formControl?.addEventListener('change', () => {
+        this.#updateDirty()
       })
+      formControl?.addEventListener('input', () => {
+        this.#updateDirty()
+      })
+      appendFormControl(this.#ataValues, { formControl, title })
     }
   }
 
   public displayValues(): void {
     this.#syncAtaValues()
+    this.#resetSavedState()
   }
 
   public async fetchCapabilities(): Promise<void> {
@@ -241,6 +269,10 @@ export class AtaValueManager {
     )
     this.#updateZoneMapping({ ...this.#defaultAtaValues, ...values })
     this.#syncAtaValues()
+    // The incoming server state becomes the new baseline (a background
+    // re-fetch mid-edit re-snapshots here); `#withBusy`'s generation guard
+    // keeps this from releasing a save that a live PUT still owns.
+    this.#resetSavedState()
     return values
   }
 
@@ -258,14 +290,19 @@ export class AtaValueManager {
   }
 
   public async setValues(): Promise<void> {
-    const body = this.#buildAtaValuesBody()
-    if (Object.keys(body).length > 0) {
-      await homeyApiPut(
-        this.#homey,
-        getAtaStatePath(this.#zone.value),
-        body satisfies Classic.GroupState,
-      )
-    }
+    await this.#withBusy(async () => {
+      const body = this.#buildAtaValuesBody()
+      if (Object.keys(body).length > 0) {
+        await homeyApiPut(
+          this.#homey,
+          getAtaStatePath(this.#zone.value),
+          body satisfies Classic.GroupState,
+        )
+      }
+      // New pristine baseline is the just-applied form. A rejected PUT
+      // throws before this, so the edit stays dirty for a retry.
+      this.#resetSavedState()
+    })
   }
 
   #buildAtaValuesBody(): Classic.GroupState {
@@ -310,6 +347,33 @@ export class AtaValueManager {
     return Object.hasOwn(this.#defaultAtaValues, value)
   }
 
+  // Snapshots the current form as the new pristine baseline and refreshes
+  // the dirty gate: called on (re)load, after each fetch/display, and
+  // after a successful save.
+  #resetSavedState(): void {
+    this.#savedState = this.#serializeState()
+    this.#updateDirty()
+  }
+
+  // Serializes every control's id and value, in DOM order, into the string
+  // the dirty check diffs against. A control still on its mixed/empty state
+  // serializes as '', so picking a concrete value registers as a change.
+  #serializeState(): string {
+    return JSON.stringify(
+      [
+        ...this.#ataValues.querySelectorAll<HTMLValueElement>('input, select'),
+      ].map(({ id, value }) => [id, value]),
+    )
+  }
+
+  // Refresh is gated by busy ALONE (never dirty), so it stays the escape
+  // hatch on a pristine form; Update folds busy into its dirty gate too.
+  #setBusy(isBusy: boolean): void {
+    this.#isBusy = isBusy
+    this.#refreshButton.disabled = isBusy
+    this.#updateDirty()
+  }
+
   #syncAtaValues(): void {
     for (const [ataKey] of this.#ataCapabilities) {
       this.#updateAtaValue(ataKey)
@@ -328,8 +392,34 @@ export class AtaValueManager {
     }
   }
 
+  // Native `disabled` (not a CSS class): it also blocks keyboard
+  // activation mid-request and is announced by screen readers. Update is
+  // live only when the form diverges from the snapshot AND nothing is in
+  // flight — the busy flag folds in so a control change mid-PUT cannot
+  // re-enable it.
+  #updateDirty(): void {
+    this.#applyButton.disabled =
+      this.#isBusy || this.#serializeState() === this.#savedState
+  }
+
   #updateZoneMapping(data: Partial<Classic.GroupState>): void {
     const { value } = this.#zone
     this.#zoneMapping[value] = { ...this.#zoneMapping[value], ...data }
+  }
+
+  // Generation-tokened: a background re-fetch (deviceupdate/zone change)
+  // re-snapshots the baseline mid-save, but only the save that owns the
+  // current generation may clear the busy state — so a debounced refresh
+  // can never release the controls a live PUT still holds.
+  async #withBusy(action: () => Promise<void>): Promise<void> {
+    const generation = ++this.#busyGeneration
+    this.#setBusy(true)
+    try {
+      await action()
+    } finally {
+      if (generation === this.#busyGeneration) {
+        this.#setBusy(false)
+      }
+    }
   }
 }


### PR DESCRIPTION
Aligns com.melcloud's settings page **and** the ATA group widget on the extension's dirty-gating UX.

**Apply/Update** — now disabled while the form is pristine, enabled only once a value actually changes, disabled during the in-flight save. Benefits: no no-op writes, a clear "there's something to save" affordance, and the button greying out after a save is itself the "saved" confirmation.

**Refresh** — deliberately **unchanged**: gated by an in-flight request only, never dirty-gated. A re-fetch is meaningful on a pristine form (pulls latest server state) and acts as "revert" on a dirty one — different semantics from Apply, so it stays always-available.

- **Settings**: per-section `DirtyGate` (frost protection / holiday mode); the saved snapshot resets on zone load and after each apply.
- **ATA group widget**: `apply_values_melcloud` gates on the fetched group state; re-snapshots on every fetch so a debounced `deviceupdate` mid-edit rebaselines without clobbering a live `setValues`; indeterminate→concrete counts as a change.

Full suite green (lint/format/typecheck/test 725/build). **Webview change — needs an on-device cold-open check before merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)