### PR TITLE
docs: drop a comment line orphaned by the picker-tree delegation

### DIFF
--- a/app.mts
+++ b/app.mts
@@ -957,7 +957,6 @@ export default class MELCloudApp extends App {
     )
   }
 
-  // The Home target tree for a selector: each `/context` building (level 0)
   // The flattened Home picker list — name-sorted buildings (level 0) each
   // followed by its own devices (level 1); `type` narrows to one
   // connection type (the ATA group widget), omitted spans both (the


### PR DESCRIPTION
Self-audit catch: the 45.0.0 adoption replaced `getHomeTargets`'s body with a one-line delegation but left the opening line of the previous comment above the new block, so it read as two competing first sentences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)