### PR TITLE
test(api): pin the HTTP method of every webview route call

### DIFF
--- a/tests/unit/api-route-guards.test.ts
+++ b/tests/unit/api-route-guards.test.ts
@@ -74,6 +74,41 @@ const extractPathLiterals = (source: string): string[] =>
     .map((match) => match.groups?.path ?? '')
     .toArray()
 
+// The typed helpers carry the verb in their name; the boot beacon calls
+// the raw SDK with the verb as its first argument. Reading the pair
+// matters because eleven declared paths differ only by method —
+// `/classic/sessions` alone is declared under POST, GET and DELETE. The
+// helper name must be followed immediately by its generic or its paren,
+// so the import list is not read as a call site. Template-built paths
+// (`/${api}/sessions`) and paths passed as a variable stay out of
+// scope, exactly as for the bare-path sweep above.
+const HELPER_CALL =
+  /homeyApi(?<verb>Get|Put|Post|Delete)(?:<[^\(\)]*>)?\(\s*[\w.#]+\s*,\s*['"](?<path>\/[a-z][\w\-\/]*)['"]/gv
+const SDK_CALL =
+  /homey\.api\(\s*['"](?<verb>[A-Z]+)['"]\s*,\s*['"](?<path>\/[a-z][\w\-\/]*)['"]/gv
+
+const extractRouteCalls = (source: string): DeclaredRoute[] => {
+  const stripped = stripComments(source)
+  return [
+    ...stripped.matchAll(HELPER_CALL).map((match) => ({
+      method: (match.groups?.verb ?? '').toUpperCase(),
+      path: match.groups?.path ?? '',
+    })),
+    ...stripped.matchAll(SDK_CALL).map((match) => ({
+      method: match.groups?.verb ?? '',
+      path: match.groups?.path ?? '',
+    })),
+  ]
+}
+
+const dedupeCalls = (calls: DeclaredRoute[]): DeclaredRoute[] => {
+  const byPair = new Map<string, DeclaredRoute>()
+  for (const call of calls) {
+    byPair.set(`${call.method} ${call.path}`, call)
+  }
+  return byPair.values().toArray()
+}
+
 const routeMatches = (routePath: string, literal: string): boolean => {
   const routeSegments = routePath.split('/')
   const literalSegments = literal.split('/')
@@ -86,16 +121,22 @@ const routeMatches = (routePath: string, literal: string): boolean => {
   )
 }
 
+const readSurfaceSources = async (
+  sourceDirs: readonly string[],
+): Promise<string[]> => {
+  const fileGroups = await Promise.all(
+    sourceDirs.map(async (dir) => listSourceFiles(dir)),
+  )
+  return Promise.all(
+    fileGroups.flat().map(async (file) => readFile(file, 'utf8')),
+  )
+}
+
 describe('api route guards', () => {
   describe.each(SURFACES)('$name', ({ manifest, sourceDirs }) => {
     it('should declare every path its webview sources call', async () => {
       const routes = await readRoutes(manifest)
-      const fileGroups = await Promise.all(
-        sourceDirs.map(async (dir) => listSourceFiles(dir)),
-      )
-      const sources = await Promise.all(
-        fileGroups.flat().map(async (file) => readFile(file, 'utf8')),
-      )
+      const sources = await readSurfaceSources(sourceDirs)
       const literals = sources.flatMap((source) => extractPathLiterals(source))
       const unmatched = [...new Set(literals)].filter((literal) =>
         routes.every((route) => !routeMatches(route.path, literal)),
@@ -103,5 +144,34 @@ describe('api route guards', () => {
 
       expect(unmatched).toStrictEqual([])
     })
+
+    it('should declare every method its webview sources call each path with', async () => {
+      const routes = await readRoutes(manifest)
+      const sources = await readSurfaceSources(sourceDirs)
+      const calls = sources.flatMap((source) => extractRouteCalls(source))
+      const unmatched = dedupeCalls(calls).filter((call) =>
+        routes.every(
+          (route) =>
+            route.method !== call.method ||
+            !routeMatches(route.path, call.path),
+        ),
+      )
+
+      expect(unmatched).toStrictEqual([])
+    })
+  })
+
+  // The pair check above would pass vacuously if its regex stopped
+  // matching, which is exactly how the verb went unchecked in the first
+  // place. Pinning that several distinct methods are recovered proves
+  // the extractor still reads both halves.
+  it('should recover several distinct methods from the call sites', async () => {
+    const sources = await Promise.all(
+      SURFACES.map(async ({ sourceDirs }) => readSurfaceSources(sourceDirs)),
+    )
+    const calls = sources.flat().flatMap((source) => extractRouteCalls(source))
+    const methods = new Set(calls.map(({ method }) => method))
+
+    expect(methods.size).toBeGreaterThan(1)
   })
 })


### PR DESCRIPTION
## What

`tests/unit/api-route-guards.test.ts` parsed `method` into its `DeclaredRoute` shape and never used it — `routeMatches` compares path segments only. This repo is the most exposed of the family: **eleven declared paths differ from a sibling by method alone.**

- `/classic/sessions` and `/home/sessions` — each POST, GET and DELETE
- every `.../settings/frost-protection`, `.../settings/holiday-mode` and `.../settings/overheat-protection` (device and building, both dialects) — GET and PUT
- `/settings/devices` — GET and PUT

So a call site could name a declared path under a verb nothing serves, and both the typecheck and the full suite would stay green while the request 404'd on-device. That is the same shape as the silent settings-page regression this session already shipped and fixed: an untyped boundary where the compiler cannot help and the guard was not looking.

## How

Route calls are now read as `(method, path)` pairs, per surface (settings page, and each widget against its own manifest). The typed helpers encode the verb in their name; `homey.api('POST', …)` passes it explicitly.

Two constraints worth noting:

- the helper name must be followed **immediately** by its generic or its paren, so the `import { homeyApiGet, … }` list is not mistaken for a call site;
- template-built paths (`` `/${api}/sessions` ``) and paths passed as a variable remain out of scope, exactly as for the pre-existing bare-path sweep — this repo genuinely has both, unlike com.heatzy.

A final assertion pins that several distinct methods are still recovered. The pair check would otherwise pass vacuously if its regex drifted, which is precisely how the verb went unchecked in the first place.

## Verification

| Mutation | Before | After |
| --- | --- | --- |
| `homeyApiGet` → `homeyApiPut` on `/classic/sessions` (declared GET/POST/DELETE, never PUT) | suite green | **1 test red** (`expected [ { method: 'PUT', … } ] to strictly equal []`) |

`format`, `lint`, `typecheck` and `test:coverage` (760 tests, 100% branches held) all exit 0.

Companion: OlivierZal/com.heatzy#1049 fixes the same flaw in the sibling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)