### PR TITLE
fix: take melcloud-api 45.0.2 for the session and availability fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "46.0.0",
       "license": "GPL-3.0-only",
       "dependencies": {
-        "@olivierzal/melcloud-api": "45.0.0",
+        "@olivierzal/melcloud-api": "45.0.2",
         "source-map-support": "^0.5.21",
         "temporal-polyfill": "^1.0.1"
       },
@@ -1065,9 +1065,9 @@
       }
     },
     "node_modules/@olivierzal/melcloud-api": {
-      "version": "45.0.0",
-      "resolved": "https://npm.pkg.github.com/download/@olivierzal/melcloud-api/45.0.0/9d2307d0098ff7d518f88c2096c0d4f6bff5b6c6",
-      "integrity": "sha512-9oJ3UHP77Y369KOVe6x9hJ6EutIfEgVmWC40wzMq/xJJf234Zt25daZXsLpb9wF965aH/cLOpMheX3p7WKC5aw==",
+      "version": "45.0.2",
+      "resolved": "https://npm.pkg.github.com/download/@olivierzal/melcloud-api/45.0.2/ad68176357ca0867d57025ed2bd8b9e21d961cb6",
+      "integrity": "sha512-jld8dVXg6CBmwxTFTDAdw1hWHmfMqMccQVmOy34tRLAUZr+FjlWVjXPn79js5QKLwHxDejwDcUUlH3V8AtFtaw==",
       "license": "MIT",
       "dependencies": {
         "temporal-polyfill": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "typecheck": "node ./node_modules/@typescript/native/bin/tsc --noEmit"
   },
   "dependencies": {
-    "@olivierzal/melcloud-api": "45.0.0",
+    "@olivierzal/melcloud-api": "45.0.2",
     "source-map-support": "^0.5.21",
     "temporal-polyfill": "^1.0.1"
   },


### PR DESCRIPTION
## What

Bumps the exact pin `@olivierzal/melcloud-api` from `45.0.0` to `45.0.2`.

## Why

Two fixes shipped behind the pin, and both land on paths this app exercises — so they were live bugs here:

- **45.0.2 — `ensureAuthenticated()` no longer destroys a valid session while probing it.** It routed through `authenticate()`, which wipes the persisted session *before* re-logging in, so a session that was merely unexercised (a boot-time context fetch that lost the network) was destroyed by the probe meant to restore it. `GET /home/sessions` reaches it (`api.mts`), and `settings/index.mts` calls that **on every settings-page open** — so the visible symptom was "I opened the settings and I was signed out".
- **45.0.1 — Classic `isAvailable` no longer swallows `EntityNotFoundError`.** A pruned id read as reachable instead of propagating. `drivers/classic-device.mts` feeds that getter straight into the availability applier, which is exactly the consumer the upstream fix describes.

Found while reviewing the contract wave: the pin is exact, so neither fix could arrive without this bump.

## Checklist

- [x] `npm run format` passes
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes (762 tests, coverage 100%)
- [x] `npm run build` passes
- [x] `npm run homey:validate` passes at `publish` level