### PR TITLE
feat!: adopt the melcloud-api cross-dialect contracts (45.0.0)

### DIFF
--- a/api.mts
+++ b/api.mts
@@ -1,12 +1,15 @@
 import type * as Classic from '@olivierzal/melcloud-api/classic'
+import type * as Home from '@olivierzal/melcloud-api/home'
 import type { Homey } from 'homey/lib/Homey'
 import {
+  type HolidayModeState,
   type HolidayModeUpdate,
   type LoginCredentials,
+  type ProtectionState,
+  type ProtectionUpdate,
   AuthenticationError,
   AuthenticationThrottledError,
 } from '@olivierzal/melcloud-api'
-import * as Home from '@olivierzal/melcloud-api/home'
 
 import type { DeviceSettings, Settings } from './types/device-settings.mts'
 import type { DriverSetting } from './types/driver-settings.mts'
@@ -64,23 +67,13 @@ const collectClassicDeviceIds = (
     ]),
   ].map(({ id }) => String(id))
 
-// Home buildings can own units of both types; the per-type registry views
-// are merged by building id so a mixed building yields a single group.
-const collectHomeGroups = (registry: Home.Registry): DeviceGroup[] => {
-  const groups = new Map<string, DeviceGroup>()
-  for (const type of Object.values(Home.DeviceType)) {
-    for (const { devices, id, name } of registry.getBuildingsByType(type)) {
-      groups.set(id, {
-        deviceIds: [
-          ...(groups.get(id)?.deviceIds ?? []),
-          ...devices.map((device) => device.id),
-        ],
-        name,
-      })
-    }
-  }
-  return groups.values().toArray()
-}
+// A Home building can own units of both connection types; the registry
+// merges them per building, so one pass covers a mixed building.
+const collectHomeGroups = (registry: Home.Registry): DeviceGroup[] =>
+  registry.getBuildings().map(({ devices, name }) => ({
+    deviceIds: devices.map((device) => device.id),
+    name,
+  }))
 
 // Diagnostics breadcrumb: the settings webview is otherwise invisible in
 // diagnostic reports (its routes never touch MELCloud), which made
@@ -126,7 +119,7 @@ const api = {
   }: {
     homey: Homey
     params: DeviceOrZoneData
-  }): Promise<Classic.FrostProtectionData> =>
+  }): Promise<ProtectionState | null> =>
     app.getClassicFrostProtection(toDeviceOrZoneData(params)),
   getClassicHolidayMode: async ({
     homey: { app },
@@ -134,7 +127,7 @@ const api = {
   }: {
     homey: Homey
     params: DeviceOrZoneData
-  }): Promise<Classic.HolidayModeData> =>
+  }): Promise<HolidayModeState | null> =>
     app.getClassicHolidayMode(toDeviceOrZoneData(params)),
   /**
    * Lists the MELCloud buildings of both dialects with the device ids
@@ -190,9 +183,9 @@ const api = {
     homey: Homey
     params: { buildingId: string }
   }): {
-    FPEnabled: boolean | null
-    FPMaxTemperature: number | null
-    FPMinTemperature: number | null
+    isEnabled: boolean | null
+    max: number | null
+    min: number | null
   } => app.getHomeBuildingFrostProtection(buildingId),
   getHomeBuildingHolidayMode: ({
     homey: { app },
@@ -201,9 +194,9 @@ const api = {
     homey: Homey
     params: { buildingId: string }
   }): {
-    HMEnabled: boolean | null
-    HMEndDate: string | null
-    HMStartDate: string | null
+    endDate: string | null
+    isEnabled: boolean | null
+    startDate: string | null
   } => app.getHomeBuildingHolidayMode(buildingId),
   getHomeBuildingOverheatProtection: ({
     homey: { app },
@@ -212,9 +205,9 @@ const api = {
     homey: Homey
     params: { buildingId: string }
   }): {
-    OHEnabled: boolean | null
-    OHMaxTemperature: number | null
-    OHMinTemperature: number | null
+    isEnabled: boolean | null
+    max: number | null
+    min: number | null
   } => app.getHomeBuildingOverheatProtection(buildingId),
   getHomeDevices: ({ homey: { app } }: { homey: Homey }): HomeDeviceZone[] =>
     app.getHomeDeviceZones(),
@@ -224,21 +217,21 @@ const api = {
   }: {
     homey: Homey
     params: { deviceId: string }
-  }): Home.FrostProtection | null => app.getHomeFrostProtection(deviceId),
+  }): ProtectionState | null => app.getHomeFrostProtection(deviceId),
   getHomeHolidayMode: ({
     homey: { app },
     params: { deviceId },
   }: {
     homey: Homey
     params: { deviceId: string }
-  }): Home.HolidayMode | null => app.getHomeHolidayMode(deviceId),
+  }): HolidayModeState | null => app.getHomeHolidayMode(deviceId),
   getHomeOverheatProtection: ({
     homey: { app },
     params: { deviceId },
   }: {
     homey: Homey
     params: { deviceId: string }
-  }): Home.OverheatProtection | null => app.getHomeOverheatProtection(deviceId),
+  }): ProtectionState | null => app.getHomeOverheatProtection(deviceId),
   getHomeTargets: ({
     homey: { app },
   }: {
@@ -267,22 +260,13 @@ const api = {
     logSettingsRoute(app, '/classic/sessions')
     return app.classicApi.isAuthenticated()
   },
-  // Home authentication is only "restored" once a /context fetch has
-  // succeeded. That boot-time fetch can fail transiently (e.g. the box
-  // network is not ready right after an app restart) even though the
-  // stored tokens are valid, which made the settings page show the Home
-  // login form at open. Retry the context fetch lazily here so the check
-  // self-heals; `list()` swallows its own failures.
-  async isHomeAuthenticated({
+  isHomeAuthenticated: async ({
     homey: { app },
   }: {
     homey: Homey
-  }): Promise<boolean> {
+  }): Promise<boolean> => {
     logSettingsRoute(app, '/home/sessions')
-    if (!app.homeApi.isAuthenticated()) {
-      await app.homeApi.list()
-    }
-    return app.homeApi.isAuthenticated()
+    return app.homeApi.ensureAuthenticated()
   },
   logWebviewBoot: ({
     body,
@@ -298,7 +282,7 @@ const api = {
     homey: { app },
     params,
   }: {
-    body: Classic.FrostProtectionQuery
+    body: ProtectionUpdate
     homey: Homey
     params: DeviceOrZoneData
   }): Promise<void> =>

--- a/app.mts
+++ b/app.mts
@@ -2,14 +2,18 @@ import 'source-map-support/register.js'
 
 import {
   type DeviceType,
+  type HolidayModeState,
   type HolidayModeUpdate,
   type Hour,
   type Logger,
+  type ProtectionState,
+  type ProtectionUpdate,
   type ReportChartLineOptions,
   type ReportChartPieOptions,
   type SettingManager,
   type SyncCallback,
   isClassicAtaFacade,
+  isHomeAtaFacade,
   NoChangesError,
   operationModeToClassic,
 } from '@olivierzal/melcloud-api'
@@ -142,19 +146,6 @@ interface HolidayModeActionArgs {
   zone: FlatZoneItem
   duration?: unknown
   time?: unknown
-}
-
-const formatErrors = (errors: Record<string, readonly string[]>): string =>
-  Object.entries(errors)
-    .map(([error, messages]) => `${error}: ${messages.join(', ')}`)
-    .join('\n')
-
-const throwOnErrors = (
-  errors: Record<string, readonly string[]> | null,
-): void => {
-  if (errors !== null) {
-    throw new Error(formatErrors(errors))
-  }
 }
 
 // Aggregates one device's settings into the per-driver map; a conflicting
@@ -603,7 +594,7 @@ export default class MELCloudApp extends App {
   public async getClassicFrostProtection({
     zoneId,
     zoneType,
-  }: DeviceOrZoneData): Promise<Classic.FrostProtectionData> {
+  }: DeviceOrZoneData): Promise<ProtectionState | null> {
     return unwrapResult(
       await this.getClassicFacade(zoneType, zoneId).getFrostProtection(),
     )
@@ -612,7 +603,7 @@ export default class MELCloudApp extends App {
   public async getClassicHolidayMode({
     zoneId,
     zoneType,
-  }: DeviceOrZoneData): Promise<Classic.HolidayModeData> {
+  }: DeviceOrZoneData): Promise<HolidayModeState | null> {
     return unwrapResult(
       await this.getClassicFacade(zoneType, zoneId).getHolidayMode(),
     )
@@ -784,9 +775,9 @@ export default class MELCloudApp extends App {
   // Aggregate frost protection across a Home building's devices: each field
   // is the shared value, or `null` when the devices disagree ("mixed").
   public getHomeBuildingFrostProtection(buildingId: string): {
-    FPEnabled: boolean | null
-    FPMaxTemperature: number | null
-    FPMinTemperature: number | null
+    isEnabled: boolean | null
+    max: number | null
+    min: number | null
   } {
     const frostProtections = this.#getHomeBuildingDeviceIds(buildingId).map(
       (deviceId) => this.getHomeFrostProtection(deviceId),
@@ -794,15 +785,15 @@ export default class MELCloudApp extends App {
     return {
       // A device with no frost config counts as off, so an all-unconfigured
       // building reads "No" rather than "mixed".
-      FPEnabled: commonValue(
+      isEnabled: commonValue(
         frostProtections.map(
-          (frostProtection) => frostProtection?.enabled ?? false,
+          (frostProtection) => frostProtection?.isEnabled ?? false,
         ),
       ),
-      FPMaxTemperature: commonValue(
+      max: commonValue(
         frostProtections.map((frostProtection) => frostProtection?.max),
       ),
-      FPMinTemperature: commonValue(
+      min: commonValue(
         frostProtections.map((frostProtection) => frostProtection?.min),
       ),
     }
@@ -811,21 +802,21 @@ export default class MELCloudApp extends App {
   // Aggregate holiday mode across a Home building's devices, `null` per
   // field on disagreement ("mixed").
   public getHomeBuildingHolidayMode(buildingId: string): {
-    HMEnabled: boolean | null
-    HMEndDate: string | null
-    HMStartDate: string | null
+    endDate: string | null
+    isEnabled: boolean | null
+    startDate: string | null
   } {
     const holidayModes = this.#getHomeBuildingDeviceIds(buildingId).map(
       (deviceId) => this.getHomeHolidayMode(deviceId),
     )
     return {
-      HMEnabled: commonValue(
-        holidayModes.map((holidayMode) => holidayMode?.enabled ?? false),
-      ),
-      HMEndDate: commonValue(
+      endDate: commonValue(
         holidayModes.map((holidayMode) => holidayMode?.endDate),
       ),
-      HMStartDate: commonValue(
+      isEnabled: commonValue(
+        holidayModes.map((holidayMode) => holidayMode?.isEnabled ?? false),
+      ),
+      startDate: commonValue(
         holidayModes.map((holidayMode) => holidayMode?.startDate),
       ),
     }
@@ -834,9 +825,9 @@ export default class MELCloudApp extends App {
   // Aggregate overheat protection across a Home building's ATA devices
   // (the feature is ATA-only), `null` per field on disagreement ("mixed").
   public getHomeBuildingOverheatProtection(buildingId: string): {
-    OHEnabled: boolean | null
-    OHMaxTemperature: number | null
-    OHMinTemperature: number | null
+    isEnabled: boolean | null
+    max: number | null
+    min: number | null
   } {
     const overheatProtections = this.#getHomeBuildingAtaDeviceIds(
       buildingId,
@@ -844,17 +835,17 @@ export default class MELCloudApp extends App {
     return {
       // A device with no overheat config counts as off, so an
       // all-unconfigured building reads "No" rather than "mixed".
-      OHEnabled: commonValue(
+      isEnabled: commonValue(
         overheatProtections.map(
-          (overheatProtection) => overheatProtection?.enabled ?? false,
+          (overheatProtection) => overheatProtection?.isEnabled ?? false,
         ),
       ),
-      OHMaxTemperature: commonValue(
+      max: commonValue(
         overheatProtections.map(
           (overheatProtection) => overheatProtection?.max,
         ),
       ),
-      OHMinTemperature: commonValue(
+      min: commonValue(
         overheatProtections.map(
           (overheatProtection) => overheatProtection?.min,
         ),
@@ -863,7 +854,7 @@ export default class MELCloudApp extends App {
   }
 
   public getHomeDevicesByType(type: Home.DeviceType): Home.Device[] {
-    return this.#homeRegistry.getByType(type)
+    return this.#homeRegistry.getDevicesByType(type)
   }
 
   // The charts widget vocabulary: Home devices as flat selectable entries
@@ -909,11 +900,11 @@ export default class MELCloudApp extends App {
     throw new NotFoundError(this.homey.__('errors.deviceNotFound'))
   }
 
-  public getHomeFrostProtection(deviceId: string): Home.FrostProtection | null {
+  public getHomeFrostProtection(deviceId: string): ProtectionState | null {
     return this.#getHomeDeviceFacade(deviceId).frostProtection
   }
 
-  public getHomeHolidayMode(deviceId: string): Home.HolidayMode | null {
+  public getHomeHolidayMode(deviceId: string): HolidayModeState | null {
     return this.#getHomeDeviceFacade(deviceId).holidayMode
   }
 
@@ -947,13 +938,11 @@ export default class MELCloudApp extends App {
     )
   }
 
-  public getHomeOverheatProtection(
-    deviceId: string,
-  ): Home.OverheatProtection | null {
+  public getHomeOverheatProtection(deviceId: string): ProtectionState | null {
     const facade = this.#getHomeDeviceFacade(deviceId)
     // ATA-only: the wire carries the field on ATW too, but the official
     // app never offers the feature there — only the ATA facade exposes it.
-    return 'overheatProtection' in facade ? facade.overheatProtection : null
+    return isHomeAtaFacade(facade) ? facade.overheatProtection : null
   }
 
   public async getHomeSignal({
@@ -969,57 +958,14 @@ export default class MELCloudApp extends App {
   }
 
   // The Home target tree for a selector: each `/context` building (level 0)
-  // followed by its own devices (level 1), both alpha-sorted, so a whole
-  // building or a single device can be addressed. `type` narrows to one
-  // connection type (the ATA group widget); omitted spans both ATA and ATW
-  // (the settings selector) — the `getHomeDeviceZones` pattern applied to
-  // this tree-shaped surface.
+  // The flattened Home picker list — name-sorted buildings (level 0) each
+  // followed by its own devices (level 1); `type` narrows to one
+  // connection type (the ATA group widget), omitted spans both (the
+  // settings selector). The tree itself now comes from the library.
   public getHomeTargets(
     type?: Home.DeviceType,
   ): (HomeBuildingZone | HomeDeviceZone)[] {
-    const devices =
-      type === undefined
-        ? this.#homeRegistry.getAll()
-        : this.#homeRegistry.getByType(type)
-    const buildings = new Map<
-      string,
-      { devices: HomeDeviceZone[]; name: string }
-    >()
-    for (const device of devices) {
-      const building = buildings.get(device.building.id) ?? {
-        devices: [],
-        name: device.building.name,
-      }
-      building.devices.push({
-        buildingName: device.building.name,
-        deviceType: device.isAta() ? 'ata' : 'atw',
-        id: device.id,
-        level: 1,
-        model: 'homeDevices',
-        name: device.name,
-      })
-      buildings.set(device.building.id, building)
-    }
-    return buildings
-      .entries()
-      .map(
-        ([id, { devices: buildingDevices, name }]): HomeBuildingZone & {
-          devices: HomeDeviceZone[]
-        } => ({
-          buildingName: name,
-          devices: buildingDevices,
-          id,
-          level: 0,
-          model: 'homeBuildings',
-          name,
-        }),
-      )
-      .toArray()
-      .toSorted(byName)
-      .flatMap(({ devices: buildingDevices, ...building }) => [
-        building,
-        ...buildingDevices.toSorted(byName),
-      ])
+    return this.#homeFacadeManager.getZones({ type })
   }
 
   public async getHomeTemperatures({
@@ -1040,25 +986,19 @@ export default class MELCloudApp extends App {
     zoneId,
     zoneType,
   }: DeviceOrZoneData & { state: Classic.GroupState }): Promise<void> {
-    const { AttributeErrors } = await this.#getClassicAtaGroupFacade({
-      zoneId,
-      zoneType,
-    }).updateGroupState(state)
-    throwOnErrors(AttributeErrors)
+    await this.#getClassicAtaGroupFacade({ zoneId, zoneType }).updateGroupState(
+      state,
+    )
   }
 
   public async updateClassicFrostProtection({
     settings,
     zoneId,
     zoneType,
-  }: DeviceOrZoneData & {
-    settings: Classic.FrostProtectionQuery
-  }): Promise<void> {
-    const { AttributeErrors } = await this.getClassicFacade(
-      zoneType,
-      zoneId,
-    ).updateFrostProtection(settings)
-    throwOnErrors(AttributeErrors)
+  }: DeviceOrZoneData & { settings: ProtectionUpdate }): Promise<void> {
+    await this.getClassicFacade(zoneType, zoneId).updateFrostProtection(
+      settings,
+    )
   }
 
   public async updateClassicHolidayMode({
@@ -1068,11 +1008,7 @@ export default class MELCloudApp extends App {
   }: DeviceOrZoneData & {
     settings: HolidayModeUpdate
   }): Promise<void> {
-    const { AttributeErrors } = await this.getClassicFacade(
-      zoneType,
-      zoneId,
-    ).updateHolidayMode(settings)
-    throwOnErrors(AttributeErrors)
+    await this.getClassicFacade(zoneType, zoneId).updateHolidayMode(settings)
   }
 
   public async updateDeviceSettings({
@@ -1390,14 +1326,14 @@ export default class MELCloudApp extends App {
   // The ids of every device (ATA and ATW) in a `/context` building.
   #getHomeBuildingAtaDeviceIds(buildingId: string): string[] {
     return this.#homeRegistry
-      .getAll()
+      .getDevices()
       .filter((device) => device.building.id === buildingId && device.isAta())
       .map((device) => device.id)
   }
 
   #getHomeBuildingDeviceIds(buildingId: string): string[] {
     return this.#homeRegistry
-      .getAll()
+      .getDevices()
       .filter((device) => device.building.id === buildingId)
       .map((device) => device.id)
   }
@@ -1536,10 +1472,7 @@ export default class MELCloudApp extends App {
       settingManager: this.#createSettingManager(),
       shouldResumeSessionInBackground: true,
     })
-    this.#facadeManager = new Classic.FacadeManager(
-      this.#classicApi,
-      this.#classicRegistry,
-    )
+    this.#facadeManager = new Classic.FacadeManager(this.#classicApi)
     setClassicFacadeManager(this.#facadeManager)
   }
 
@@ -1582,18 +1515,16 @@ export default class MELCloudApp extends App {
   // zone/device — routed by parsing the option value.
   async #isHolidayModeEnabled(value: string): Promise<boolean> {
     if (isHomeDeviceValue(value)) {
-      return this.getHomeHolidayMode(getHomeDeviceId(value))?.enabled === true
+      return this.getHomeHolidayMode(getHomeDeviceId(value))?.isEnabled === true
     }
     if (isHomeBuildingValue(value)) {
       return (
-        this.getHomeBuildingHolidayMode(getHomeBuildingId(value)).HMEnabled ===
+        this.getHomeBuildingHolidayMode(getHomeBuildingId(value)).isEnabled ===
         true
       )
     }
-    const { HMEnabled: isEnabled } = await this.getClassicHolidayMode(
-      toZoneValueData(value),
-    )
-    return isEnabled
+    const holidayMode = await this.getClassicHolidayMode(toZoneValueData(value))
+    return holidayMode?.isEnabled === true
   }
 
   async #logBootReady(): Promise<void> {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "45.11.0",
       "license": "GPL-3.0-only",
       "dependencies": {
-        "@olivierzal/melcloud-api": "44.1.0",
+        "@olivierzal/melcloud-api": "45.0.0",
         "source-map-support": "^0.5.21",
         "temporal-polyfill": "^1.0.1"
       },
@@ -1065,9 +1065,9 @@
       }
     },
     "node_modules/@olivierzal/melcloud-api": {
-      "version": "44.1.0",
-      "resolved": "https://npm.pkg.github.com/download/@olivierzal/melcloud-api/44.1.0/3841dd48983d2edba554083ddc8fb39718164747",
-      "integrity": "sha512-Q9/ipc8Aa5iWlDkHpuVTR39Feb0cygs168kQFFoCVcPBwDq4CJbf9R2FxJh4a57dART1hYs1UhGP9p2ZwUN1Rg==",
+      "version": "45.0.0",
+      "resolved": "https://npm.pkg.github.com/download/@olivierzal/melcloud-api/45.0.0/9d2307d0098ff7d518f88c2096c0d4f6bff5b6c6",
+      "integrity": "sha512-9oJ3UHP77Y369KOVe6x9hJ6EutIfEgVmWC40wzMq/xJJf234Zt25daZXsLpb9wF965aH/cLOpMheX3p7WKC5aw==",
       "license": "MIT",
       "dependencies": {
         "temporal-polyfill": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "typecheck": "node ./node_modules/@typescript/native/bin/tsc --noEmit"
   },
   "dependencies": {
-    "@olivierzal/melcloud-api": "44.1.0",
+    "@olivierzal/melcloud-api": "45.0.0",
     "source-map-support": "^0.5.21",
     "temporal-polyfill": "^1.0.1"
   },

--- a/settings/index.mts
+++ b/settings/index.mts
@@ -1,6 +1,7 @@
 import type {
   HolidayModeUpdate,
   LoginCredentials,
+  ProtectionUpdate,
 } from '@olivierzal/melcloud-api'
 import type * as Classic from '@olivierzal/melcloud-api/classic'
 import type * as Home from '@olivierzal/melcloud-api/home'
@@ -1477,7 +1478,7 @@ class ZoneSettingsManager {
     isEnabled,
     max,
     min,
-  }: Classic.FrostProtectionQuery): Promise<void> {
+  }: ProtectionUpdate): Promise<void> {
     await this.#putZoneSetting(
       {
         id: 'frost_protection',
@@ -1486,12 +1487,8 @@ class ZoneSettingsManager {
           this.displayFrostProtectionData()
         },
       },
-      { isEnabled, max, min } satisfies Classic.FrostProtectionQuery,
-      {
-        FPMaxTemperature: max,
-        FPMinTemperature: min,
-        ...(isEnabled !== undefined && { FPEnabled: isEnabled }),
-      },
+      { isEnabled, max, min } satisfies ProtectionUpdate,
+      { FPEnabled: isEnabled, FPMaxTemperature: max, FPMinTemperature: min },
     )
   }
 
@@ -1794,7 +1791,7 @@ class ZoneSettingsManager {
   // the panel, alert success or failure.
   async #putZoneSetting(
     { display, id, path }: ZoneSettingDescriptor,
-    query: Classic.FrostProtectionQuery | HolidayModeUpdate,
+    query: HolidayModeUpdate | ProtectionUpdate,
     zoneSettings: MixableZoneSettings,
   ): Promise<void> {
     await this.#gateFor(id).runBusy(async () => {

--- a/tests/unit/api.test.ts
+++ b/tests/unit/api.test.ts
@@ -1,13 +1,14 @@
 import type * as Classic from '@olivierzal/melcloud-api/classic'
+import type * as Home from '@olivierzal/melcloud-api/home'
 import type { Homey } from 'homey/lib/Homey'
 import {
   type HolidayModeUpdate,
   type LoginCredentials,
+  type ProtectionUpdate,
   AuthenticationError,
   AuthenticationThrottledError,
 } from '@olivierzal/melcloud-api'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import * as Home from '@olivierzal/melcloud-api/home'
 
 import type { DeviceSettings, Settings } from '../../types/device-settings.mts'
 import type { DriverSetting } from '../../types/driver-settings.mts'
@@ -37,8 +38,8 @@ const { default: api } = await import('../../api.mts')
 
 const mockIsAuthenticated = vi.fn<() => boolean>()
 const mockIsHomeAuthenticated = vi.fn<() => boolean>()
-const mockHomeList = vi.fn<() => Promise<unknown[]>>()
-const mockGetBuildingsByType = vi.fn<Home.Registry['getBuildingsByType']>()
+const mockEnsureHomeAuthenticated = vi.fn<() => Promise<boolean>>()
+const mockGetHomeBuildings = vi.fn<Home.Registry['getBuildings']>()
 const mockClassicAuthenticate = vi.fn<() => Promise<void>>()
 const mockHomeAuthenticate = vi.fn<() => Promise<void>>()
 const mockClassicLogOut = vi.fn<() => void>()
@@ -85,10 +86,10 @@ const mockApp = {
   getHomeTargets: vi.fn<() => (HomeBuildingZone | HomeDeviceZone)[]>(),
   homeApi: {
     authenticate: mockHomeAuthenticate,
+    ensureAuthenticated: mockEnsureHomeAuthenticated,
     isAuthenticated: mockIsHomeAuthenticated,
-    list: mockHomeList,
     logOut: mockHomeLogOut,
-    registry: { getBuildingsByType: mockGetBuildingsByType },
+    registry: { getBuildings: mockGetHomeBuildings },
   },
   log: vi.fn<(...args: readonly unknown[]) => void>(),
   updateClassicFrostProtection: vi.fn<() => Promise<void>>(),
@@ -150,12 +151,13 @@ describe('api', () => {
           name: 'Bâtiment vide',
         }),
       ])
-      mockGetBuildingsByType.mockImplementation((type) => [
+      // The registry merges a mixed building's connection types itself.
+      mockGetHomeBuildings.mockReturnValue([
         {
-          devices:
-            type === Home.DeviceType.Ata
-              ? [mock<Home.Device>({ id: 'uuid-1' })]
-              : [mock<Home.Device>({ id: 'uuid-2' })],
+          devices: [
+            mock<Home.Device>({ id: 'uuid-1' }),
+            mock<Home.Device>({ id: 'uuid-2' }),
+          ],
           id: 'home-building-1',
           name: 'Appartement',
         },
@@ -169,27 +171,23 @@ describe('api', () => {
 
     it('should serve Home groups from the registry without a wire call', () => {
       mockGetBuildings.mockReturnValue([])
-      mockGetBuildingsByType.mockImplementation((type) =>
-        type === Home.DeviceType.Ata
-          ? [
-              {
-                devices: [mock<Home.Device>({ id: 'uuid-1' })],
-                id: 'home-building-1',
-                name: 'Appartement',
-              },
-            ]
-          : [],
-      )
+      mockGetHomeBuildings.mockReturnValue([
+        {
+          devices: [mock<Home.Device>({ id: 'uuid-1' })],
+          id: 'home-building-1',
+          name: 'Appartement',
+        },
+      ])
 
       expect(api.getDeviceGroups({ homey })).toStrictEqual([
         { deviceIds: ['uuid-1'], name: 'Appartement' },
       ])
-      expect(mockHomeList).not.toHaveBeenCalled()
+      expect(mockEnsureHomeAuthenticated).not.toHaveBeenCalled()
     })
 
     it('should return no groups when both dialects are empty', () => {
       mockGetBuildings.mockReturnValue([])
-      mockGetBuildingsByType.mockReturnValue([])
+      mockGetHomeBuildings.mockReturnValue([])
 
       expect(api.getDeviceGroups({ homey })).toStrictEqual([])
     })
@@ -581,35 +579,21 @@ describe('api', () => {
   })
 
   describe('home session retrieval', () => {
-    it('should not retry the context fetch when already authenticated', async () => {
-      mockIsHomeAuthenticated.mockReturnValue(true)
+    it('should delegate the lazy self-heal to the SDK contract', async () => {
+      mockEnsureHomeAuthenticated.mockResolvedValue(true)
 
       const isAuthenticated = await api.isHomeAuthenticated({ homey })
 
       expect(isAuthenticated).toBe(true)
-      expect(mockHomeList).not.toHaveBeenCalled()
+      expect(mockEnsureHomeAuthenticated).toHaveBeenCalledTimes(1)
     })
 
-    it('should retry the context fetch once when the boot restore failed', async () => {
-      mockIsHomeAuthenticated
-        .mockReturnValueOnce(false)
-        .mockReturnValueOnce(true)
-      mockHomeList.mockResolvedValue([])
-
-      const isAuthenticated = await api.isHomeAuthenticated({ homey })
-
-      expect(isAuthenticated).toBe(true)
-      expect(mockHomeList).toHaveBeenCalledTimes(1)
-    })
-
-    it('should return false when the retried context fetch does not restore the session', async () => {
-      mockIsHomeAuthenticated.mockReturnValue(false)
-      mockHomeList.mockResolvedValue([])
+    it('should return false when the SDK cannot restore the session', async () => {
+      mockEnsureHomeAuthenticated.mockResolvedValue(false)
 
       const isAuthenticated = await api.isHomeAuthenticated({ homey })
 
       expect(isAuthenticated).toBe(false)
-      expect(mockHomeList).toHaveBeenCalledTimes(1)
     })
   })
 
@@ -675,7 +659,7 @@ describe('api', () => {
 
   describe('frost protection settings update', () => {
     it('should delegate to app.updateClassicFrostProtection', async () => {
-      const body = mock<Classic.FrostProtectionQuery>()
+      const body = mock<ProtectionUpdate>()
       const params = mock<ZoneData>({ zoneId: '1', zoneType: 'buildings' })
       mockApp.updateClassicFrostProtection.mockResolvedValue()
 

--- a/tests/unit/app.test.ts
+++ b/tests/unit/app.test.ts
@@ -1,6 +1,9 @@
 import {
+  type HolidayModeState,
   type HolidayModeUpdate,
   type LoginCredentials,
+  type ProtectionState,
+  type ProtectionUpdate,
   type ReportChartLineOptions,
   type ReportChartPieOptions,
   type Result,
@@ -8,6 +11,7 @@ import {
   err,
   NoChangesError,
   ok,
+  UpdateRejectedError,
 } from '@olivierzal/melcloud-api'
 import { Temporal } from 'temporal-polyfill'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -92,10 +96,17 @@ const mockApiInstance = {
 }
 
 const mockHomeRegistry = {
-  getAll: vi.fn<() => unknown[]>().mockReturnValue([]),
-  getBuildingsByType: vi.fn<(type: Home.DeviceType) => unknown[]>(),
+  getBuildings: vi
+    .fn<(params?: { type?: Home.DeviceType }) => unknown[]>()
+    .mockReturnValue([]),
   getById: vi.fn<(id: string) => unknown>(),
-  getByType: vi.fn<(type: Home.DeviceType) => unknown[]>().mockReturnValue([]),
+  getDevices: vi.fn<() => unknown[]>().mockReturnValue([]),
+  getDevicesByType: vi
+    .fn<(type: Home.DeviceType) => unknown[]>()
+    .mockReturnValue([]),
+  getZones: vi
+    .fn<(params?: { type?: Home.DeviceType }) => unknown[]>()
+    .mockReturnValue([]),
 }
 
 const mockHomeApiInstance = {
@@ -110,6 +121,8 @@ const mockFacadeManagerGetZones = vi
   .fn<(options?: { type?: Classic.DeviceType }) => unknown[]>()
   .mockReturnValue([])
 const mockHomeFacadeManagerGet = vi.fn<(model: unknown) => unknown>()
+const mockHomeFacadeManagerGetZones =
+  vi.fn<(params?: { type?: Home.DeviceType }) => unknown[]>()
 const mockHomeFacadeManagerGetBuilding = vi.fn<(id: string) => unknown>()
 const mockHomeFacadeManagerUpdateFrostProtection =
   vi.fn<Home.FacadeManager['updateFrostProtection']>()
@@ -289,6 +302,7 @@ const newMockHomeFacadeManager =
     return mock<Home.FacadeManager>({
       get: mockHomeFacadeManagerGet,
       getBuilding: mockHomeFacadeManagerGetBuilding,
+      getZones: mockHomeFacadeManagerGetZones,
       updateFrostProtection: mockHomeFacadeManagerUpdateFrostProtection,
       updateHolidayMode: mockHomeFacadeManagerUpdateHolidayMode,
       updateOverheatProtection: mockHomeFacadeManagerUpdateOverheatProtection,
@@ -307,6 +321,7 @@ const setupMocks = (): void => {
   mockHomeCreate.mockResolvedValue(mockHomeApiInstance)
   mockFacadeManagerConstructor.mockImplementation(newMockFacadeManager)
   mockHomeFacadeManagerConstructor.mockImplementation(newMockHomeFacadeManager)
+  mockHomeFacadeManagerGetZones.mockReturnValue([])
   mockGetLanguage.mockReturnValue('en')
   mockGetTimezone.mockReturnValue('Europe/Paris')
   mockTranslate.mockImplementation((key: string) => key)
@@ -461,12 +476,16 @@ const setupWidgetListeners = (): {
   return { mockRegisterAta, mockRegisterCharts }
 }
 
+// Mutations resolve void and throw UpdateRejectedError on a wire
+// rejection (melcloud-api 45.0.0): `null` models the accepted write.
 const mockUpdateResult = (
   attributeErrors: Record<string, string[]> | null,
 ): ReturnType<typeof vi.fn> =>
-  vi
-    .fn<() => Promise<{ AttributeErrors: Record<string, string[]> | null }>>()
-    .mockResolvedValue({ AttributeErrors: attributeErrors })
+  attributeErrors === null
+    ? vi.fn<() => Promise<void>>().mockResolvedValue()
+    : vi
+        .fn<() => Promise<void>>()
+        .mockRejectedValue(new UpdateRejectedError(attributeErrors))
 
 const initWithHolidayModeFacade = async (
   app: InstanceType<typeof MelCloudApp>,
@@ -505,6 +524,28 @@ const homeHolidayZone = { id: 'homeDevices_guid-1' } as const
 
 // Point the Home registry/facade at one ATA device so the Home holiday and
 // frost paths resolve for `guid-1`.
+// The picker tree now comes from the library; the app filters its leaves
+// and suffixes them, so tests drive the manager's flat list directly.
+const stubHomeZones = (
+  devices: {
+    buildingName: string
+    id: string
+    name: string
+    deviceType?: 'ata' | 'atw'
+  }[],
+): void => {
+  mockHomeFacadeManagerGetZones.mockReturnValue(
+    devices.map(({ buildingName, deviceType = 'ata', id, name }) => ({
+      buildingName,
+      deviceType,
+      id,
+      level: 1,
+      model: 'homeDevices',
+      name,
+    })),
+  )
+}
+
 const stubHomeDevice = (facade: unknown): void => {
   mockHomeRegistry.getById.mockReturnValue({
     id: 'guid-1',
@@ -535,7 +576,7 @@ const stubBuilding = (
       isAtw: (): boolean => false,
     },
   ]
-  mockHomeRegistry.getAll.mockReturnValue(devices)
+  mockHomeRegistry.getDevices.mockReturnValue(devices)
   mockHomeRegistry.getById.mockImplementation((id) =>
     devices.find((device) => device.id === id),
   )
@@ -543,6 +584,9 @@ const stubBuilding = (
     frostProtection: frostById[(model as { id: string }).id] ?? null,
     holidayMode: holidayById[(model as { id: string }).id] ?? null,
     overheatProtection: overheatById[(model as { id: string }).id] ?? null,
+    // The facade guards read the discriminator the wave added, so the
+    // stub carries it instead of relying on structural sniffing.
+    type: Home.DeviceType.Ata,
   }))
 }
 
@@ -586,8 +630,8 @@ describe('melCloudApp', () => {
     mockGetDrivers.mockReturnValue({})
     mockFacadeManagerGetZones.mockReturnValue([])
     mockApiInstance.isAuthenticated.mockReturnValue(true)
-    mockHomeRegistry.getAll.mockReturnValue([])
-    mockHomeRegistry.getByType.mockReturnValue([])
+    mockHomeRegistry.getDevices.mockReturnValue([])
+    mockHomeRegistry.getDevicesByType.mockReturnValue([])
     app = createApp()
   })
 
@@ -1250,7 +1294,7 @@ describe('melCloudApp', () => {
         timestamp: string
       }[],
     ): void => {
-      mockHomeRegistry.getByType.mockImplementation((type) =>
+      mockHomeRegistry.getDevicesByType.mockImplementation((type) =>
         type === Home.DeviceType.Ata ? [homeAtaDevice] : [],
       )
       mockHomeRegistry.getById.mockReturnValue({
@@ -1353,7 +1397,7 @@ describe('melCloudApp', () => {
       mockApiInstance.registry.devices.getById.mockReturnValue({
         name: 'Living Room',
       })
-      mockHomeRegistry.getByType.mockImplementation((type) =>
+      mockHomeRegistry.getDevicesByType.mockImplementation((type) =>
         type === Home.DeviceType.Ata ? [homeAtaDevice] : [],
       )
       mockHomeRegistry.getById.mockReturnValue({
@@ -1556,13 +1600,13 @@ describe('melCloudApp', () => {
   describe('home device listing by type', () => {
     it('should delegate to registry getByType', async () => {
       const mockModels = [{ id: 'device-1', name: 'Living Room' }]
-      mockHomeRegistry.getByType.mockReturnValue(mockModels)
+      mockHomeRegistry.getDevicesByType.mockReturnValue(mockModels)
       await app.onInit()
 
       const result = app.getHomeDevicesByType(Home.DeviceType.Ata)
 
       expect(result).toBe(mockModels)
-      expect(mockHomeRegistry.getByType).toHaveBeenCalledWith(
+      expect(mockHomeRegistry.getDevicesByType).toHaveBeenCalledWith(
         Home.DeviceType.Ata,
       )
     })
@@ -1643,33 +1687,8 @@ describe('melCloudApp', () => {
   })
 
   describe('home ata targets', () => {
-    it('should nest alpha-sorted devices under their alpha-sorted building', async () => {
-      mockHomeRegistry.getByType.mockReturnValue([
-        {
-          building: { id: 'building-2', name: 'Verkstan' },
-          id: 'device-2',
-          name: 'Salon',
-          isAta: (): boolean => true,
-          isAtw: (): boolean => false,
-        },
-        {
-          building: { id: 'building-2', name: 'Verkstan' },
-          id: 'device-1',
-          name: 'Bureau',
-          isAta: (): boolean => true,
-          isAtw: (): boolean => false,
-        },
-        {
-          building: { id: 'building-1', name: 'Appartement' },
-          id: 'device-3',
-          name: 'Woonkamer',
-          isAta: (): boolean => true,
-          isAtw: (): boolean => false,
-        },
-      ])
-      await app.onInit()
-
-      expect(app.getHomeTargets(Home.DeviceType.Ata)).toStrictEqual([
+    it('should serve the library picker list, narrowed to the asked type', async () => {
+      const zones = [
         {
           buildingName: 'Appartement',
           id: 'building-1',
@@ -1685,33 +1704,14 @@ describe('melCloudApp', () => {
           model: 'homeDevices',
           name: 'Woonkamer',
         },
-        {
-          buildingName: 'Verkstan',
-          id: 'building-2',
-          level: 0,
-          model: 'homeBuildings',
-          name: 'Verkstan',
-        },
-        {
-          buildingName: 'Verkstan',
-          deviceType: 'ata',
-          id: 'device-1',
-          level: 1,
-          model: 'homeDevices',
-          name: 'Bureau',
-        },
-        {
-          buildingName: 'Verkstan',
-          deviceType: 'ata',
-          id: 'device-2',
-          level: 1,
-          model: 'homeDevices',
-          name: 'Salon',
-        },
-      ])
-      expect(mockHomeRegistry.getByType).toHaveBeenCalledWith(
-        Home.DeviceType.Ata,
-      )
+      ]
+      mockHomeFacadeManagerGetZones.mockReturnValue(zones)
+      await app.onInit()
+
+      expect(app.getHomeTargets(Home.DeviceType.Ata)).toStrictEqual(zones)
+      expect(mockHomeFacadeManagerGetZones).toHaveBeenCalledWith({
+        type: Home.DeviceType.Ata,
+      })
     })
   })
 
@@ -2153,21 +2153,9 @@ describe('melCloudApp', () => {
 
   describe('home device zones', () => {
     it('should suffix the building and sort for the flat pickers', async () => {
-      mockHomeRegistry.getAll.mockReturnValue([
-        {
-          building: { name: 'Vinkenstraat 22' },
-          id: 'b',
-          name: 'Garage',
-          isAta: (): boolean => true,
-          isAtw: (): boolean => false,
-        },
-        {
-          building: { name: 'Verkstan' },
-          id: 'a',
-          name: 'Garage ',
-          isAta: (): boolean => true,
-          isAtw: (): boolean => false,
-        },
+      stubHomeZones([
+        { buildingName: 'Vinkenstraat 22', id: 'b', name: 'Garage' },
+        { buildingName: 'Verkstan', id: 'a', name: 'Garage ' },
       ])
       await app.onInit()
 
@@ -2194,13 +2182,12 @@ describe('melCloudApp', () => {
     })
 
     it('should filter by device type when one is given', async () => {
-      mockHomeRegistry.getByType.mockReturnValue([
+      stubHomeZones([
         {
-          building: { name: 'Huis' },
+          buildingName: 'Huis',
+          deviceType: 'atw',
           id: 'atw-1',
           name: 'Warmtepomp',
-          isAta: (): boolean => false,
-          isAtw: (): boolean => true,
         },
       ])
       await app.onInit()
@@ -2215,9 +2202,9 @@ describe('melCloudApp', () => {
           name: 'Warmtepomp (Huis)',
         },
       ])
-      expect(mockHomeRegistry.getByType).toHaveBeenCalledWith(
-        Home.DeviceType.Atw,
-      )
+      expect(mockHomeFacadeManagerGetZones).toHaveBeenCalledWith({
+        type: Home.DeviceType.Atw,
+      })
     })
   })
 
@@ -2520,7 +2507,7 @@ describe('melCloudApp', () => {
 
       await expect(
         app.updateClassicFrostProtection({
-          settings: mock<Classic.FrostProtectionQuery>(),
+          settings: mock<ProtectionUpdate>(),
           zoneId: '1',
           zoneType: 'buildings',
         }),
@@ -2537,7 +2524,7 @@ describe('melCloudApp', () => {
 
       await expect(
         app.updateClassicFrostProtection({
-          settings: mock<Classic.FrostProtectionQuery>(),
+          settings: mock<ProtectionUpdate>(),
           zoneId: '1',
           zoneType: 'buildings',
         }),
@@ -2648,13 +2635,21 @@ describe('melCloudApp', () => {
             name: 'Maison',
           },
         ])
-        mockHomeRegistry.getAll.mockReturnValue([
+        mockHomeFacadeManagerGetZones.mockReturnValue([
           {
-            building: { id: 'chalet-1', name: 'Chalet' },
+            buildingName: 'Chalet',
+            id: 'chalet-1',
+            level: 0,
+            model: 'homeBuildings',
+            name: 'Chalet',
+          },
+          {
+            buildingName: 'Chalet',
+            deviceType: 'ata',
             id: 'guid-9',
+            level: 1,
+            model: 'homeDevices',
             name: 'Salon',
-            isAta: (): boolean => true,
-            isAtw: (): boolean => false,
           },
         ])
         await app.onInit()
@@ -2994,10 +2989,8 @@ describe('melCloudApp', () => {
         async (isEnabled) => {
           await initWithHolidayModeFacade(app, {
             getHolidayMode: vi
-              .fn<() => Promise<Result<Classic.HolidayModeData>>>()
-              .mockResolvedValue(
-                ok(mock<Classic.HolidayModeData>({ HMEnabled: isEnabled })),
-              ),
+              .fn<() => Promise<Result<HolidayModeState | null>>>()
+              .mockResolvedValue(ok(mock<HolidayModeState>({ isEnabled }))),
           })
 
           const run = getMockCallArg<
@@ -3009,8 +3002,8 @@ describe('melCloudApp', () => {
       )
 
       it.each([
-        { holidayMode: { enabled: true }, shouldBeOn: true },
-        { holidayMode: { enabled: false }, shouldBeOn: false },
+        { holidayMode: { isEnabled: true }, shouldBeOn: true },
+        { holidayMode: { isEnabled: false }, shouldBeOn: false },
         // No holiday data on the facade reads as "off".
         { holidayMode: null, shouldBeOn: false },
       ])(
@@ -3029,12 +3022,12 @@ describe('melCloudApp', () => {
 
       it.each([
         {
-          holidayById: { d1: { enabled: true }, d2: { enabled: true } },
+          holidayById: { d1: { isEnabled: true }, d2: { isEnabled: true } },
           shouldBeOn: true,
         },
         // Devices disagree: the building aggregate is "mixed", read as off.
         {
-          holidayById: { d1: { enabled: true }, d2: { enabled: false } },
+          holidayById: { d1: { isEnabled: true }, d2: { isEnabled: false } },
           shouldBeOn: false,
         },
       ])(
@@ -3087,17 +3080,15 @@ describe('melCloudApp', () => {
   describe('home overheat protection', () => {
     it('should read a Home ATA device overheat protection off the facade', async () => {
       await app.onInit()
-      const overheatProtection = mock<Home.OverheatProtection>({
-        active: false,
-      })
-      stubHomeDevice({ overheatProtection })
+      const overheatProtection = mock<ProtectionState>({ isEnabled: true })
+      stubHomeDevice({ overheatProtection, type: Home.DeviceType.Ata })
 
       expect(app.getHomeOverheatProtection('guid-1')).toBe(overheatProtection)
     })
 
-    it('should read null for a facade without the ATA-only getter', async () => {
+    it('should read null for an ATW facade, which never carries it', async () => {
       await app.onInit()
-      stubHomeDevice({ frostProtection: null })
+      stubHomeDevice({ frostProtection: null, type: Home.DeviceType.Atw })
 
       expect(app.getHomeOverheatProtection('guid-1')).toBeNull()
     })
@@ -3125,14 +3116,14 @@ describe('melCloudApp', () => {
     it('keeps shared frost values and nulls the disagreements', async () => {
       await app.onInit()
       stubBuilding({
-        d1: { active: false, enabled: true, max: 12, min: 6 },
-        d2: { active: false, enabled: true, max: 14, min: 6 },
+        d1: { isEnabled: true, max: 12, min: 6 },
+        d2: { isEnabled: true, max: 14, min: 6 },
       })
 
       expect(app.getHomeBuildingFrostProtection('b1')).toStrictEqual({
-        FPEnabled: true,
-        FPMaxTemperature: null,
-        FPMinTemperature: 6,
+        isEnabled: true,
+        max: null,
+        min: 6,
       })
     })
 
@@ -3141,9 +3132,9 @@ describe('melCloudApp', () => {
       stubBuilding({})
 
       expect(app.getHomeBuildingFrostProtection('b1')).toStrictEqual({
-        FPEnabled: false,
-        FPMaxTemperature: null,
-        FPMinTemperature: null,
+        isEnabled: false,
+        max: null,
+        min: null,
       })
     })
 
@@ -3152,15 +3143,15 @@ describe('melCloudApp', () => {
       stubBuilding(
         {},
         {
-          d1: { active: false, enabled: true, endDate: 'e', startDate: 's' },
-          d2: { active: false, enabled: true, endDate: 'e', startDate: 'x' },
+          d1: { endDate: 'e', isEnabled: true, startDate: 's' },
+          d2: { endDate: 'e', isEnabled: true, startDate: 'x' },
         },
       )
 
       expect(app.getHomeBuildingHolidayMode('b1')).toStrictEqual({
-        HMEnabled: true,
-        HMEndDate: 'e',
-        HMStartDate: null,
+        endDate: 'e',
+        isEnabled: true,
+        startDate: null,
       })
     })
 
@@ -3169,9 +3160,9 @@ describe('melCloudApp', () => {
       stubBuilding({}, {})
 
       expect(app.getHomeBuildingHolidayMode('b1')).toStrictEqual({
-        HMEnabled: false,
-        HMEndDate: null,
-        HMStartDate: null,
+        endDate: null,
+        isEnabled: false,
+        startDate: null,
       })
     })
 
@@ -3181,15 +3172,15 @@ describe('melCloudApp', () => {
         {},
         {},
         {
-          d1: { active: false, enabled: true, max: 37, min: 35 },
-          d2: { active: false, enabled: true, max: 38, min: 35 },
+          d1: { isEnabled: true, max: 37, min: 35 },
+          d2: { isEnabled: true, max: 38, min: 35 },
         },
       )
 
       expect(app.getHomeBuildingOverheatProtection('b1')).toStrictEqual({
-        OHEnabled: true,
-        OHMaxTemperature: null,
-        OHMinTemperature: 35,
+        isEnabled: true,
+        max: null,
+        min: 35,
       })
     })
 
@@ -3198,9 +3189,9 @@ describe('melCloudApp', () => {
       stubBuilding({}, {}, {})
 
       expect(app.getHomeBuildingOverheatProtection('b1')).toStrictEqual({
-        OHEnabled: false,
-        OHMaxTemperature: null,
-        OHMinTemperature: null,
+        isEnabled: false,
+        max: null,
+        min: null,
       })
     })
 
@@ -3210,7 +3201,7 @@ describe('melCloudApp', () => {
         {},
         {},
         {
-          d1: { active: false, enabled: true, max: 37, min: 35 },
+          d1: { isEnabled: true, max: 37, min: 35 },
         },
       )
       // Turn d2 into an ATW device: it must not drag the aggregate to
@@ -3229,15 +3220,15 @@ describe('melCloudApp', () => {
           isAtw: (): boolean => true,
         },
       ]
-      mockHomeRegistry.getAll.mockReturnValue(devices)
+      mockHomeRegistry.getDevices.mockReturnValue(devices)
       mockHomeRegistry.getById.mockImplementation((id) =>
         devices.find((device) => device.id === id),
       )
 
       expect(app.getHomeBuildingOverheatProtection('b1')).toStrictEqual({
-        OHEnabled: true,
-        OHMaxTemperature: 37,
-        OHMinTemperature: 35,
+        isEnabled: true,
+        max: 37,
+        min: 35,
       })
     })
 
@@ -3292,35 +3283,8 @@ describe('melCloudApp', () => {
       )
     })
 
-    it('builds the target tree: buildings with their devices nested, sorted', async () => {
-      mockHomeRegistry.getAll.mockReturnValue([
-        {
-          building: { id: 'b2', name: 'Bravo' },
-          id: 'd3',
-          name: 'Zeta',
-          isAta: (): boolean => true,
-          isAtw: (): boolean => false,
-        },
-        {
-          building: { id: 'b1', name: 'Alpha' },
-          id: 'd2',
-          name: 'Yankee',
-          isAta: (): boolean => true,
-          isAtw: (): boolean => false,
-        },
-        {
-          building: { id: 'b1', name: 'Alpha' },
-          id: 'd1',
-          name: 'Xray',
-          isAta: (): boolean => true,
-          isAtw: (): boolean => false,
-        },
-      ])
-      await app.onInit()
-
-      // Buildings alpha-sorted; each building's devices nested (level 1) and
-      // sorted under it; every node stamped with its building name.
-      expect(app.getHomeTargets()).toStrictEqual([
+    it('serves the library picker list unfiltered when no type is given', async () => {
+      const zones = [
         {
           buildingName: 'Alpha',
           id: 'b1',
@@ -3336,30 +3300,14 @@ describe('melCloudApp', () => {
           model: 'homeDevices',
           name: 'Xray',
         },
-        {
-          buildingName: 'Alpha',
-          deviceType: 'ata',
-          id: 'd2',
-          level: 1,
-          model: 'homeDevices',
-          name: 'Yankee',
-        },
-        {
-          buildingName: 'Bravo',
-          id: 'b2',
-          level: 0,
-          model: 'homeBuildings',
-          name: 'Bravo',
-        },
-        {
-          buildingName: 'Bravo',
-          deviceType: 'ata',
-          id: 'd3',
-          level: 1,
-          model: 'homeDevices',
-          name: 'Zeta',
-        },
-      ])
+      ]
+      mockHomeFacadeManagerGetZones.mockReturnValue(zones)
+      await app.onInit()
+
+      expect(app.getHomeTargets()).toStrictEqual(zones)
+      expect(mockHomeFacadeManagerGetZones).toHaveBeenCalledWith({
+        type: undefined,
+      })
     })
   })
 
@@ -3501,28 +3449,11 @@ describe('melCloudApp', () => {
       ])
       // Unsorted on purpose: home targets must come back alpha-sorted
       // (building, then its devices), appended after the classic ones.
-      mockHomeRegistry.getByType.mockReturnValue([
-        {
-          building: { id: 'account-1', name: 'Maison' },
-          id: 'home-2',
-          name: 'Building two',
-          isAta: (): boolean => true,
-          isAtw: (): boolean => false,
-        },
-        {
-          building: { id: 'account-1', name: 'Maison' },
-          id: 'home-1',
-          name: 'Building one',
-          isAta: (): boolean => true,
-          isAtw: (): boolean => false,
-        },
-        {
-          building: { id: 'account-1', name: 'Maison' },
-          id: 'home-3',
-          name: 'Bedroom',
-          isAta: (): boolean => true,
-          isAtw: (): boolean => false,
-        },
+      // The library sorts its picker list, so the stub is already ordered.
+      stubHomeZones([
+        { buildingName: 'Maison', id: 'home-3', name: 'Bedroom' },
+        { buildingName: 'Maison', id: 'home-1', name: 'Building one' },
+        { buildingName: 'Maison', id: 'home-2', name: 'Building two' },
       ])
       await app.onInit()
 
@@ -3590,14 +3521,8 @@ describe('melCloudApp', () => {
           name: 'Device 2',
         },
       ])
-      mockHomeRegistry.getAll.mockReturnValue([
-        {
-          building: { id: 'antwerp-1', name: 'Antwerpen' },
-          id: 'guid-1',
-          name: 'Device 1',
-          isAta: (): boolean => true,
-          isAtw: (): boolean => false,
-        },
+      stubHomeZones([
+        { buildingName: 'Antwerpen', id: 'guid-1', name: 'Device 1' },
       ])
       await app.onInit()
 


### PR DESCRIPTION
Adopts melcloud-api 45.0.0. The app no longer translates between the two dialects' vocabularies — **179 net lines deleted**, suite green (756 tests, 100 % coverage), build and publish-level validation clean.

- **One settings vocabulary**: `ProtectionState`/`ProtectionUpdate`/`HolidayModeState` replace the `FP*`/`HM*`/`OH*` PascalCase juggling across app methods, API routes and the settings webview — including the building aggregates.
- **`throwOnErrors`/`formatErrors` deleted**: mutations resolve `void`, the library throws `UpdateRejectedError` carrying the per-attribute messages.
- **The Home picker tree moves to the library**: `getHomeTargets` is now a one-line delegation to `manager.getZones`, and `collectHomeGroups` drops its per-type loop (`getBuildings()` merges a mixed building itself).
- **`isHomeAuthenticated` delegates to `ensureAuthenticated()`** instead of hand-rolling the lazy context retry.
- Unified registry accessor names, `Classic.FacadeManager(api)`, and the ATA-only overheat read via the `isHomeAtaFacade` guard instead of structural sniffing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)