### PR TITLE
refactor: harmonize the app-API surface (shared transport, /devices/groups)

### DIFF
--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -22,6 +22,10 @@
     },
     "getDeviceGroups": {
       "method": "GET",
+      "path": "/devices/groups"
+    },
+    "getDeviceGroupsLegacy": {
+      "method": "GET",
       "path": "/device_groups"
     },
     "getDeviceSettings": {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,18 @@ coverage.
   `homey-button-*` classes; `settings/index.css` only fills documented SDK
   gaps (date inputs, checkbox `:indeterminate`, `fieldset[hidden]`
   specificity) and app-specific design.
+- App-API surface conventions: paths are kebab-case REST (`get*` for
+  GET, `update*` for PUT — never `set*`); handler renames are
+  wire-invisible (routing is method+path), path renames are NOT (phone
+  webviews cache bundles across versions — keep the old path as an
+  alias). `GET /device_groups` (`getDeviceGroupsLegacy`) is the FROZEN
+  inter-app contract the extension's older releases call during version
+  skew — never remove or rename it; `/devices/groups` is the current
+  form. `settings/callback-api.mts` is the settings pages' transport
+  (the settings SDK is error-first-callback, unlike the widget SDK —
+  which is why `public/homey-api.mts` stays a separate, promise-native
+  widget layer); byte-identical copies live in com.heatzy and
+  com.melcloud.extension — edit all three together.
 - Dirty-gating: `public/dirty-gate.mts` is the ONE primitive behind every
   webview Apply/Refresh pair (settings sections, frost/holiday panels, the
   ATA group widget) — never re-derive its invariant at a call site. Its

--- a/api.mts
+++ b/api.mts
@@ -155,6 +155,17 @@ const api = {
       .filter(({ deviceIds }) => deviceIds.length > 0)
       .toSorted((group1, group2) => group1.name.localeCompare(group2.name))
   },
+  /**
+   * Serves `/device_groups`, the FROZEN inter-app path: extension
+   * installs in the wild call it during version skew (its current
+   * releases probe `/devices/groups` first, older ones only know this
+   * one) — never remove or rename it.
+   * @param context - Homey API context.
+   * @param context.homey - Homey instance carrying the app.
+   * @returns One entry per non-empty building, sorted by name.
+   */
+  getDeviceGroupsLegacy: (context: { homey: Homey }): DeviceGroup[] =>
+    api.getDeviceGroups(context),
   getDeviceSettings: ({ homey: { app } }: { homey: Homey }): DeviceSettings => {
     logSettingsRoute(app, '/settings/devices')
     return app.getDeviceSettings()

--- a/app.json
+++ b/app.json
@@ -23,6 +23,10 @@
     },
     "getDeviceGroups": {
       "method": "GET",
+      "path": "/devices/groups"
+    },
+    "getDeviceGroupsLegacy": {
+      "method": "GET",
       "path": "/device_groups"
     },
     "getDeviceSettings": {

--- a/settings/callback-api.mts
+++ b/settings/callback-api.mts
@@ -1,0 +1,58 @@
+import type Homey from 'homey/lib/HomeySettings'
+
+// The settings SDK's `homey.api`/`homey.confirm` are error-first
+// callbacks (unlike the widget SDK's promise-returning `homey.api`), so
+// the settings pages share one promisification primitive and per-verb
+// wrappers over it. Byte-identical copies of this module live in the
+// sibling Homey apps — edit them together.
+export const homeyCallback = async <T,>(
+  call: (callback: (error: Error | null, result: T) => void) => void,
+): Promise<T> =>
+  new Promise((resolve, reject) => {
+    call((error, result) => {
+      if (error !== null) {
+        reject(error)
+        return
+      }
+      resolve(result)
+    })
+  })
+
+export const homeyApiDelete = async (
+  homey: Homey,
+  path: string,
+): Promise<void> =>
+  homeyCallback((callback) => {
+    homey.api('DELETE', path, callback)
+  })
+
+export const homeyApiGet = async <T,>(homey: Homey, path: string): Promise<T> =>
+  homeyCallback((callback) => {
+    homey.api('GET', path, callback)
+  })
+
+export const homeyApiPost = async <T,>(
+  homey: Homey,
+  path: string,
+  body: unknown,
+): Promise<T> =>
+  homeyCallback((callback) => {
+    homey.api('POST', path, body, callback)
+  })
+
+export const homeyApiPut = async <T,>(
+  homey: Homey,
+  path: string,
+  body: unknown,
+): Promise<T> =>
+  homeyCallback((callback) => {
+    homey.api('PUT', path, body, callback)
+  })
+
+export const homeyConfirm = async (
+  homey: Homey,
+  message: string,
+): Promise<boolean> =>
+  homeyCallback((callback) => {
+    homey.confirm(message, null, callback)
+  })

--- a/settings/index.mts
+++ b/settings/index.mts
@@ -49,56 +49,16 @@ import {
   isHomeBuildingValue,
   isHomeDeviceValue,
 } from '../public/zones.mts'
+import {
+  homeyApiDelete,
+  homeyApiGet,
+  homeyApiPost,
+  homeyApiPut,
+  homeyCallback,
+  homeyConfirm,
+} from './callback-api.mts'
 
 // ── Helpers ──
-
-// Promisifies any error-first Homey settings callback (the extension's
-// idiom, aligned here so the two apps share one promisification form).
-const homeyCallback = async <T,>(
-  call: (callback: (error: Error | null, result: T) => void) => void,
-): Promise<T> =>
-  new Promise((resolve, reject) => {
-    call((error, result) => {
-      if (error !== null) {
-        reject(error)
-        return
-      }
-      resolve(result)
-    })
-  })
-
-const homeyApiGet = async <T,>(homey: Homey, path: string): Promise<T> =>
-  homeyCallback((callback) => {
-    homey.api('GET', path, callback)
-  })
-
-const homeyApiPost = async <T,>(
-  homey: Homey,
-  path: string,
-  body: unknown,
-): Promise<T> =>
-  homeyCallback((callback) => {
-    homey.api('POST', path, body, callback)
-  })
-
-const homeyApiPut = async <T,>(
-  homey: Homey,
-  path: string,
-  body: unknown,
-): Promise<T> =>
-  homeyCallback((callback) => {
-    homey.api('PUT', path, body, callback)
-  })
-
-const homeyApiDelete = async (homey: Homey, path: string): Promise<void> =>
-  homeyCallback((callback) => {
-    homey.api('DELETE', path, callback)
-  })
-
-const homeyConfirm = async (homey: Homey, message: string): Promise<boolean> =>
-  homeyCallback((callback) => {
-    homey.confirm(message, null, callback)
-  })
 
 interface CheckboxGroup {
   readonly label: string

--- a/tests/unit/api.test.ts
+++ b/tests/unit/api.test.ts
@@ -183,6 +183,25 @@ describe('api', () => {
 
       expect(api.getDeviceGroups({ homey })).toStrictEqual([])
     })
+
+    it('should serve the frozen legacy path with the same payload', () => {
+      mockGetBuildings.mockReturnValue([])
+      mockGetBuildingsByType.mockImplementation((type) =>
+        type === Home.DeviceType.Ata
+          ? [
+              {
+                devices: [mock<Home.Device>({ id: 'uuid-1' })],
+                id: 'home-building-1',
+                name: 'Appartement',
+              },
+            ]
+          : [],
+      )
+
+      expect(api.getDeviceGroupsLegacy({ homey })).toStrictEqual(
+        api.getDeviceGroups({ homey }),
+      )
+    })
   })
 
   describe('device settings retrieval', () => {


### PR DESCRIPTION
Part of the family-wide API-surface harmonization (sibling PRs on com.heatzy and com.melcloud.extension).

- **`settings/callback-api.mts`** — the settings page's error-first-callback transport extracted as a byte-identical tri-repo module (the widget layer `public/homey-api.mts` stays separate by design: the widget SDK is promise-native).
- **`GET /devices/groups`** — the inter-app grouping route moves to kebab-case REST (the extension's own shape for the same concept); **`/device_groups` stays as `getDeviceGroupsLegacy`**, the FROZEN inter-app contract older extension releases call during version skew — documented never-remove in CLAUDE.md and in the handler's JSDoc. The extension probes new-then-legacy (sibling PR), so no release coordination is strictly required.
- Alias covered by a dedicated test.

Full suite green (733 tests). The only wire change is additive (new route + kept alias).

🤖 Generated with [Claude Code](https://claude.com/claude-code)