### PR TITLE
docs: prune comments to the doctrine (intent and constraint only)

### DIFF
--- a/app.mts
+++ b/app.mts
@@ -136,9 +136,8 @@ const toDurationDays = (duration: unknown): number => {
 
 // Flow-action arguments shared by the holiday-mode cards: `zone` always,
 // `duration`/`time` only on the cards that declare them. The zone carries
-// its `${model}_${id}` option value as `id` — the shape every stored card
-// arg has always had — so run listeners route by parsing it (legacy Flows
-// included) and never need the structured coordinates threaded back.
+// its `${model}_${id}` option value as `id` — the shape stored card args
+// in existing Flows carry — so run listeners route by parsing it.
 interface HolidayModeActionArgs {
   zone: FlatZoneItem
   duration?: unknown
@@ -272,8 +271,8 @@ interface FlatZoneItem {
 }
 
 // A node from either zone source: a Classic zone (carrying its building
-// name since melcloud-api 43.1.0) or a Home building/device (same shape).
-// The single vocabulary every picker draws from.
+// name) or a Home building/device (same shape). The single vocabulary
+// every picker draws from.
 type PickerNode = Classic.FlatZone | HomeBuildingZone | HomeDeviceZone
 
 // A flat picker lists every node at one level, so a leaf's bare name can
@@ -290,8 +289,7 @@ const toFlatName = ({ buildingName, model, name }: PickerNode): string => {
 }
 
 // Flat autocomplete items over the given nodes, name-sorted. The selected
-// item's `id` carries the `${model}_${id}` routing — run listeners parse it,
-// needing no structured coordinates.
+// item's `id` carries the `${model}_${id}` routing value run listeners parse.
 const toFlatZoneItems = (nodes: readonly PickerNode[]): FlatZoneItem[] =>
   nodes
     .map((node) => ({
@@ -393,7 +391,6 @@ const formatErrorEntries = (
   entries: readonly RawErrorEntry[],
   { locale, timeZone }: { locale: string; timeZone: string },
 ): FormattedErrorDetails[] => {
-  // Reused across all entries instead of rebuilding a formatter per call.
   const dateTimeMedFormat = new Intl.DateTimeFormat(locale, {
     day: 'numeric',
     hour: 'numeric',
@@ -663,9 +660,9 @@ export default class MELCloudApp extends App {
   }
 
   // The Classic zone source: every zone (buildings, floors, areas, devices)
-  // flattened, each stamped with its owning building name (melcloud-api
-  // 43.1.0), optionally narrowed to one device type. Every flat Classic
-  // picker draws from here with the filters it needs.
+  // flattened, each stamped with its owning building name, optionally
+  // narrowed to one device type. Every flat Classic picker draws from
+  // here with the filters it needs.
   public getClassicTargets(type?: Classic.DeviceType): Classic.FlatZone[] {
     return this.#facadeManager.getZones(type === undefined ? {} : { type })
   }
@@ -1134,8 +1131,6 @@ export default class MELCloudApp extends App {
     })
   }
 
-  // Sync matching classic devices by pulling their latest state from MELCloud.
-  // Per-device sync failures are logged without aborting the full sync run.
   // Deferred half of the loss notification: the readiness await
   // orders the device check after driver init — a backed-off resume
   // reports the loss during `App#onInit`, when `getDrivers()` is
@@ -1546,10 +1541,7 @@ export default class MELCloudApp extends App {
   // alert API and no webview is open when a sync loses the session).
   // The library fires once per loss episode, so no dedup is needed
   // here; the deferral mirrors #createNotification (off the event
-  // callstack, best-effort). Residual credentials on an API without any
-  // paired device (say, a Classic-only user who once tried Home) only
-  // get a log line: the timeline nag is reserved for a loss that stops
-  // device updates. The episode is recorded synchronously so a
+  // callstack, best-effort). The episode is recorded synchronously so a
   // recovery event can never outrun it.
   #notifySessionLost(api: Api): void {
     this.#sessionLossStates.set(api, 'pending')

--- a/drivers/classic-report.mts
+++ b/drivers/classic-report.mts
@@ -69,7 +69,6 @@ export class EnergyReport<
     if (device === null) {
       return null
     }
-    // Fetch energy data from the previous period (offset by config.minus)
     const toDateTime = this.reportDateTime()
     const to = toDateTime.toPlainDate().toString()
     // Total mode reports from the epoch: omitting `from` lets the API
@@ -86,7 +85,6 @@ export class EnergyReport<
   }
 
   // COP (Coefficient of Performance) = produced energy / consumed energy.
-  // Falls back to divisor of 1 to avoid division by zero when no energy consumed
   #calculateCopValue(
     data: Classic.EnergyData<T>,
     capability: string & keyof EnergyCapabilities<T>,
@@ -105,8 +103,7 @@ export class EnergyReport<
     return sumTags(data, tags) / this.#linkedDeviceCount
   }
 
-  // Power values are stored as 24-element arrays (one per hour).
-  // Multiply by KILOWATT_TO_WATT to convert from kW to W
+  // Power values are stored as 24-element kW arrays (one per hour).
   #calculatePowerValue(
     data: Classic.EnergyData<T>,
     tags: readonly (keyof Classic.EnergyData<T>)[],

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -54,7 +54,7 @@ const config = defineConfig([
     ignores: [
       '.homeybuild/',
       'coverage/',
-      // esbuild outputs (see scripts/bundle.mjs), also gitignored
+      // Stale pre-`.homeybuild` esbuild outputs, also gitignored
       'settings/index.mjs',
       'widgets/*/public/index.mjs',
     ],
@@ -185,7 +185,6 @@ const config = defineConfig([
           types: ['boolean'],
         },
         // ── Parameters ───────────────────────────────────────
-        // Unused parameters must wear the underscore.
         {
           format: ['camelCase'],
           leadingUnderscore: 'require',
@@ -430,8 +429,8 @@ const config = defineConfig([
         'error',
         {
           bundledDependencies: false,
-          // Widget and settings sources are bundled by esbuild, so their
-          // imports may live in devDependencies.
+          // Widget sources are bundled by esbuild, so their imports may
+          // live in devDependencies.
           devDependencies: ['*.config.ts', 'tests/**', 'widgets/**'],
           optionalDependencies: false,
           peerDependencies: false,

--- a/scripts/bundle.mjs
+++ b/scripts/bundle.mjs
@@ -60,10 +60,7 @@ await Promise.all(
   }),
 )
 
-// Courtesy cleanup: builds predating the `.homeybuild` emission left
-// bundles in the source tree. The CLI would copy them into the package,
-// where this build immediately overwrites them — harmless, but they
-// linger confusingly in the working tree.
+// Remove stale source-tree bundles left by pre-`.homeybuild` builds.
 await Promise.all(
   entryPoints.flatMap((entryPoint) =>
     ['.js', '.mjs'].map(async (extension) =>

--- a/settings/index.mts
+++ b/settings/index.mts
@@ -543,7 +543,7 @@ class AuthManager {
   }
 
   // Folded when the credentials are settled, expanded while attention
-  // is needed — same rule the section's visibility used to follow.
+  // is needed.
   public collapseAuthenticationSection(isCollapsed: boolean): void {
     this.#authenticationSection.open = !isCollapsed
   }
@@ -1693,9 +1693,6 @@ class ZoneSettingsManager {
     }
   }
 
-  // The selected target's settings base URL: a Home device routes to the
-  // Home device endpoints; every Classic zone/device keeps the classic zone
-  // path (`getZonePath` splits `${model}_${id}` at the first underscore).
   // A blank enabled select means a Home building's devices disagree
   // ("mixed") and the user has not chosen: applying would silently write a
   // single value (off) to them all, so require an explicit choice first.
@@ -1770,15 +1767,13 @@ class SettingsApp {
   }
 
   // `ready()` always fires — an unbounded await here would hold Homey's
-  // loading overlay open forever on a single hung or failed call. The
-  // failure alert waits until after `ready()`: an alert raised while the
-  // overlay is still up never gets seen.
+  // loading overlay open forever on a single hung or failed call.
   public async init(): Promise<void> {
     const { error, hasFailed } = await runWebview(this.#homey, this.#run())
     if (hasFailed) {
       // After `ready` (runWebview's finally): an alert raised under the
-      // overlay is never seen, and fire-and-forget keeps this non-throwing
-      // so a rejected alert cannot trip the HTML loader's catch.
+      // overlay is never seen, and fire-and-forget keeps a rejected alert
+      // from bubbling out of `start()` as an unhandled rejection.
       fireAndForget(this.#homey.alert(getErrorMessage(error)))
     }
   }
@@ -1838,8 +1833,7 @@ class SettingsApp {
     fireAndForget(this.#zoneSettingsManager.fetchZoneSettings())
   }
 
-  // The Home account has no zone tree: each device is a standalone
-  // selectable target, appended after any Classic zones.
+  // Home targets are appended after any Classic zones.
   async #fetchHomeTargets(): Promise<void> {
     // A tree: each Home building followed by its own devices (indented),
     // both frost/holiday targets.
@@ -1894,9 +1888,7 @@ class SettingsApp {
   /** @alerts Displays post-login errors to the user. */
   async #onLogin(api: Api): Promise<void> {
     // Reflect the server truth instead of assuming success: the login
-    // POST resolves even when the post-login device sync fails, and a
-    // hardcoded `true` here hid the credentials frame for the session
-    // only to bring it back on the next page open.
+    // POST resolves even when the post-login device sync fails.
     this.#authState[api] = await this.#fetchSessionState(api)
     if (this.#authState[api]) {
       try {

--- a/tests/mock-device-class.ts
+++ b/tests/mock-device-class.ts
@@ -1,6 +1,5 @@
 import { vi } from 'vitest'
 
-// Options for createMockDeviceClass.
 // - `overrides`: instance-level props assigned in the constructor (shallow merge).
 // - `superMocks`: prototype-level async methods that delegate to the provided vi.fn.
 //   Required when BaseMELCloudDevice calls super.X() (e.g. addCapability,

--- a/tests/unit/classic-device.test.ts
+++ b/tests/unit/classic-device.test.ts
@@ -729,7 +729,6 @@ describe(ClassicMELCloudDevice, () => {
       })
       setDriver(deviceWithRegular)
       await deviceWithRegular.onInit()
-      // The detached chain settles within one macrotask turn.
       await settleDetached()
 
       expect(deviceWithRegular.error).toHaveBeenCalledWith(

--- a/types/classic-atw.mts
+++ b/types/classic-atw.mts
@@ -1,8 +1,6 @@
 // The derived-state LABELS are shared across both dialects; the Home-named
 // union carries the canonical capability ids.
 import type { HomeAtwOperationalState } from '@olivierzal/melcloud-api'
-// The derived-state LABELS are shared across both dialects; the Home-named
-// union carries the canonical capability ids.
 import * as Classic from '@olivierzal/melcloud-api/classic'
 
 import type {

--- a/widgets/ata-group-setting/public/animation.mts
+++ b/widgets/ata-group-setting/public/animation.mts
@@ -125,9 +125,9 @@ const areAnimationsEnabled = (homey: Homey<HomeySettings>): boolean =>
 const prefersReducedMotion = (): boolean =>
   matchMedia('(prefers-reduced-motion: reduce)').matches
 
-// Calculates a randomized delay with exponential speed scaling. Higher speed
-// values produce shorter delays via exponential interpolation between
-// factorMin and factorMax
+// Randomized delay with exponential speed scaling: higher speeds yield
+// shorter delays via exponential interpolation between SPEED_FACTOR_MIN
+// and SPEED_FACTOR_MAX.
 const generateDelay = (delay: number, speed: number): number => {
   const speedFactor =
     SPEED_FACTOR_MIN *
@@ -157,11 +157,9 @@ const parseStateParams = (
   }
 }
 
-// Converts a CSS pixel length (e.g. `12.5px`) into its numeric value.
-// Non-numeric values such as `auto` yield NaN. Unlike Number.parseFloat,
-// an empty string coerces to 0 — no call site can produce one, since the
-// inline positions are written before being read and getComputedStyle
-// returns resolved values
+// Non-numeric values such as `auto` yield NaN; an empty string would
+// coerce to 0, but no call site can produce one (inline positions are
+// written before being read; getComputedStyle returns resolved values).
 const parsePixelValue = (value: string): number =>
   Number(value.replace('px', ''))
 

--- a/widgets/charts/public/index.mts
+++ b/widgets/charts/public/index.mts
@@ -130,7 +130,6 @@ const hourlyCharts = new Set<HomeySettings['chart']>([
   'signal',
 ])
 
-// D3/Tableau-inspired color palette for chart series
 const colors = [
   '#1F77B4',
   '#D62728',


### PR DESCRIPTION
Family-wide comment pass (adversarially reviewed proposal by proposal): drops reviewer narration, debate relics, version/library provenance and restatements of adjacent code; trims verbose blocks to their load-bearing constraint; fixes (partially) obsolete comments. On-device evidence, config triage-ledger reasons and lint-required JSDoc untouched. **No code changes** — 10 files changed, 26 insertions(+), 56 deletions(-). Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)