### PR TITLE
style: drop the experimentalTernaries flag

### DIFF
--- a/api.mts
+++ b/api.mts
@@ -44,9 +44,9 @@ const toLoginFailure = (
     return new Error(getErrorMessage(error))
   }
   const reason =
-    error instanceof AuthenticationThrottledError ?
-      'settings.authenticate.throttled'
-    : 'settings.authenticate.rejected'
+    error instanceof AuthenticationThrottledError
+      ? 'settings.authenticate.throttled'
+      : 'settings.authenticate.rejected'
   return new Error(homey.__(reason, { name: API_DISPLAY_NAMES[service] }))
 }
 

--- a/app.mts
+++ b/app.mts
@@ -84,8 +84,8 @@ const byName = (
 // not agree on reads as "mixed" (`null`).
 const commonValue = <T,>(values: readonly T[]): NonNullable<T> | null => {
   const [first, ...rest] = values
-  return values.length > 0 && rest.every((value) => value === first) ?
-      (first ?? null)
+  return values.length > 0 && rest.every((value) => value === first)
+    ? (first ?? null)
     : null
 }
 
@@ -112,13 +112,13 @@ const daysAgo = (days: number, timezone: string): string =>
 // last-24-hours choice the report picker offers when hourly buckets
 // exist.
 const chartDaysStart = (days: number, timezone: string): string =>
-  days === 0 ?
-    daysAgo(1, timezone)
-  : Temporal.Now.zonedDateTimeISO(timezone)
-      .startOfDay()
-      .subtract({ days: days - 1 })
-      .toPlainDateTime()
-      .toString()
+  days === 0
+    ? daysAgo(1, timezone)
+    : Temporal.Now.zonedDateTimeISO(timezone)
+        .startOfDay()
+        .subtract({ days: days - 1 })
+        .toPlainDateTime()
+        .toString()
 
 // The manifest min/max/step only constrain manual input: a flow token
 // dropped into the field can carry anything at runtime. Only numbers
@@ -248,9 +248,9 @@ const getLocalizedCapabilitiesOptions = (
   type: options.type,
   values: options.values?.map(({ id, title }) => ({
     id:
-      enumType !== undefined && Object.hasOwn(enumType, id) ?
-        String(enumType[id])
-      : id,
+      enumType !== undefined && Object.hasOwn(enumType, id)
+        ? String(enumType[id])
+        : id,
     label: title[language] ?? title.en,
   })),
 })
@@ -284,8 +284,8 @@ type PickerNode = Classic.FlatZone | HomeBuildingZone | HomeDeviceZone
 // flow, chart and group widget pickers).
 const toFlatName = ({ buildingName, model, name }: PickerNode): string => {
   const trimmed = name.trim()
-  return model === 'buildings' || model === 'homeBuildings' ?
-      trimmed
+  return model === 'buildings' || model === 'homeBuildings'
+    ? trimmed
     : `${trimmed} (${buildingName.trim()})`
 }
 
@@ -343,15 +343,15 @@ const syntheticErrorLogWindow = (
 ): Omit<Classic.ErrorLog, 'errors'> => {
   const periodDays = period ?? DEFAULT_ERROR_LOG_PERIOD_DAYS
   const toDate =
-    to !== undefined && to !== '' ?
-      Temporal.PlainDate.from(to)
-    : Temporal.Now.plainDateISO(timeZone)
+    to !== undefined && to !== ''
+      ? Temporal.PlainDate.from(to)
+      : Temporal.Now.plainDateISO(timeZone)
   // A user-picked "since" date pins the window start, like the
   // library's own parseErrorLogQuery does on the Classic path.
   const fromDate =
-    from !== undefined && from !== '' ?
-      Temporal.PlainDate.from(from)
-    : toDate.subtract({ days: periodDays })
+    from !== undefined && from !== ''
+      ? Temporal.PlainDate.from(from)
+      : toDate.subtract({ days: periodDays })
   const nextToDate = fromDate.subtract({ days: 1 })
   return {
     fromDate: fromDate.toString(),
@@ -408,9 +408,9 @@ const formatErrorEntries = (
     )
     .map(({ device, error, instant }) => ({
       date:
-        Temporal.Instant.compare(instant, MIN_PLAUSIBLE_ERROR_INSTANT) < 0 ?
-          UNKNOWN_DATE_PLACEHOLDER
-        : dateTimeMedFormat.format(instant),
+        Temporal.Instant.compare(instant, MIN_PLAUSIBLE_ERROR_INSTANT) < 0
+          ? UNKNOWN_DATE_PLACEHOLDER
+          : dateTimeMedFormat.format(instant),
       device,
       error,
     }))
@@ -730,9 +730,9 @@ export default class MELCloudApp extends App {
       from: Temporal.PlainDate.from(fromDate),
       timeZone,
       to:
-        query.to !== undefined && query.to !== '' ?
-          Temporal.PlainDate.from(query.to)
-        : null,
+        query.to !== undefined && query.to !== ''
+          ? Temporal.PlainDate.from(query.to)
+          : null,
     }
     const allHomeEntries = await this.#getHomeErrorEntries(timeZone)
     const homeEntries = allHomeEntries.filter((entry) =>
@@ -941,9 +941,9 @@ export default class MELCloudApp extends App {
     type?: Home.DeviceType,
   ): (HomeBuildingZone | HomeDeviceZone)[] {
     const devices =
-      type === undefined ?
-        this.#homeRegistry.getAll()
-      : this.#homeRegistry.getByType(type)
+      type === undefined
+        ? this.#homeRegistry.getAll()
+        : this.#homeRegistry.getByType(type)
     const buildings = new Map<
       string,
       { devices: HomeDeviceZone[]; name: string }
@@ -1222,9 +1222,9 @@ export default class MELCloudApp extends App {
     // Classic owns the unprefixed keys (legacy); Home is namespaced to
     // avoid collisions (e.g. `username` → `homeUsername`).
     const prefixKey = (key: string): string =>
-      api === 'classic' ? key : (
-        `${api}${key.charAt(0).toUpperCase()}${key.slice(1)}`
-      )
+      api === 'classic'
+        ? key
+        : `${api}${key.charAt(0).toUpperCase()}${key.slice(1)}`
     return {
       get: (key: string): string | null | undefined => {
         const value: unknown = this.homey.settings.get(prefixKey(key))
@@ -1312,9 +1312,9 @@ export default class MELCloudApp extends App {
     const stringIds = ids?.map(String)
     return drivers.flatMap((driver) => {
       const devices = driver.getDevices()
-      return stringIds === undefined ? devices : (
-          devices.filter(({ id }) => stringIds.includes(String(id)))
-        )
+      return stringIds === undefined
+        ? devices
+        : devices.filter(({ id }) => stringIds.includes(String(id)))
     })
   }
 
@@ -1329,9 +1329,9 @@ export default class MELCloudApp extends App {
   // and post-init `onSync` calls find every driver ready.
   #getDrivers(driverId?: string): MELCloudDriver[] {
     const drivers = Object.values(this.homey.drivers.getDrivers())
-    return driverId === undefined ? drivers : (
-        drivers.filter((driver) => driver.id === driverId)
-      )
+    return driverId === undefined
+      ? drivers
+      : drivers.filter((driver) => driver.id === driverId)
   }
 
   // The ids of every device (ATA and ATW) in a `/context` building.
@@ -1585,8 +1585,8 @@ export default class MELCloudApp extends App {
     // card; the false card just clears the window.
     this.#registerHolidayModeCard('holiday_mode_action', ({ duration }) => {
       const days = this.#holidayModeDays(duration)
-      return days > HOLIDAY_MODE_OFF_DURATION ?
-          this.#holidayModeWindow(days)
+      return days > HOLIDAY_MODE_OFF_DURATION
+        ? this.#holidayModeWindow(days)
         : this.#holidayModeOff()
     })
     this.#registerHolidayModeCard(

--- a/drivers/base-device.mts
+++ b/drivers/base-device.mts
@@ -407,9 +407,9 @@ export abstract class BaseMELCloudDevice<
     await sequential(
       [...currentCapabilities.symmetricDifference(requiredCapabilities)],
       async (capability) => {
-        await (requiredCapabilities.has(capability) ?
-          this.addCapability(capability)
-        : this.removeCapability(capability))
+        await (requiredCapabilities.has(capability)
+          ? this.addCapability(capability)
+          : this.removeCapability(capability))
       },
     )
 
@@ -448,9 +448,9 @@ export abstract class BaseMELCloudDevice<
     changedCapabilities: string[],
   ): Promise<void> {
     await sequential(changedCapabilities, async (capability) => {
-      await (newSettings[capability] === true ?
-        this.addCapability(capability)
-      : this.removeCapability(capability))
+      await (newSettings[capability] === true
+        ? this.addCapability(capability)
+        : this.removeCapability(capability))
     })
     this.#tagMappings.list = this.cleanMapping(this.driver.tagMappings.list)
   }

--- a/drivers/base-driver.mts
+++ b/drivers/base-driver.mts
@@ -96,8 +96,8 @@ export abstract class BaseMELCloudDriver extends Driver {
               },
             ) => {
               const value = args.device.getCapabilityValue(capability)
-              return typeof value === 'string' || typeof value === 'number' ?
-                  value === args[getArg(capability)]
+              return typeof value === 'string' || typeof value === 'number'
+                ? value === args[getArg(capability)]
                 : value
             },
           )

--- a/drivers/home-device.mts
+++ b/drivers/home-device.mts
@@ -41,8 +41,8 @@ export abstract class HomeMELCloudDevice<
     Record<string, unknown>
   > {
     const facade = this.cachedFacade
-    return facade === undefined ?
-        {}
+    return facade === undefined
+      ? {}
       : this.driver.getCapabilitiesOptions(facade)
   }
 
@@ -52,8 +52,8 @@ export abstract class HomeMELCloudDevice<
 
   protected override getRequiredCapabilities(): string[] {
     const facade = this.cachedFacade
-    return facade === undefined ?
-        []
+    return facade === undefined
+      ? []
       : this.driver.getRequiredCapabilities(facade)
   }
 

--- a/drivers/home-melcloud/device.mts
+++ b/drivers/home-melcloud/device.mts
@@ -56,9 +56,9 @@ export default class HomeMELCloudDeviceAta extends HomeMELCloudDevice<AtaType> {
     onoff: ({ power: isOn }) => isOn,
     target_temperature: ({ setTemperature: temperature }) => temperature,
     thermostat_mode: ({ operationMode, power: isOn }) =>
-      isOn ?
-        operationModeFromDevice[operationModeToClassic[operationMode]]
-      : ThermostatModeAta.off,
+      isOn
+        ? operationModeFromDevice[operationModeToClassic[operationMode]]
+        : ThermostatModeAta.off,
     vertical: ({ vaneVerticalDirection }) =>
       verticalFromDevice[verticalToClassic[vaneVerticalDirection]],
   }

--- a/drivers/home-melcloud_atw/device.mts
+++ b/drivers/home-melcloud_atw/device.mts
@@ -95,8 +95,8 @@ export default class HomeMELCloudDeviceAtw extends HomeMELCloudDevice<AtwType> {
     if (capabilities === undefined) {
       return true
     }
-    return measure === 'consumed' ?
-        capabilities.hasEstimatedEnergyConsumption ||
+    return measure === 'consumed'
+      ? capabilities.hasEstimatedEnergyConsumption ||
           capabilities.hasMeasuredEnergyConsumption
       : capabilities.hasEstimatedEnergyProduction ||
           capabilities.hasMeasuredEnergyProduction

--- a/drivers/home-melcloud_atw/driver.mts
+++ b/drivers/home-melcloud_atw/driver.mts
@@ -29,19 +29,19 @@ const energyCapabilities = (
     'hasMeasuredEnergyProduction',
   ])
   return [
-    ...(hasConsumed ?
-      ['measure_power', 'meter_power', 'meter_power.daily']
-    : []),
-    ...(hasProduced ?
-      [
-        'measure_power.produced',
-        'meter_power.produced',
-        'meter_power.produced_daily',
-      ]
-    : []),
-    ...(hasConsumed && hasProduced ?
-      ['meter_power.cop', 'meter_power.cop_daily']
-    : []),
+    ...(hasConsumed
+      ? ['measure_power', 'meter_power', 'meter_power.daily']
+      : []),
+    ...(hasProduced
+      ? [
+          'measure_power.produced',
+          'meter_power.produced',
+          'meter_power.produced_daily',
+        ]
+      : []),
+    ...(hasConsumed && hasProduced
+      ? ['meter_power.cop', 'meter_power.cop_daily']
+      : []),
   ]
 }
 
@@ -99,15 +99,15 @@ export default class HomeMELCloudDriverAtw extends HomeMELCloudDriver {
       ...this.#measureCapabilities,
       ...energyCapabilities(capabilities),
       ...this.#zone1ControlCapabilities,
-      ...(capabilities?.hasHotWater === true ?
-        [
-          ...this.#hotWaterMeasureCapabilities,
-          ...this.#hotWaterControlCapabilities,
-        ]
-      : []),
-      ...(capabilities?.hasZone2 === true ?
-        [...this.#zone2MeasureCapabilities, ...this.#zone2ControlCapabilities]
-      : []),
+      ...(capabilities?.hasHotWater === true
+        ? [
+            ...this.#hotWaterMeasureCapabilities,
+            ...this.#hotWaterControlCapabilities,
+          ]
+        : []),
+      ...(capabilities?.hasZone2 === true
+        ? [...this.#zone2MeasureCapabilities, ...this.#zone2ControlCapabilities]
+        : []),
     ]
   }
 }

--- a/drivers/home-report-atw.mts
+++ b/drivers/home-report-atw.mts
@@ -31,9 +31,9 @@ const latestBucketWatts = (
       latest = point
     }
   }
-  return latest === null ? 0 : (
-      latest.value * MINUTES_PER_HOUR * WATTS_PER_KILOWATT
-    )
+  return latest === null
+    ? 0
+    : latest.value * MINUTES_PER_HOUR * WATTS_PER_KILOWATT
 }
 
 export class HomeEnergyReportAtw extends HomeEnergyReport<

--- a/drivers/home-report.mts
+++ b/drivers/home-report.mts
@@ -158,8 +158,8 @@ export abstract class HomeEnergyReport<
     if (facade === null) {
       return null
     }
-    return this.mode === 'total' ?
-        this.#applyTotals(facade)
+    return this.mode === 'total'
+      ? this.#applyTotals(facade)
       : this.#applyRegular(facade)
   }
 
@@ -178,9 +178,9 @@ export abstract class HomeEnergyReport<
     const storedTotal = this.#storedNumber(totalKey(measure))
     const cursor = this.#storedCursor(cursorKey(measure))
     const accrued =
-      cursor !== null && Temporal.Instant.compare(cursor, upTo) < 0 ?
-        await this.#fetchAccrual(facade, { cursor, measure, upTo })
-      : 0
+      cursor !== null && Temporal.Instant.compare(cursor, upTo) < 0
+        ? await this.#fetchAccrual(facade, { cursor, measure, upTo })
+        : 0
     const total = storedTotal + accrued
     await this.#device.setStoreValue(totalKey(measure), total)
     await this.#device.setStoreValue(cursorKey(measure), upTo.toString())
@@ -196,9 +196,9 @@ export abstract class HomeEnergyReport<
     const dayStart = now.startOfDay().toInstant()
     const powerStart = nowInstant.subtract(POWER_WINDOW)
     const from =
-      Temporal.Instant.compare(dayStart, powerStart) <= 0 ?
-        dayStart
-      : powerStart
+      Temporal.Instant.compare(dayStart, powerStart) <= 0
+        ? dayStart
+        : powerStart
     const points = await this.#fetchMeasurePoints(facade, entries, {
       from,
       to: nowInstant,

--- a/drivers/melcloud_atw/device.mts
+++ b/drivers/melcloud_atw/device.mts
@@ -134,8 +134,8 @@ export default class ClassicMELCloudDeviceAtw extends ClassicMELCloudDevice<
     // number type).
     return (data) => {
       const value = data[tag]
-      return value !== 0 && Number.isFinite(value) ?
-          value
+      return value !== 0 && Number.isFinite(value)
+        ? value
         : this.getCapabilityOptions(capability).min
     }
   }

--- a/drivers/melcloud_atw/driver.mts
+++ b/drivers/melcloud_atw/driver.mts
@@ -64,12 +64,12 @@ export default class ClassicMELCloudDriverAtw extends ClassicMELCloudDriver<AtwT
     return [
       ...this.#zone1Capabilities,
       ...(canCool === true ? this.#zone1CoolCapabilities : []),
-      ...(hasClassicZone2 === true ?
-        [
-          ...this.#zone2Capabilities,
-          ...(canCool === true ? this.#zone2CoolCapabilities : []),
-        ]
-      : []),
+      ...(hasClassicZone2 === true
+        ? [
+            ...this.#zone2Capabilities,
+            ...(canCool === true ? this.#zone2CoolCapabilities : []),
+          ]
+        : []),
     ]
   }
 }

--- a/prettier.config.ts
+++ b/prettier.config.ts
@@ -1,7 +1,6 @@
 import type { Config } from 'prettier'
 
 const config: Config = {
-  experimentalTernaries: true,
   plugins: ['prettier-plugin-packagejson'],
   semi: false,
   singleQuote: true,

--- a/public/homey-api.mts
+++ b/public/homey-api.mts
@@ -80,9 +80,9 @@ export const surfaceError = (error: unknown): void => {
     return
   }
   setTimeout(() => {
-    throw error instanceof Error ? error : (
-        new Error('Unhandled widget error', { cause: error })
-      )
+    throw error instanceof Error
+      ? error
+      : new Error('Unhandled widget error', { cause: error })
   }, 0)
 }
 

--- a/settings/index.mts
+++ b/settings/index.mts
@@ -339,9 +339,9 @@ const createSettingsButton = (
   button.type = 'button'
   button.id = `${action}_settings_${sectionId}`
   button.classList.add(
-    action === 'apply' ?
-      'homey-button-danger-shadow'
-    : 'homey-button-secondary-shadow',
+    action === 'apply'
+      ? 'homey-button-danger-shadow'
+      : 'homey-button-secondary-shadow',
   )
   button.textContent = homey.__(
     action === 'apply' ? 'settings.update' : 'settings.refresh',
@@ -464,9 +464,9 @@ const getSubzones = (
 const serializeSettingElements = (elements: HTMLValueElement[]): string =>
   JSON.stringify(
     elements.map((element) =>
-      element instanceof HTMLInputElement && element.type === 'checkbox' ?
-        [element.checked, element.indeterminate]
-      : element.value,
+      element instanceof HTMLInputElement && element.type === 'checkbox'
+        ? [element.checked, element.indeterminate]
+        : element.value,
     ),
   )
 
@@ -769,9 +769,9 @@ class DeviceSettingsManager {
 
   async #applyDeviceSettings(body: Settings, driverId?: string): Promise<void> {
     const driverQuery =
-      driverId === undefined ? '' : (
-        `?${new URLSearchParams({ driverId } satisfies { driverId: string })}`
-      )
+      driverId === undefined
+        ? ''
+        : `?${new URLSearchParams({ driverId } satisfies { driverId: string })}`
     await homeyApiPut<unknown>(
       this.#homey,
       `/settings/devices${driverQuery}`,
@@ -992,9 +992,9 @@ class DeviceSettingsManager {
       return false
     }
     const settings =
-      driverId === undefined ?
-        this.flatDeviceSettings
-      : (this.#deviceSettings[driverId] ?? {})
+      driverId === undefined
+        ? this.flatDeviceSettings
+        : (this.#deviceSettings[driverId] ?? {})
     const setting = settings[id]
     return setting === null || value !== setting
   }
@@ -1057,13 +1057,11 @@ class DeviceSettingsManager {
     if (settingId !== undefined) {
       const value = this.flatDeviceSettings[settingId]
       element.value =
-        (
-          typeof value === 'boolean' ||
-          typeof value === 'number' ||
-          typeof value === 'string'
-        ) ?
-          String(value)
-        : ''
+        typeof value === 'boolean' ||
+        typeof value === 'number' ||
+        typeof value === 'string'
+          ? String(value)
+          : ''
     }
   }
 
@@ -1562,8 +1560,8 @@ class ZoneSettingsManager {
   }
 
   #gateFor(id: 'frost_protection' | 'holiday_mode'): DirtyGate {
-    return id === 'frost_protection' ?
-        this.#frostProtectionDirtyGate
+    return id === 'frost_protection'
+      ? this.#frostProtectionDirtyGate
       : this.#holidayModeDirtyGate
   }
 
@@ -1610,8 +1608,8 @@ class ZoneSettingsManager {
         this.#homey,
         url,
       )
-      return frostProtection === null ?
-          {}
+      return frostProtection === null
+        ? {}
         : {
             FPEnabled: frostProtection.enabled,
             FPMaxTemperature: frostProtection.max,
@@ -1622,8 +1620,8 @@ class ZoneSettingsManager {
       this.#homey,
       url,
     )
-    return holidayMode === null ?
-        {}
+    return holidayMode === null
+      ? {}
       : {
           HMEnabled: holidayMode.enabled,
           HMEndDate: holidayMode.endDate,
@@ -1636,8 +1634,8 @@ class ZoneSettingsManager {
     if (isHomeBuildingValue(value)) {
       return `/home/buildings/${getHomeBuildingId(value)}`
     }
-    return isHomeDeviceValue(value) ?
-        `/home/devices/${getHomeDeviceId(value)}`
+    return isHomeDeviceValue(value)
+      ? `/home/devices/${getHomeDeviceId(value)}`
       : `/classic/zones/${getZonePath(value)}`
   }
 
@@ -1674,9 +1672,9 @@ class ZoneSettingsManager {
     const isEnabled = this.#holidayModeEnabled.value === 'true'
     const { value: startDateValue } = this.#holidayModeStartDate
     const endDate =
-      this.#holidayModeEndDate.value === '' ?
-        undefined
-      : this.#holidayModeEndDate.value
+      this.#holidayModeEndDate.value === ''
+        ? undefined
+        : this.#holidayModeEndDate.value
     if (isEnabled && endDate === undefined) {
       fireAndForget(
         this.#homey.alert(
@@ -1908,9 +1906,9 @@ class SettingsApp {
           this.#disableForError(error)
         }
         await this.#homey.alert(
-          error instanceof NoDeviceError ?
-            error.message
-          : getErrorMessage(error),
+          error instanceof NoDeviceError
+            ? error.message
+            : getErrorMessage(error),
         )
       }
     } else {

--- a/tests/unit/api.test.ts
+++ b/tests/unit/api.test.ts
@@ -143,9 +143,9 @@ describe('api', () => {
       mockGetBuildingsByType.mockImplementation((type) => [
         {
           devices:
-            type === Home.DeviceType.Ata ?
-              [mock<Home.Device>({ id: 'uuid-1' })]
-            : [mock<Home.Device>({ id: 'uuid-2' })],
+            type === Home.DeviceType.Ata
+              ? [mock<Home.Device>({ id: 'uuid-1' })]
+              : [mock<Home.Device>({ id: 'uuid-2' })],
           id: 'home-building-1',
           name: 'Appartement',
         },
@@ -160,15 +160,15 @@ describe('api', () => {
     it('should serve Home groups from the registry without a wire call', () => {
       mockGetBuildings.mockReturnValue([])
       mockGetBuildingsByType.mockImplementation((type) =>
-        type === Home.DeviceType.Ata ?
-          [
-            {
-              devices: [mock<Home.Device>({ id: 'uuid-1' })],
-              id: 'home-building-1',
-              name: 'Appartement',
-            },
-          ]
-        : [],
+        type === Home.DeviceType.Ata
+          ? [
+              {
+                devices: [mock<Home.Device>({ id: 'uuid-1' })],
+                id: 'home-building-1',
+                name: 'Appartement',
+              },
+            ]
+          : [],
       )
 
       expect(api.getDeviceGroups({ homey })).toStrictEqual([

--- a/tests/unit/app.test.ts
+++ b/tests/unit/app.test.ts
@@ -448,9 +448,9 @@ const setupWidgetListeners = (): {
   const mockRegisterCharts =
     vi.fn<(id: string, listener: (query: string) => unknown) => void>()
   mockGetWidget.mockImplementation((widgetId: string) =>
-    widgetId === 'ata-group-setting' ?
-      { registerSettingAutocompleteListener: mockRegisterAta }
-    : { registerSettingAutocompleteListener: mockRegisterCharts },
+    widgetId === 'ata-group-setting'
+      ? { registerSettingAutocompleteListener: mockRegisterAta }
+      : { registerSettingAutocompleteListener: mockRegisterCharts },
   )
   return { mockRegisterAta, mockRegisterCharts }
 }

--- a/tests/unit/home-melcloud-atw-device.test.ts
+++ b/tests/unit/home-melcloud-atw-device.test.ts
@@ -121,17 +121,17 @@ const defineEnergyContext = (
     cachedFacade: {
       configurable: true,
       get: () =>
-        flags === undefined ? undefined : (
-          {
-            capabilities: {
-              hasEstimatedEnergyConsumption: false,
-              hasEstimatedEnergyProduction: false,
-              hasMeasuredEnergyConsumption: false,
-              hasMeasuredEnergyProduction: false,
-              ...flags,
+        flags === undefined
+          ? undefined
+          : {
+              capabilities: {
+                hasEstimatedEnergyConsumption: false,
+                hasEstimatedEnergyProduction: false,
+                hasMeasuredEnergyConsumption: false,
+                hasMeasuredEnergyProduction: false,
+                ...flags,
+              },
             },
-          }
-        ),
     },
     driver: {
       configurable: true,

--- a/tests/unit/home-melcloud-device.test.ts
+++ b/tests/unit/home-melcloud-device.test.ts
@@ -46,9 +46,9 @@ const defineEnergyContext = (
     cachedFacade: {
       configurable: true,
       get: () =>
-        hasEnergyConsumedMeter === undefined ? undefined : (
-          { capabilities: { hasEnergyConsumedMeter } }
-        ),
+        hasEnergyConsumedMeter === undefined
+          ? undefined
+          : { capabilities: { hasEnergyConsumedMeter } },
     },
     driver: {
       configurable: true,

--- a/types/atw.mts
+++ b/types/atw.mts
@@ -114,9 +114,9 @@ const thermostatModeValuesAtw = [
 export const getThermostatModeValuesAtw = (
   canCool: boolean,
 ): CapabilitiesOptionsValues<keyof typeof Classic.OperationModeZone>[] =>
-  canCool ?
-    thermostatModeValuesAtw
-  : thermostatModeValuesAtw.filter(({ id }) => !id.endsWith(COOL_SUFFIX))
+  canCool
+    ? thermostatModeValuesAtw
+    : thermostatModeValuesAtw.filter(({ id }) => !id.endsWith(COOL_SUFFIX))
 
 export const thermostatModeZone2TitleAtw: LocalizedStrings = addSuffixToTitle(
   thermostatMode.title,

--- a/types/bases.mts
+++ b/types/bases.mts
@@ -9,15 +9,15 @@ export const localizeWithAffix = (
     Object.entries(affix).map(([language, localizedAffix]) => [
       language,
       /* v8 ignore next 2 -- both arms run (atw suffix, ata-erv prefix callers) but v8 misattributes the `??` sub-branches inside this map-callback ternary; the identical bare ternary below records both arms covered */
-      position === 'prefix' ?
-        `${localizedAffix ?? affix.en} ${(base[language] ?? base.en).toLowerCase()}`
-      : `${base[language] ?? base.en} ${localizedAffix ?? affix.en}`,
+      position === 'prefix'
+        ? `${localizedAffix ?? affix.en} ${(base[language] ?? base.en).toLowerCase()}`
+        : `${base[language] ?? base.en} ${localizedAffix ?? affix.en}`,
     ]),
   ),
   en:
-    position === 'prefix' ?
-      `${affix.en} ${base.en.toLowerCase()}`
-    : `${base.en} ${affix.en}`,
+    position === 'prefix'
+      ? `${affix.en} ${base.en.toLowerCase()}`
+      : `${base.en} ${affix.en}`,
 })
 
 export interface BaseGetCapabilities {

--- a/types/capabilities.mts
+++ b/types/capabilities.mts
@@ -6,26 +6,36 @@ import type * as classicAtw from './classic-atw.mts'
 import type * as classicErv from './classic-erv.mts'
 
 type GetCapabilities<T extends Classic.DeviceType> =
-  T extends typeof Classic.DeviceType.Ata ? classicAta.GetCapabilities
-  : T extends typeof Classic.DeviceType.Atw ? classicAtw.GetCapabilities
-  : T extends typeof Classic.DeviceType.Erv ? classicErv.GetCapabilities
-  : never
+  T extends typeof Classic.DeviceType.Ata
+    ? classicAta.GetCapabilities
+    : T extends typeof Classic.DeviceType.Atw
+      ? classicAtw.GetCapabilities
+      : T extends typeof Classic.DeviceType.Erv
+        ? classicErv.GetCapabilities
+        : never
 
 type ListCapabilities<T extends Classic.DeviceType> =
-  T extends typeof Classic.DeviceType.Ata ? classicAta.ListCapabilities
-  : T extends typeof Classic.DeviceType.Atw ? classicAtw.ListCapabilities
-  : T extends typeof Classic.DeviceType.Erv ? classicErv.ListCapabilities
-  : never
+  T extends typeof Classic.DeviceType.Ata
+    ? classicAta.ListCapabilities
+    : T extends typeof Classic.DeviceType.Atw
+      ? classicAtw.ListCapabilities
+      : T extends typeof Classic.DeviceType.Erv
+        ? classicErv.ListCapabilities
+        : never
 
 export type Capabilities<T extends Classic.DeviceType> =
-  T extends typeof Classic.DeviceType.Ata ? classicAta.Capabilities
-  : T extends typeof Classic.DeviceType.Atw ? classicAtw.Capabilities
-  : T extends typeof Classic.DeviceType.Erv ? classicErv.Capabilities
-  : never
+  T extends typeof Classic.DeviceType.Ata
+    ? classicAta.Capabilities
+    : T extends typeof Classic.DeviceType.Atw
+      ? classicAtw.Capabilities
+      : T extends typeof Classic.DeviceType.Erv
+        ? classicErv.Capabilities
+        : never
 
 export type CapabilitiesOptions<T extends Classic.DeviceType> =
-  T extends typeof Classic.DeviceType.Atw ? classicAtw.CapabilitiesOptions
-  : CapabilitiesOptionsAtaErv
+  T extends typeof Classic.DeviceType.Atw
+    ? classicAtw.CapabilitiesOptions
+    : CapabilitiesOptionsAtaErv
 
 export interface CapabilitiesOptionsAtaErv {
   readonly fan_speed: RangeOptions
@@ -61,10 +71,13 @@ export type ConvertToDevice<T extends Classic.DeviceType> = {
 }['bivariant']
 
 export type EnergyCapabilities<T extends Classic.DeviceType> =
-  T extends typeof Classic.DeviceType.Ata ? classicAta.EnergyCapabilities
-  : T extends typeof Classic.DeviceType.Atw ? classicAtw.EnergyCapabilities
-  : T extends typeof Classic.DeviceType.Erv ? classicErv.EnergyCapabilities
-  : Record<string, never>
+  T extends typeof Classic.DeviceType.Ata
+    ? classicAta.EnergyCapabilities
+    : T extends typeof Classic.DeviceType.Atw
+      ? classicAtw.EnergyCapabilities
+      : T extends typeof Classic.DeviceType.Erv
+        ? classicErv.EnergyCapabilities
+        : Record<string, never>
 
 export type EnergyCapabilityTagEntry<T extends Classic.DeviceType> = [
   capability: string & keyof EnergyCapabilities<T>,
@@ -95,10 +108,13 @@ export type OperationalCapabilityTagEntry<T extends Classic.DeviceType> = [
 ]
 
 export type SetCapabilities<T extends Classic.DeviceType> =
-  T extends typeof Classic.DeviceType.Ata ? classicAta.SetCapabilities
-  : T extends typeof Classic.DeviceType.Atw ? classicAtw.SetCapabilities
-  : T extends typeof Classic.DeviceType.Erv ? classicErv.SetCapabilities
-  : never
+  T extends typeof Classic.DeviceType.Ata
+    ? classicAta.SetCapabilities
+    : T extends typeof Classic.DeviceType.Atw
+      ? classicAtw.SetCapabilities
+      : T extends typeof Classic.DeviceType.Erv
+        ? classicErv.SetCapabilities
+        : never
 
 export type SetCapabilityTagMapping<T extends Classic.DeviceType> = Record<
   keyof SetCapabilities<T>,

--- a/types/home.mts
+++ b/types/home.mts
@@ -16,19 +16,25 @@ import type {
 } from './home-atw.mts'
 
 type HomeCapabilities<T extends Home.DeviceType> =
-  T extends typeof Home.DeviceType.Ata ? HomeCapabilitiesAta
-  : T extends typeof Home.DeviceType.Atw ? HomeCapabilitiesAtw
-  : never
+  T extends typeof Home.DeviceType.Ata
+    ? HomeCapabilitiesAta
+    : T extends typeof Home.DeviceType.Atw
+      ? HomeCapabilitiesAtw
+      : never
 
 type HomeSetCapabilities<T extends Home.DeviceType> =
-  T extends typeof Home.DeviceType.Ata ? HomeSetCapabilitiesAta
-  : T extends typeof Home.DeviceType.Atw ? HomeSetCapabilitiesAtw
-  : never
+  T extends typeof Home.DeviceType.Ata
+    ? HomeSetCapabilitiesAta
+    : T extends typeof Home.DeviceType.Atw
+      ? HomeSetCapabilitiesAtw
+      : never
 
 type HomeValues<T extends Home.DeviceType> =
-  T extends typeof Home.DeviceType.Ata ? Home.AtaValues
-  : T extends typeof Home.DeviceType.Atw ? Home.AtwValues
-  : never
+  T extends typeof Home.DeviceType.Ata
+    ? Home.AtaValues
+    : T extends typeof Home.DeviceType.Atw
+      ? Home.AtwValues
+      : never
 
 /**
  * Converter from a Home device facade to the corresponding Homey capability
@@ -61,9 +67,11 @@ export interface HomeDeviceDetails {
 }
 
 export type HomeDeviceFacade<T extends Home.DeviceType> =
-  T extends typeof Home.DeviceType.Ata ? Home.DeviceAtaFacade
-  : T extends typeof Home.DeviceType.Atw ? Home.DeviceAtwFacade
-  : never
+  T extends typeof Home.DeviceType.Ata
+    ? Home.DeviceAtaFacade
+    : T extends typeof Home.DeviceType.Atw
+      ? Home.DeviceAtwFacade
+      : never
 
 export type HomeMELCloudDevice = HomeMELCloudDeviceAta | HomeMELCloudDeviceAtw
 

--- a/widgets/ata-group-setting/public/animation.mts
+++ b/widgets/ata-group-setting/public/animation.mts
@@ -151,9 +151,9 @@ const parseStateParams = (
     isSomethingOn: isOn !== false,
     newMode: Number(mode ?? null),
     newSpeed:
-      numberSpeed === 0 || Number.isNaN(numberSpeed) ?
-        ClassicFanSpeed.moderate
-      : numberSpeed,
+      numberSpeed === 0 || Number.isNaN(numberSpeed)
+        ? ClassicFanSpeed.moderate
+        : numberSpeed,
   }
 }
 
@@ -560,9 +560,9 @@ export class AnimationController {
     if (elementName !== undefined) {
       const previousElement = getPreviousElement(elementName, index)
       const previousPosition =
-        previousElement === null ?
-          -gap * 2
-        : parsePixelValue(previousElement.style[positionProperty])
+        previousElement === null
+          ? -gap * 2
+          : parsePixelValue(previousElement.style[positionProperty])
       element.style[positionProperty] = generateStyleString(
         {
           gap,

--- a/widgets/ata-group-setting/public/ata-values.mts
+++ b/widgets/ata-group-setting/public/ata-values.mts
@@ -110,12 +110,10 @@ const createSelect = (
 const coolModeNumbers: ReadonlySet<number> = classicCoolModes
 
 const getCoolingAdjustedMin = (id: string, min: string): string =>
-  (
-    id === 'SetTemperature' &&
-    coolModeNumbers.has(Number(getSelect('OperationMode').value))
-  ) ?
-    String(ClassicTemperature.cooling_min)
-  : min
+  id === 'SetTemperature' &&
+  coolModeNumbers.has(Number(getSelect('OperationMode').value))
+    ? String(ClassicTemperature.cooling_min)
+    : min
 
 const clampNumericInput = ({
   id,
@@ -166,8 +164,8 @@ const getAtaStatePath = (value: string): string => {
   if (model === 'homeBuildings') {
     return `/home/buildings/${encodeURIComponent(id)}/ata`
   }
-  return model === 'homeDevices' ?
-      `/home/devices/${encodeURIComponent(id)}/ata`
+  return model === 'homeDevices'
+    ? `/home/devices/${encodeURIComponent(id)}/ata`
     : `/classic/zones/${model}/${id}/ata`
 }
 

--- a/widgets/charts/public/index.mts
+++ b/widgets/charts/public/index.mts
@@ -748,14 +748,12 @@ const fetchChartData = async (
   homey: Homey,
   { chart, days, zoneValue }: ChartSelection,
 ): Promise<ReportChartLineOptions | ReportChartPieOptions> => {
-  const daysQuery =
-    chartsWithDays.has(chart) ?
-      `?${new URLSearchParams({ days: String(days) } satisfies DaysQuery)}`
+  const daysQuery = chartsWithDays.has(chart)
+    ? `?${new URLSearchParams({ days: String(days) } satisfies DaysQuery)}`
     : ''
   const isHome = zoneValue.startsWith(HOME_DEVICES_PATH_PREFIX)
-  const path =
-    isHome ?
-      `home/devices/${zoneValue.slice(HOME_DEVICES_PATH_PREFIX.length)}`
+  const path = isHome
+    ? `home/devices/${zoneValue.slice(HOME_DEVICES_PATH_PREFIX.length)}`
     : `classic/${zoneValue}`
   return homeyApiGet<ReportChartLineOptions | ReportChartPieOptions>(
     homey,
@@ -993,9 +991,9 @@ class ChartWidget {
     type?: Classic.DeviceType | Home.DeviceType,
   ): Promise<T[]> {
     const typeQuery =
-      type === undefined ? '' : (
-        `?${new URLSearchParams({ type: String(type) })}`
-      )
+      type === undefined
+        ? ''
+        : `?${new URLSearchParams({ type: String(type) })}`
     return homeyApiGet<T[]>(this.#homey, `/${vendor}/devices${typeQuery}`)
   }
 


### PR DESCRIPTION
Removes `experimentalTernaries: true` from `prettier.config.ts` and reformats (26 files, the `?` moves from line end to line start).

**Why**: the option exists for ternary *chains*, which the lint doctrine (complexity/statement caps) keeps out of this codebase — the whole 5-repo family counts **2 chain links for 129 multiline ternaries**. Never promoted to a Prettier default in ~3 years, unsupported by every alternative formatter (oxfmt, Biome), its only remaining effect was formatter lock-in. Formatting-only; no behavior change. Sibling PRs on the 4 other repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)