### PR TITLE
feat: class every non-ERV device as a thermostat

### DIFF
--- a/.homeycompose/drivers/templates/defaults.json
+++ b/.homeycompose/drivers/templates/defaults.json
@@ -745,7 +745,7 @@
       }
     }
   },
-  "class": "heatpump",
+  "class": "thermostat",
   "icon": "{{driverAssetsPath}}/icon.svg",
   "images": {
     "large": "{{driverAssetsPath}}/images/large.png",

--- a/app.json
+++ b/app.json
@@ -4184,7 +4184,7 @@
           ]
         }
       },
-      "class": "heatpump",
+      "class": "thermostat",
       "icon": "/drivers/home-melcloud/assets/icon.svg",
       "images": {
         "large": "/drivers/home-melcloud/assets/images/large.png",
@@ -5144,7 +5144,7 @@
           "min": 10
         }
       },
-      "class": "heatpump",
+      "class": "thermostat",
       "icon": "/drivers/home-melcloud_atw/assets/icon.svg",
       "images": {
         "large": "/drivers/home-melcloud_atw/assets/images/large.png",
@@ -6535,7 +6535,7 @@
           ]
         }
       },
-      "class": "heatpump",
+      "class": "thermostat",
       "icon": "/drivers/melcloud/assets/icon.svg",
       "images": {
         "large": "/drivers/melcloud/assets/images/large.png",
@@ -8772,7 +8772,7 @@
           }
         }
       },
-      "class": "heatpump",
+      "class": "thermostat",
       "icon": "/drivers/melcloud_atw/assets/icon.svg",
       "images": {
         "large": "/drivers/melcloud_atw/assets/images/large.png",

--- a/drivers/base-device.mts
+++ b/drivers/base-device.mts
@@ -96,6 +96,7 @@ export abstract class BaseMELCloudDevice<
   } = { get: {}, list: {}, set: {} }
 
   public override async onInit(): Promise<void> {
+    await this.#migrateDeviceClass()
     await this.setWarning(null)
     this.#registerCapabilityListeners()
     await this.ensureDevice()
@@ -339,6 +340,19 @@ export abstract class BaseMELCloudDevice<
 
   #isThermostatModeSupportingOff(): boolean {
     return this.thermostatMode !== null && 'off' in this.thermostatMode
+  }
+
+  // Devices paired before the class change keep their stored class
+  // forever, so migrate them once. Guarded by the manifest class: an
+  // airtreatment driver (ERV) must never be flipped, whatever its
+  // stored class says.
+  async #migrateDeviceClass(): Promise<void> {
+    if (
+      this.getClass() === 'heatpump' &&
+      this.driver.manifest.class === 'thermostat'
+    ) {
+      await this.setClass('thermostat')
+    }
   }
 
   async #pushUpdate(

--- a/tests/mock-device-class.ts
+++ b/tests/mock-device-class.ts
@@ -33,6 +33,8 @@ export const createMockDeviceClass = (
 
     public getCapabilityValue = vi.fn<(capability: string) => unknown>()
 
+    public getClass = vi.fn<() => string>().mockReturnValue('thermostat')
+
     public getData = vi
       .fn<() => { id: number | string }>()
       .mockReturnValue({ id: 1 })
@@ -82,6 +84,8 @@ export const createMockDeviceClass = (
 
     public setCapabilityValue =
       vi.fn<(capability: string, value: unknown) => Promise<void>>()
+
+    public setClass = vi.fn<(deviceClass: string) => Promise<void>>()
 
     public setSettings =
       vi.fn<(settings: Record<string, unknown>) => Promise<void>>()

--- a/tests/unit/app.test.ts
+++ b/tests/unit/app.test.ts
@@ -216,6 +216,7 @@ const mockManifestDrivers: ManifestDriver[] = [
         ],
       },
     },
+    class: 'thermostat',
     id: 'melcloud',
     name: { en: 'melcloud' },
     settings: [
@@ -234,6 +235,7 @@ const mockManifestDrivers: ManifestDriver[] = [
   },
   {
     capabilities: [],
+    class: 'thermostat',
     id: 'melcloud-login',
     name: { en: 'melcloud-login' },
     pair: [
@@ -250,6 +252,7 @@ const mockManifestDrivers: ManifestDriver[] = [
   },
   {
     capabilities: [],
+    class: 'thermostat',
     id: 'melcloud-odd',
     name: { en: 'melcloud-odd' },
     settings: [
@@ -3185,6 +3188,7 @@ describe('melCloudApp', () => {
       const driversWithLogin: ManifestDriver[] = [
         {
           capabilities: [],
+          class: 'thermostat',
           id: 'melcloud',
           name: { en: 'melcloud' },
           pair: Object.assign(
@@ -3569,6 +3573,7 @@ describe('melCloudApp', () => {
       const driversWithValues: ManifestDriver[] = [
         {
           capabilities: [],
+          class: 'thermostat',
           id: 'melcloud',
           name: { en: 'melcloud' },
           settings: [

--- a/tests/unit/classic-device.test.ts
+++ b/tests/unit/classic-device.test.ts
@@ -31,16 +31,19 @@ import {
 } from './classic-device-test-device.ts'
 
 const {
+  getClassMock,
   getFacadeMock,
   getSettingMock,
   realtimeMock,
   registerMultipleCapabilityListenerMock,
+  setClassMock,
   setValuesMock,
   superAddCapabilityMock,
   superRemoveCapabilityMock,
   superSetWarningMock,
   triggerCapabilityListenerMock,
 } = vi.hoisted(() => ({
+  getClassMock: vi.fn<() => string>(),
   getFacadeMock: vi.fn<(kind: string, id: number) => unknown>(),
   getSettingMock: vi.fn<(key: string) => unknown>(),
   realtimeMock: vi.fn<(event: string, data: unknown) => void>(),
@@ -52,6 +55,7 @@ const {
         delay?: number,
       ) => void
     >(),
+  setClassMock: vi.fn<(deviceClass: string) => Promise<void>>(),
   setValuesMock: vi.fn<(data: Record<string, unknown>) => Promise<unknown>>(),
   superAddCapabilityMock: vi.fn<(...args: readonly unknown[]) => unknown>(),
   superRemoveCapabilityMock: vi.fn<(...args: readonly unknown[]) => unknown>(),
@@ -96,6 +100,7 @@ vi.mock(import('homey'), async () => {
     default: {
       Device: createMockDeviceClass({
         overrides: {
+          getClass: getClassMock,
           getSetting: getSettingMock,
           homey: {
             __: vi
@@ -114,6 +119,7 @@ vi.mock(import('homey'), async () => {
           },
           registerMultipleCapabilityListener:
             registerMultipleCapabilityListenerMock,
+          setClass: setClassMock,
           triggerCapabilityListener: triggerCapabilityListenerMock,
         },
         superMocks: {
@@ -176,6 +182,7 @@ describe(ClassicMELCloudDevice, () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    getClassMock.mockReturnValue('thermostat')
     mockFacade()
     device = new TestDevice()
     setDriver(device)
@@ -198,6 +205,25 @@ describe(ClassicMELCloudDevice, () => {
         expect.any(Number),
       )
       expect(getFacadeMock).toHaveBeenCalledWith('devices', 1)
+    })
+
+    it('should migrate a stored heatpump class to the thermostat manifest class', async () => {
+      const driverWithClass = Object.create(mockDriver) as typeof mockDriver
+      Object.assign(driverWithClass, {
+        manifest: mock({ class: 'thermostat' }),
+      })
+      setDriver(device, driverWithClass)
+      getClassMock.mockReturnValue('heatpump')
+
+      await device.onInit()
+
+      expect(setClassMock).toHaveBeenCalledWith('thermostat')
+    })
+
+    it('should leave a non-heatpump stored class untouched', async () => {
+      await device.onInit()
+
+      expect(setClassMock).not.toHaveBeenCalled()
     })
   })
 

--- a/types/manifest.mts
+++ b/types/manifest.mts
@@ -44,6 +44,7 @@ export interface Manifest {
 
 export interface ManifestDriver {
   readonly capabilities: readonly string[]
+  readonly class: string
   readonly id: string
   readonly name: LocalizedStrings
   readonly capabilitiesOptions?: Record<


### PR DESCRIPTION
Per request: all devices except ERV are now classed **`thermostat`** instead of `heatpump`.

- **`.homeycompose/drivers/templates/defaults.json`** — `class: heatpump → thermostat`; inherited by the 4 AC/heat-pump drivers (`melcloud`, `melcloud_atw`, `home-melcloud`, `home-melcloud_atw`). `melcloud_erv` keeps its `airtreatment` override.
- **Migration** (`drivers/base-device.mts` onInit): a device paired before the change keeps its stored class forever, so `getClass() === 'heatpump'` migrates once via `setClass('thermostat')` — **guarded by the driver manifest class**, so an airtreatment driver can never be flipped whatever its stored class says.
- `ManifestDriver` gains the (always-present) `class` field; mock device class + fixtures updated; migration covered both ways (migrates / leaves untouched).

Full suite green (733 tests, 100 % branches held). Ships with the next release (coordinated separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)