### PR TITLE
refactor: speak the ProtectionUpdate contract on the Home write paths

### DIFF
--- a/api.mts
+++ b/api.mts
@@ -317,7 +317,7 @@ const api = {
     homey: { app },
     params: { buildingId },
   }: {
-    body: { isEnabled: boolean; max: number; min: number }
+    body: ProtectionUpdate
     homey: Homey
     params: { buildingId: string }
   }): Promise<void> => app.updateHomeBuildingFrostProtection(buildingId, body),
@@ -335,7 +335,7 @@ const api = {
     homey: { app },
     params: { buildingId },
   }: {
-    body: { isEnabled: boolean; max: number; min: number }
+    body: ProtectionUpdate
     homey: Homey
     params: { buildingId: string }
   }): Promise<void> =>
@@ -345,7 +345,7 @@ const api = {
     homey: { app },
     params: { deviceId },
   }: {
-    body: { isEnabled: boolean; max: number; min: number }
+    body: ProtectionUpdate
     homey: Homey
     params: { deviceId: string }
   }): Promise<void> => app.updateHomeFrostProtection([deviceId], body),
@@ -363,7 +363,7 @@ const api = {
     homey: { app },
     params: { deviceId },
   }: {
-    body: { isEnabled: boolean; max: number; min: number }
+    body: ProtectionUpdate
     homey: Homey
     params: { deviceId: string }
   }): Promise<void> => app.updateHomeOverheatProtection([deviceId], body),

--- a/app.mts
+++ b/app.mts
@@ -1068,7 +1068,7 @@ export default class MELCloudApp extends App {
 
   public async updateHomeBuildingFrostProtection(
     buildingId: string,
-    settings: { isEnabled: boolean; max: number; min: number },
+    settings: ProtectionUpdate,
   ): Promise<void> {
     await this.updateHomeFrostProtection(
       this.#getHomeBuildingDeviceIds(buildingId),
@@ -1088,7 +1088,7 @@ export default class MELCloudApp extends App {
 
   public async updateHomeBuildingOverheatProtection(
     buildingId: string,
-    settings: { isEnabled: boolean; max: number; min: number },
+    settings: ProtectionUpdate,
   ): Promise<void> {
     await this.updateHomeOverheatProtection(
       this.#getHomeBuildingDeviceIds(buildingId),
@@ -1098,7 +1098,7 @@ export default class MELCloudApp extends App {
 
   public async updateHomeFrostProtection(
     deviceIds: readonly string[],
-    settings: { isEnabled: boolean; max: number; min: number },
+    settings: ProtectionUpdate,
   ): Promise<void> {
     await this.#homeFacadeManager.updateFrostProtection(deviceIds, settings)
   }
@@ -1112,7 +1112,7 @@ export default class MELCloudApp extends App {
 
   public async updateHomeOverheatProtection(
     deviceIds: readonly string[],
-    settings: { isEnabled: boolean; max: number; min: number },
+    settings: ProtectionUpdate,
   ): Promise<void> {
     await this.#homeFacadeManager.updateOverheatProtection(deviceIds, settings)
   }


### PR DESCRIPTION
## What

Replaces eight inline `{ isEnabled: boolean; max: number; min: number }` literals with the `ProtectionUpdate` contract they restate.

## Why

`ProtectionUpdate` was already imported in both layers and used **once** — the Classic frost-protection path — while the four Home protection writes spelled the shape out by hand:

- `api.mts`: `updateHomeBuildingFrostProtection`, `updateHomeBuildingOverheatProtection`, `updateHomeFrostProtection`, `updateHomeOverheatProtection`
- `app.mts`: the four methods behind them

Structural typing means those sites keep compiling if `ProtectionUpdate` gains or changes a field — they diverge silently, which is the failure mode a shared contract exists to prevent. That the holiday twin `HolidayModeUpdate` is used on **3 of 3** handlers shows the inconsistency was internal, not a deliberate carve-out.

No behaviour change: the inline literal and the contract are structurally identical today.

## Checklist

- [x] `npm run format` passes
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes (762 tests, coverage 100%)