### PR TITLE
style: drop the bespoke export-type lint rule for documented doctrine

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -281,6 +281,14 @@ coverage.
   narrowing across `await`: a re-check of externally-mutated state (e.g.
   `signal.aborted`) reads as "always false" — route through an API that
   reads the live value instead (`signal.throwIfAborted()`).
+- All-type exports hoist the keyword (`export type { A, B }`); mixed
+  exports keep inline `type` specifiers, mirroring the inline-type-imports
+  style. No shipped rule enforces the export side
+  (`consistent-type-exports` tolerates inline specifiers once present;
+  `import-x/consistent-type-specifier-style` covers imports only): the
+  convention is maintained by hand, in review — a bespoke
+  `no-restricted-syntax` selector for it was removed by decision
+  (2026-07-28).
 
 ## Repo process
 

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -514,18 +514,6 @@ const config = defineConfig([
       'no-object-constructor': 'error',
       'no-param-reassign': 'error',
       'no-promise-executor-return': 'error',
-      // `consistent-type-exports` tolerates inline specifiers on all-type
-      // exports; no shipped rule hoists them, so the constraint is spelled
-      // out here (imports get the same via `consistent-type-imports`).
-      'no-restricted-syntax': [
-        'error',
-        {
-          message:
-            'An all-type export hoists the keyword: `export type { … }`.',
-          selector:
-            "ExportNamedDeclaration[exportKind='value']:has(ExportSpecifier[exportKind='type']):not(:has(ExportSpecifier[exportKind='value']))",
-        },
-      ],
       'no-return-assign': ['error', 'always'],
       'no-self-compare': 'error',
       'no-sequences': [


### PR DESCRIPTION
Replaces the `no-restricted-syntax` selector merged earlier today with documented doctrine in CLAUDE.md: all-type exports hoist the keyword (`export type { A, B }`), mixed exports keep inline `type` specifiers, and the convention is maintained by hand in review since no shipped rule enforces the export side. The codebase already complies (no all-type inline exports found) and the full suite is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)