### PR TITLE
refactor: share one dirty-gate primitive across the settings and widget webviews

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,8 +78,9 @@ coverage.
   historical heatzy bug), and disabled greying styles
   `[class*='homey-button']:disabled` generically, never a per-class list
   (a class list silently missed renamed buttons).
-  `tests/unit/dirty-gate.test.ts` locks the behavior; com.heatzy carries a
-  byte-identical copy (`settings/dirty-gate.mts`) — edit both together.
+  `tests/unit/dirty-gate.test.ts` locks the behavior; com.heatzy and
+  com.melcloud.extension carry byte-identical copies
+  (`settings/dirty-gate.mts` in each) — edit all three together.
 - The injected sheet resets `fieldset.homey-form-checkbox-set` /
   `-radio-set` with `all: unset`, which leaves `display: inline` — and
   WebKit renders inline fieldsets atomically, so SIBLING sets tile side

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,16 @@ coverage.
   `homey-button-*` classes; `settings/index.css` only fills documented SDK
   gaps (date inputs, checkbox `:indeterminate`, `fieldset[hidden]`
   specificity) and app-specific design.
+- Dirty-gating: `public/dirty-gate.mts` is the ONE primitive behind every
+  webview Apply/Refresh pair (settings sections, frost/holiday panels, the
+  ATA group widget) — never re-derive its invariant at a call site. Its
+  `serialize` must stay a PURE form snapshot, never a request-body builder
+  (those filter null deltas out and desync the pristine check — the
+  historical heatzy bug), and disabled greying styles
+  `[class*='homey-button']:disabled` generically, never a per-class list
+  (a class list silently missed renamed buttons).
+  `tests/unit/dirty-gate.test.ts` locks the behavior; com.heatzy carries a
+  byte-identical copy (`settings/dirty-gate.mts`) — edit both together.
 - The injected sheet resets `fieldset.homey-form-checkbox-set` /
   `-radio-set` with `all: unset`, which leaves `display: inline` — and
   WebKit renders inline fieldsets atomically, so SIBLING sets tile side

--- a/public/dirty-gate.mts
+++ b/public/dirty-gate.mts
@@ -1,0 +1,88 @@
+// The webviews' shared dirty-gating primitive: one gate owns one Apply
+// button — greyed while the form matches its saved baseline OR a request
+// is in flight — and its sibling Refresh buttons, greyed by busy alone so
+// they stay the escape hatch on a pristine form. The factory owns the
+// whole invariant; a call site only supplies `serialize`. Byte-identical
+// copies of this module live in the sibling Homey apps — edit them
+// together.
+
+export interface DirtyGate {
+  readonly markSaved: () => void
+  readonly recompute: () => void
+  readonly runBusy: (action: () => Promise<void>) => Promise<void>
+  readonly setBusy: (isBusy: boolean) => void
+  readonly wire: (targets: readonly EventTarget[]) => void
+}
+
+export interface DirtyGateOptions {
+  readonly applyElement: HTMLButtonElement
+  readonly refreshElements?: readonly HTMLButtonElement[]
+  readonly serialize: () => string
+}
+
+// `input` covers live typing in number/date fields; `change` covers the
+// selects and the final commit (and, since `serialize` reads the whole
+// form, any field a cascade handler mutated).
+const wireRecompute = (
+  targets: readonly EventTarget[],
+  recompute: () => void,
+): void => {
+  for (const target of targets) {
+    for (const eventName of ['change', 'input']) {
+      target.addEventListener(eventName, recompute)
+    }
+  }
+}
+
+// `serialize` must be a PURE snapshot of the form's current values — never
+// a request-body builder: those filter defaults and null deltas out, which
+// desyncs the pristine check. The gate snapshots it at creation, so Apply
+// starts greyed even when no data ever loads; call `markSaved` after every
+// (re)populate and successful save, `wire` on the controls the snapshot
+// reads, and route every request through `runBusy`.
+export const createDirtyGate = ({
+  applyElement,
+  refreshElements = [],
+  serialize,
+}: DirtyGateOptions): DirtyGate => {
+  let busyGeneration = 0
+  let isBusy = false
+  let saved = serialize()
+  // Native `disabled` (not a CSS class): it blocks keyboard activation
+  // during in-flight actions and is announced by screen readers.
+  const recompute = (): void => {
+    applyElement.disabled = isBusy || serialize() === saved
+  }
+  const markSaved = (): void => {
+    saved = serialize()
+    recompute()
+  }
+  // Refresh is gated by busy ALONE (never dirty); Apply folds the busy
+  // flag into its dirty check so a mid-request edit cannot re-enable it.
+  const setBusy = (isBusyNow: boolean): void => {
+    isBusy = isBusyNow
+    for (const element of refreshElements) {
+      element.disabled = isBusyNow
+    }
+    recompute()
+  }
+  // Generation-tokened: only the action holding the latest claim may
+  // release the busy state, so an overlapping action can never free the
+  // buttons a live request still owns.
+  const runBusy = async (action: () => Promise<void>): Promise<void> => {
+    const generation = ++busyGeneration
+    setBusy(true)
+    try {
+      await action()
+    } finally {
+      if (generation === busyGeneration) {
+        setBusy(false)
+      }
+    }
+  }
+  const wire = (targets: readonly EventTarget[]): void => {
+    wireRecompute(targets, recompute)
+  }
+  recompute()
+  return { markSaved, recompute, runBusy, setBusy, wire }
+}

--- a/settings/index.css
+++ b/settings/index.css
@@ -136,12 +136,11 @@ input.homey-form-checkbox-input:indeterminate
   transform: translate(-50%, -50%);
 }
 
-/* The SDK's shadow/full button classes carry no disabled state of their
-   own — surface an in-flight action (a settings update running until its
-   success or failure alert) as greyed and non-interactive. */
-.homey-button-danger-shadow:disabled,
-.homey-button-primary-full:disabled,
-.homey-button-secondary-shadow:disabled {
+/* The SDK's button classes carry no disabled state of their own — surface
+   a greyed, non-interactive state on EVERY homey-button variant (dirty-
+   gated Apply, in-flight actions). The attribute selector keeps the rule
+   variant-proof: a per-class list silently missed renamed buttons. */
+[class*='homey-button']:disabled {
   cursor: not-allowed;
   opacity: 0.5;
 }

--- a/settings/index.mts
+++ b/settings/index.mts
@@ -25,6 +25,7 @@ import type {
 } from '../types/error-log.mts'
 import type { HomeBuildingZone, HomeDeviceZone } from '../types/zone.mts'
 import { getErrorMessage } from '../lib/get-error-message.mts'
+import { type DirtyGate, createDirtyGate } from '../public/dirty-gate.mts'
 import {
   type HTMLValueElement,
   booleanStrings,
@@ -455,73 +456,6 @@ const getSubzones = (
   ...('areas' in zone ? zone.areas : []),
   ...('floors' in zone ? zone.floors : []),
 ]
-
-// Per-section dirty-gating state: `saved` holds the serialization of the
-// zone values last loaded into the panel, `busy` marks a request in
-// flight. Apply is enabled only when the current form diverges from
-// `saved` AND nothing is busy; Refresh is gated by `busy` alone.
-interface DirtyGate {
-  readonly applyId: string
-  readonly busy: { value: boolean }
-  readonly refreshId: string
-  readonly saved: { value: string }
-  readonly serialize: () => string
-}
-
-// Apply is enabled only when the form diverges from the last-loaded values
-// AND no request is in flight — the native `disabled` also blocks keyboard
-// activation mid-request and is announced by screen readers.
-const updateDirty = (gate: DirtyGate): void => {
-  disableButton(
-    gate.applyId,
-    gate.busy.value || gate.serialize() === gate.saved.value,
-  )
-}
-
-// Recompute a section's dirty state on every input it exposes, so Apply
-// reflects unsaved edits. `input` covers live typing in the number/date
-// fields; `change` covers the selects and the final commit (and, since
-// `serialize` reads the whole section, any field a cascade handler mutated).
-const wireDirtyRecompute = (
-  elements: HTMLValueElement[],
-  gate: DirtyGate,
-): void => {
-  for (const element of elements) {
-    for (const eventName of ['change', 'input']) {
-      element.addEventListener(eventName, () => {
-        updateDirty(gate)
-      })
-    }
-  }
-}
-
-// Take the current form as the pristine baseline — called on load, on every
-// repopulate, and after a successful apply — then re-evaluate Apply.
-const snapshotSavedState = (gate: DirtyGate): void => {
-  gate.saved.value = gate.serialize()
-  updateDirty(gate)
-}
-
-// Refresh is gated by `busy` alone (never dirty), matching the section's
-// disable-during-request behavior; Apply folds the busy flag into its dirty
-// check so a mid-request edit cannot re-enable it.
-const setButtonsBusy = (gate: DirtyGate, areBusy: boolean): void => {
-  gate.busy.value = areBusy
-  disableButton(gate.refreshId, areBusy)
-  updateDirty(gate)
-}
-
-const withBusyButtons = async (
-  gate: DirtyGate,
-  action: () => Promise<void>,
-): Promise<void> => {
-  setButtonsBusy(gate, true)
-  try {
-    await action()
-  } finally {
-    setButtonsBusy(gate, false)
-  }
-}
 
 // Serialize a device-settings section's controls as a pure form snapshot for
 // its DirtyGate — the same value-only shape the frost/holiday gates use. A
@@ -984,32 +918,31 @@ class DeviceSettingsManager {
     driverId?: string,
   ): void {
     this.#syncSettings(elements, driverId)
-    snapshotSavedState(gate)
+    gate.markSaved()
   }
 
   // Build and wire one device-settings section's DirtyGate (the common one
   // when `driverId` is omitted, else a driver's), keyed by section id in
-  // `#dirtyGates`. Snapshots the freshly populated controls as the pristine
-  // baseline, so Apply starts disabled until an edit diverges from it.
+  // `#dirtyGates`. The gate snapshots the freshly populated controls at
+  // creation, so Apply starts disabled until an edit diverges from them.
   #registerSettingsSection(
     elements: HTMLValueElement[],
     driverId?: string,
   ): void {
     const sectionId = toSectionId(driverId ?? 'common')
-    const gate: DirtyGate = {
-      applyId: `apply_settings_${sectionId}`,
-      busy: { value: false },
-      refreshId: `refresh_settings_${sectionId}`,
-      saved: { value: '' },
+    const applyElement = getButton(`apply_settings_${sectionId}`)
+    const refreshElement = getButton(`refresh_settings_${sectionId}`)
+    const gate = createDirtyGate({
+      applyElement,
+      refreshElements: [refreshElement],
       serialize: () => serializeSettingElements(elements),
-    }
+    })
     this.#dirtyGates.set(sectionId, gate)
-    wireDirtyRecompute(elements, gate)
-    snapshotSavedState(gate)
-    getButton(gate.applyId).addEventListener('click', () => {
+    gate.wire(elements)
+    applyElement.addEventListener('click', () => {
       fireAndForget(this.#submitDeviceSettings(gate, elements, driverId))
     })
-    getButton(gate.refreshId).addEventListener('click', () => {
+    refreshElement.addEventListener('click', () => {
       this.#refreshSettings(gate, elements, driverId)
     })
   }
@@ -1025,11 +958,11 @@ class DeviceSettingsManager {
   ): void {
     if (driverId === undefined) {
       for (const sectionGate of this.#dirtyGates.values()) {
-        setButtonsBusy(sectionGate, areBusy)
+        sectionGate.setBusy(areBusy)
       }
       return
     }
-    setButtonsBusy(gate, areBusy)
+    gate.setBusy(areBusy)
   }
 
   #setSetting(settings: Settings, element: HTMLValueElement): void {
@@ -1078,13 +1011,13 @@ class DeviceSettingsManager {
       // update (a blank select, a re-toggled checkbox). Re-baseline so
       // Apply drops back to disabled.
       this.#alertNoChanges(elements, driverId)
-      snapshotSavedState(gate)
+      gate.markSaved()
       return
     }
     await this.#withSectionBusy(gate, driverId, async () => {
       try {
         await this.#applyDeviceSettings(body, driverId)
-        snapshotSavedState(gate)
+        gate.markSaved()
       } catch (error) {
         await this.#homey.alert(getErrorMessage(error))
       }
@@ -1352,30 +1285,26 @@ class ZoneSettingsManager {
     this.#frostProtectionMaxTemperature = initFrostProtectionMax()
     this.#holidayModeStartDate = getInput('start_date')
     this.#holidayModeEndDate = getInput('end_date')
-    this.#frostProtectionDirtyGate = {
-      applyId: 'apply_frost_protection',
-      busy: { value: false },
-      refreshId: 'refresh_frost_protection',
-      saved: { value: '' },
+    this.#frostProtectionDirtyGate = createDirtyGate({
+      applyElement: getButton('apply_frost_protection'),
+      refreshElements: [getButton('refresh_frost_protection')],
       serialize: (): string =>
         JSON.stringify([
           this.#frostProtectionEnabled.value,
           this.#frostProtectionMinTemperature.value,
           this.#frostProtectionMaxTemperature.value,
         ]),
-    }
-    this.#holidayModeDirtyGate = {
-      applyId: 'apply_holiday_mode',
-      busy: { value: false },
-      refreshId: 'refresh_holiday_mode',
-      saved: { value: '' },
+    })
+    this.#holidayModeDirtyGate = createDirtyGate({
+      applyElement: getButton('apply_holiday_mode'),
+      refreshElements: [getButton('refresh_holiday_mode')],
       serialize: (): string =>
         JSON.stringify([
           this.#holidayModeEnabled.value,
           this.#holidayModeStartDate.value,
           this.#holidayModeEndDate.value,
         ]),
-    }
+    })
   }
 
   public addEventListeners(): void {
@@ -1390,8 +1319,8 @@ class ZoneSettingsManager {
     this.#addDirtyRecomputeListeners()
     // Baseline before the first (fire-and-forget) load lands, so Apply
     // starts pristine (disabled) instead of spuriously enabled.
-    snapshotSavedState(this.#frostProtectionDirtyGate)
-    snapshotSavedState(this.#holidayModeDirtyGate)
+    this.#frostProtectionDirtyGate.markSaved()
+    this.#holidayModeDirtyGate.markSaved()
   }
 
   /** @silent Falls back to default values on error. */
@@ -1412,7 +1341,7 @@ class ZoneSettingsManager {
     }
     // Populating the panel re-baselines it: the freshly loaded (or saved)
     // values become the pristine state, so Apply drops back to disabled.
-    snapshotSavedState(this.#frostProtectionDirtyGate)
+    this.#frostProtectionDirtyGate.markSaved()
   }
 
   public displayHolidayModeData(): void {
@@ -1433,7 +1362,7 @@ class ZoneSettingsManager {
     }
     // Populating the panel re-baselines it: the freshly loaded (or saved)
     // values become the pristine state, so Apply drops back to disabled.
-    snapshotSavedState(this.#holidayModeDirtyGate)
+    this.#holidayModeDirtyGate.markSaved()
   }
 
   /** @silent Falls back to default values on error. */
@@ -1542,22 +1471,16 @@ class ZoneSettingsManager {
   }
 
   #addDirtyRecomputeListeners(): void {
-    wireDirtyRecompute(
-      [
-        this.#frostProtectionEnabled,
-        this.#frostProtectionMinTemperature,
-        this.#frostProtectionMaxTemperature,
-      ],
-      this.#frostProtectionDirtyGate,
-    )
-    wireDirtyRecompute(
-      [
-        this.#holidayModeEnabled,
-        this.#holidayModeStartDate,
-        this.#holidayModeEndDate,
-      ],
-      this.#holidayModeDirtyGate,
-    )
+    this.#frostProtectionDirtyGate.wire([
+      this.#frostProtectionEnabled,
+      this.#frostProtectionMinTemperature,
+      this.#frostProtectionMaxTemperature,
+    ])
+    this.#holidayModeDirtyGate.wire([
+      this.#holidayModeEnabled,
+      this.#holidayModeStartDate,
+      this.#holidayModeEndDate,
+    ])
   }
 
   #addFrostProtectionEventListeners(): void {
@@ -1628,7 +1551,7 @@ class ZoneSettingsManager {
     id,
     path,
   }: ZoneSettingDescriptor): Promise<void> {
-    await withBusyButtons(this.#gateFor(id), async () => {
+    await this.#gateFor(id).runBusy(async () => {
       try {
         this.#updateZoneMapping(await this.#getZoneSettingData(path))
         display()
@@ -1725,7 +1648,7 @@ class ZoneSettingsManager {
     query: Classic.FrostProtectionQuery | HolidayModeUpdate,
     zoneSettings: Partial<Classic.ZoneSettings>,
   ): Promise<void> {
-    await withBusyButtons(this.#gateFor(id), async () => {
+    await this.#gateFor(id).runBusy(async () => {
       try {
         await homeyApiPut<unknown>(
           this.#homey,

--- a/tests/unit/dirty-gate.test.ts
+++ b/tests/unit/dirty-gate.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest'
+
+import { createDirtyGate } from '../../public/dirty-gate.mts'
+
+// The gate is headless: buttons only need a `disabled` slot, and wired
+// targets only need to dispatch events, so plain doubles are enough.
+const setup = (): {
+  applyElement: HTMLButtonElement
+  form: { value: string }
+  gate: ReturnType<typeof createDirtyGate>
+  refreshElement: HTMLButtonElement
+} => {
+  const applyElement = { disabled: false } as unknown as HTMLButtonElement
+  const refreshElement = { disabled: false } as unknown as HTMLButtonElement
+  const form = { value: 'pristine' }
+  const gate = createDirtyGate({
+    applyElement,
+    refreshElements: [refreshElement],
+    serialize: () => form.value,
+  })
+  return { applyElement, form, gate, refreshElement }
+}
+
+describe('dirty gate', () => {
+  it('should start pristine with Apply greyed and Refresh live', () => {
+    const { applyElement, refreshElement } = setup()
+
+    expect(applyElement.disabled).toBe(true)
+    expect(refreshElement.disabled).toBe(false)
+  })
+
+  it('should enable Apply when the form diverges and grey it once saved', () => {
+    const { applyElement, form, gate } = setup()
+
+    form.value = 'edited'
+    gate.recompute()
+
+    expect(applyElement.disabled).toBe(false)
+
+    gate.markSaved()
+
+    expect(applyElement.disabled).toBe(true)
+  })
+
+  it('should recompute on change and input events from wired targets', () => {
+    const { applyElement, form, gate } = setup()
+    const target = new EventTarget()
+    gate.wire([target])
+
+    form.value = 'edited'
+    target.dispatchEvent(new Event('change'))
+
+    expect(applyElement.disabled).toBe(false)
+
+    form.value = 'pristine'
+    target.dispatchEvent(new Event('input'))
+
+    expect(applyElement.disabled).toBe(true)
+  })
+
+  it('should grey both buttons while busy and restore them after', () => {
+    const { applyElement, form, gate, refreshElement } = setup()
+
+    form.value = 'edited'
+    gate.setBusy(true)
+
+    expect(applyElement.disabled).toBe(true)
+    expect(refreshElement.disabled).toBe(true)
+
+    gate.setBusy(false)
+
+    expect(applyElement.disabled).toBe(false)
+    expect(refreshElement.disabled).toBe(false)
+  })
+
+  it('should release the buttons when the action rejects and keep the edit dirty', async () => {
+    const { applyElement, form, gate, refreshElement } = setup()
+
+    form.value = 'edited'
+
+    await expect(
+      gate.runBusy(async () => {
+        await Promise.reject(new Error('boom'))
+      }),
+    ).rejects.toThrow('boom')
+
+    expect(applyElement.disabled).toBe(false)
+    expect(refreshElement.disabled).toBe(false)
+  })
+
+  it('should let only the latest claim release the busy state', async () => {
+    const { gate, refreshElement } = setup()
+    const firstClaim = Promise.withResolvers<null>()
+    const secondClaim = Promise.withResolvers<null>()
+    const first = gate.runBusy(async () => {
+      await firstClaim.promise
+    })
+    const second = gate.runBusy(async () => {
+      await secondClaim.promise
+    })
+
+    firstClaim.resolve(null)
+    await first
+
+    expect(refreshElement.disabled).toBe(true)
+
+    secondClaim.resolve(null)
+    await second
+
+    expect(refreshElement.disabled).toBe(false)
+  })
+})

--- a/widgets/ata-group-setting/public/ata-values.mts
+++ b/widgets/ata-group-setting/public/ata-values.mts
@@ -8,6 +8,7 @@ import type { Settings } from '../../../types/device-settings.mts'
 import type { DriverCapabilitiesOptions } from '../../../types/driver-settings.mts'
 import type { AtaGroupSettingWidgetSettings } from '../../../types/widgets.mts'
 import type { HomeBuildingZone, HomeDeviceZone } from '../../../types/zone.mts'
+import { type DirtyGate, createDirtyGate } from '../../../public/dirty-gate.mts'
 import {
   type HTMLValueElement,
   booleanStrings,
@@ -173,28 +174,17 @@ const getAtaStatePath = (value: string): string => {
 // ── AtaValueManager class ──
 
 export class AtaValueManager {
-  readonly #applyButton: HTMLButtonElement
-
   #ataCapabilities: [keyof Classic.GroupState, DriverCapabilitiesOptions][] = []
 
   readonly #ataValues: HTMLDivElement
 
-  // Bumped whenever a save claims the busy state; only the claim holding
-  // the current value may release it (see `#withBusy`).
-  #busyGeneration = 0
-
   #defaultAtaValues: Partial<Record<keyof Classic.GroupState, null>> = {}
 
+  // Owns Update (greyed until the form diverges from its saved baseline)
+  // and Refresh (greyed during a request alone).
+  readonly #dirtyGate: DirtyGate
+
   readonly #homey: Homey
-
-  // A save (PUT) is in flight: greys Update and Refresh until it settles.
-  #isBusy = false
-
-  readonly #refreshButton: HTMLButtonElement
-
-  // Serialized snapshot of the form as of the last save/(re)load: Update
-  // is dirty-gated against it, so it greys out until an edit diverges.
-  #savedState = ''
 
   readonly #zone: HTMLSelectElement
 
@@ -209,11 +199,13 @@ export class AtaValueManager {
     this.#homey = homey
     this.#ataValues = ataValuesElement
     this.#zone = zoneElement
-    this.#applyButton = getButton('apply_values_melcloud')
-    this.#refreshButton = getButton('refresh_values_melcloud')
-    // Establish the pristine baseline up front: Update starts greyed even
-    // when no zone resolves and the first fetch never runs.
-    this.#resetSavedState()
+    // The gate snapshots its pristine baseline at creation: Update starts
+    // greyed even when no zone resolves and the first fetch never runs.
+    this.#dirtyGate = createDirtyGate({
+      applyElement: getButton('apply_values_melcloud'),
+      refreshElements: [getButton('refresh_values_melcloud')],
+      serialize: (): string => this.#serializeState(),
+    })
   }
 
   public applyDefaultZone(
@@ -234,23 +226,23 @@ export class AtaValueManager {
   }
 
   public createAtaFormControls(): void {
+    const formControls: HTMLValueElement[] = []
     for (const [id, { title, type, values }] of this.#ataCapabilities) {
       const formControl = this.#createAtaControl({ id, type, values })
-      // Every control feeds the dirty check so Update tracks edits live:
-      // `input` catches typing in the numeric field, `change` the selects.
-      formControl?.addEventListener('change', () => {
-        this.#updateDirty()
-      })
-      formControl?.addEventListener('input', () => {
-        this.#updateDirty()
-      })
+      if (formControl !== null) {
+        formControls.push(formControl)
+      }
       appendFormControl(this.#ataValues, { formControl, title })
     }
+    // Every control feeds the dirty check so Update tracks edits live; the
+    // freshly built (still empty) controls are the pristine baseline.
+    this.#dirtyGate.wire(formControls)
+    this.#dirtyGate.markSaved()
   }
 
   public displayValues(): void {
     this.#syncAtaValues()
-    this.#resetSavedState()
+    this.#dirtyGate.markSaved()
   }
 
   public async fetchCapabilities(): Promise<void> {
@@ -270,9 +262,9 @@ export class AtaValueManager {
     this.#updateZoneMapping({ ...this.#defaultAtaValues, ...values })
     this.#syncAtaValues()
     // The incoming server state becomes the new baseline (a background
-    // re-fetch mid-edit re-snapshots here); `#withBusy`'s generation guard
+    // re-fetch mid-edit re-snapshots here); `runBusy`'s generation guard
     // keeps this from releasing a save that a live PUT still owns.
-    this.#resetSavedState()
+    this.#dirtyGate.markSaved()
     return values
   }
 
@@ -290,7 +282,7 @@ export class AtaValueManager {
   }
 
   public async setValues(): Promise<void> {
-    await this.#withBusy(async () => {
+    await this.#dirtyGate.runBusy(async () => {
       const body = this.#buildAtaValuesBody()
       if (Object.keys(body).length > 0) {
         await homeyApiPut(
@@ -301,7 +293,7 @@ export class AtaValueManager {
       }
       // New pristine baseline is the just-applied form. A rejected PUT
       // throws before this, so the edit stays dirty for a retry.
-      this.#resetSavedState()
+      this.#dirtyGate.markSaved()
     })
   }
 
@@ -347,14 +339,6 @@ export class AtaValueManager {
     return Object.hasOwn(this.#defaultAtaValues, value)
   }
 
-  // Snapshots the current form as the new pristine baseline and refreshes
-  // the dirty gate: called on (re)load, after each fetch/display, and
-  // after a successful save.
-  #resetSavedState(): void {
-    this.#savedState = this.#serializeState()
-    this.#updateDirty()
-  }
-
   // Serializes every control's id and value, in DOM order, into the string
   // the dirty check diffs against. A control still on its mixed/empty state
   // serializes as '', so picking a concrete value registers as a change.
@@ -364,14 +348,6 @@ export class AtaValueManager {
         ...this.#ataValues.querySelectorAll<HTMLValueElement>('input, select'),
       ].map(({ id, value }) => [id, value]),
     )
-  }
-
-  // Refresh is gated by busy ALONE (never dirty), so it stays the escape
-  // hatch on a pristine form; Update folds busy into its dirty gate too.
-  #setBusy(isBusy: boolean): void {
-    this.#isBusy = isBusy
-    this.#refreshButton.disabled = isBusy
-    this.#updateDirty()
   }
 
   #syncAtaValues(): void {
@@ -392,34 +368,8 @@ export class AtaValueManager {
     }
   }
 
-  // Native `disabled` (not a CSS class): it also blocks keyboard
-  // activation mid-request and is announced by screen readers. Update is
-  // live only when the form diverges from the snapshot AND nothing is in
-  // flight — the busy flag folds in so a control change mid-PUT cannot
-  // re-enable it.
-  #updateDirty(): void {
-    this.#applyButton.disabled =
-      this.#isBusy || this.#serializeState() === this.#savedState
-  }
-
   #updateZoneMapping(data: Partial<Classic.GroupState>): void {
     const { value } = this.#zone
     this.#zoneMapping[value] = { ...this.#zoneMapping[value], ...data }
-  }
-
-  // Generation-tokened: a background re-fetch (deviceupdate/zone change)
-  // re-snapshots the baseline mid-save, but only the save that owns the
-  // current generation may clear the busy state — so a debounced refresh
-  // can never release the controls a live PUT still holds.
-  async #withBusy(action: () => Promise<void>): Promise<void> {
-    const generation = ++this.#busyGeneration
-    this.#setBusy(true)
-    try {
-      await action()
-    } finally {
-      if (generation === this.#busyGeneration) {
-        this.#setBusy(false)
-      }
-    }
   }
 }


### PR DESCRIPTION
Factors the dirty-gating shipped in #1466 into **one headless primitive** so its invariant can no longer be re-derived (and subtly broken) per webview.

## What
- **`public/dirty-gate.mts`** — `createDirtyGate({applyElement, refreshElements, serialize})` owns the whole invariant: Apply greyed while pristine OR busy, Refresh greyed by busy alone, saved-baseline snapshots (`markSaved`), generation-tokened busy claims (`runBusy` — an overlapping action can no longer release buttons a live request still owns), and `change`/`input` wiring (`wire`).
- **Adopted everywhere**: settings device-settings sections, frost-protection + holiday-mode panels, and the ATA group widget (drops its 5 private twin members). `serialize` is the only per-call-site piece, documented as a **pure form snapshot** — never a request-body builder.
- **`settings/index.css`** — disabled greying now targets `[class*='homey-button']:disabled` (same specificity (0,2,0)) instead of a per-class list, so a renamed button variant cannot silently escape the rule.
- **`tests/unit/dirty-gate.test.ts`** — 6 behavior-locking tests (pristine start, dirty/saved cycle, wired events, busy semantics, rejection release, generation guard).
- **CLAUDE.md** — doctrine: module ownership, serialize purity, generic `:disabled`, byte-identical com.heatzy copy (sibling heatzy PR).

## Why
The three historical dirty-gating bugs were each a re-derivation drift: a serialize reusing a PUT-body builder (never pristine), a CSS class list missing the real buttons (never greyed), and sections left ungated. One primitive + one extension point removes the drift surface.

No behavior change intended. Full suite green (731 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
