### PR TITLE
style: hoist the type keyword on all-type exports, enforced by rule

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -514,6 +514,18 @@ const config = defineConfig([
       'no-object-constructor': 'error',
       'no-param-reassign': 'error',
       'no-promise-executor-return': 'error',
+      // `consistent-type-exports` tolerates inline specifiers on all-type
+      // exports; no shipped rule hoists them, so the constraint is spelled
+      // out here (imports get the same via `consistent-type-imports`).
+      'no-restricted-syntax': [
+        'error',
+        {
+          message:
+            'An all-type export hoists the keyword: `export type { … }`.',
+          selector:
+            "ExportNamedDeclaration[exportKind='value']:has(ExportSpecifier[exportKind='type']):not(:has(ExportSpecifier[exportKind='value']))",
+        },
+      ],
       'no-return-assign': ['error', 'always'],
       'no-self-compare': 'error',
       'no-sequences': [


### PR DESCRIPTION
Propagates the melcloud-api `no-restricted-syntax` selector that requires all-type exports to hoist the keyword (`export type { … }`): `consistent-type-exports` tolerates inline specifiers once present and `import-x` only covers imports, so the constraint is spelled out as a selector; mixed exports keep inline specifiers. The codebase already complies — no source changes were needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)