### PR TITLE
test: sweep the template-built calls and pin each surface non-empty

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "46.0.0",
       "license": "GPL-3.0-only",
       "dependencies": {
-        "@olivierzal/melcloud-api": "45.0.0",
+        "@olivierzal/melcloud-api": "45.0.2",
         "source-map-support": "^0.5.21",
         "temporal-polyfill": "^1.0.1"
       },
@@ -1065,9 +1065,9 @@
       }
     },
     "node_modules/@olivierzal/melcloud-api": {
-      "version": "45.0.0",
-      "resolved": "https://npm.pkg.github.com/download/@olivierzal/melcloud-api/45.0.0/9d2307d0098ff7d518f88c2096c0d4f6bff5b6c6",
-      "integrity": "sha512-9oJ3UHP77Y369KOVe6x9hJ6EutIfEgVmWC40wzMq/xJJf234Zt25daZXsLpb9wF965aH/cLOpMheX3p7WKC5aw==",
+      "version": "45.0.2",
+      "resolved": "https://npm.pkg.github.com/download/@olivierzal/melcloud-api/45.0.2/ad68176357ca0867d57025ed2bd8b9e21d961cb6",
+      "integrity": "sha512-jld8dVXg6CBmwxTFTDAdw1hWHmfMqMccQVmOy34tRLAUZr+FjlWVjXPn79js5QKLwHxDejwDcUUlH3V8AtFtaw==",
       "license": "MIT",
       "dependencies": {
         "temporal-polyfill": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "typecheck": "node ./node_modules/@typescript/native/bin/tsc --noEmit"
   },
   "dependencies": {
-    "@olivierzal/melcloud-api": "45.0.0",
+    "@olivierzal/melcloud-api": "45.0.2",
     "source-map-support": "^0.5.21",
     "temporal-polyfill": "^1.0.1"
   },

--- a/tests/integration/api-contract.test.ts
+++ b/tests/integration/api-contract.test.ts
@@ -10,15 +10,13 @@ import chartsConfig from '../../widgets/charts/widget.compose.json' with { type:
 const sortedKeys = (object: object): string[] =>
   Object.keys(object).toSorted((left, right) => left.localeCompare(right))
 
+// One equality per surface pins the ids ↔ handlers mapping in both
+// directions at once: a handler with no declaration and a declaration
+// with no handler both break it, and the diff names the offender. A
+// per-id existence sweep alongside it could only ever fail together
+// with the equality, so it is not kept.
 describe('api contract', () => {
   describe('app API', () => {
-    it.each(Object.keys(appConfig.api))(
-      '%s handler exists in api.mts',
-      (name) => {
-        expect(api).toHaveProperty(name)
-      },
-    )
-
     // The compile-time half of the contract, asserted on the whole
     // union at once: no per-name method reference ever leaves its
     // object (unbound-method).
@@ -26,26 +24,19 @@ describe('api contract', () => {
       expectTypeOf<(typeof api)[keyof typeof api]>().toBeFunction()
     })
 
-    it('should not have handlers missing from app.json', () => {
+    it('should declare exactly the handlers app.json names', () => {
       expect(sortedKeys(api)).toStrictEqual(sortedKeys(appConfig.api))
     })
   })
 
   describe('ata-group-setting widget API', () => {
-    it.each(Object.keys(ataGroupSettingConfig.api))(
-      '%s handler exists in api.mts',
-      (name) => {
-        expect(ataGroupSettingApi).toHaveProperty(name)
-      },
-    )
-
     it('should expose only function handlers', () => {
       expectTypeOf<
         (typeof ataGroupSettingApi)[keyof typeof ataGroupSettingApi]
       >().toBeFunction()
     })
 
-    it('should not have handlers missing from widget.compose.json', () => {
+    it('should declare exactly the handlers widget.compose.json names', () => {
       expect(sortedKeys(ataGroupSettingApi)).toStrictEqual(
         sortedKeys(ataGroupSettingConfig.api),
       )
@@ -53,18 +44,11 @@ describe('api contract', () => {
   })
 
   describe('charts widget API', () => {
-    it.each(Object.keys(chartsConfig.api))(
-      '%s handler exists in api.mts',
-      (name) => {
-        expect(chartsApi).toHaveProperty(name)
-      },
-    )
-
     it('should expose only function handlers', () => {
       expectTypeOf<(typeof chartsApi)[keyof typeof chartsApi]>().toBeFunction()
     })
 
-    it('should not have handlers missing from widget.compose.json', () => {
+    it('should declare exactly the handlers widget.compose.json names', () => {
       expect(sortedKeys(chartsApi)).toStrictEqual(sortedKeys(chartsConfig.api))
     })
   })

--- a/tests/unit/api-route-guards.test.ts
+++ b/tests/unit/api-route-guards.test.ts
@@ -74,6 +74,16 @@ const extractPathLiterals = (source: string): string[] =>
     .map((match) => match.groups?.path ?? '')
     .toArray()
 
+// Path-shaped template literals are swept wherever they are written,
+// not just inside a call: a builder returning one of several templates
+// puts them a function away from any verb, and they would otherwise be
+// the only paths nothing checks.
+const extractPathTemplates = (source: string): string[] =>
+  stripComments(source)
+    .matchAll(/`(?<template>\/[a-z][^`]*)`/gv)
+    .map((match) => match.groups?.template ?? '')
+    .toArray()
+
 // The typed helpers carry the verb in their name; the boot beacon calls
 // the raw SDK with the verb as its first argument. Reading the pair
 // matters because eleven declared paths differ only by method —
@@ -179,6 +189,25 @@ const extractTemplateCalls = (source: string): TemplateCall[] =>
     }))
     .toArray()
 
+// Counting every helper call site, whatever shape its path takes, turns
+// the sweeps above from "found something" into "found everything": a
+// call the extractors cannot read shows up as a shortfall instead of
+// passing unseen. A generic may wrap across lines, so newlines are
+// allowed inside it.
+const HELPER_CALL_SITE = /homeyApi(?:Get|Put|Post|Delete)(?:<[^\(\)]*>)?\s*\(/gv
+
+// Some call sites hand over a path the site itself does not spell: a
+// parameter on a list helper, or a builder returning one of several
+// templates. Their verb is unreadable there, but every path they can
+// produce is written somewhere in the same sources, which the sweep
+// below reads. Counting them keeps the accounting complete instead of
+// letting them vanish.
+const HELPER_INDIRECT_CALL =
+  /homeyApi(?:Get|Put|Post|Delete)(?:<[^\(\)]*>)?\(\s*[\w.#]+\s*,\s*[a-z]\w*/gv
+
+const countMatches = (source: string, pattern: RegExp): number =>
+  stripComments(source).matchAll(pattern).toArray().length
+
 const dedupeCalls = (calls: DeclaredRoute[]): DeclaredRoute[] => {
   const byPair = new Map<string, DeclaredRoute>()
   for (const call of calls) {
@@ -216,9 +245,18 @@ describe('api route guards', () => {
       const routes = await readRoutes(manifest)
       const sources = await readSurfaceSources(sourceDirs)
       const literals = sources.flatMap((source) => extractPathLiterals(source))
-      const unmatched = [...new Set(literals)].filter((literal) =>
-        routes.every((route) => !routeMatches(route.path, literal)),
+      const templates = sources.flatMap((source) =>
+        extractPathTemplates(source),
       )
+      const unmatched = [
+        ...[...new Set(literals)].filter((literal) =>
+          routes.every((route) => !routeMatches(route.path, literal)),
+        ),
+        ...[...new Set(templates)].filter((template) => {
+          const pattern = toTemplatePattern(template)
+          return routes.every((route) => !pattern.test(route.path))
+        }),
+      ]
 
       expect(unmatched).toStrictEqual([])
     })
@@ -254,18 +292,26 @@ describe('api route guards', () => {
       expect(unmatched).toStrictEqual([])
     })
 
-    // Both checks above pass vacuously on an empty call list, which is
-    // how the verb went unchecked in the first place. Every surface
-    // calls its own API, so recovering nothing means the extractors
-    // stopped matching rather than the sources stopping calling.
-    it('should recover at least one call from its own sources', async () => {
+    // Both checks above pass vacuously on a call the extractors cannot
+    // read, which is how the verb went unchecked in the first place.
+    // Accounting for every call site — parsed, or one of the two
+    // parameterised list helpers — turns that silence into a failure.
+    it('should account for every helper call site in its own sources', async () => {
       const sources = await readSurfaceSources(sourceDirs)
-      const calls = [
-        ...sources.flatMap((source) => extractRouteCalls(source)),
-        ...sources.flatMap((source) => extractTemplateCalls(source)),
-      ]
+      const callSites = sources.reduce(
+        (total, source) => total + countMatches(source, HELPER_CALL_SITE),
+        0,
+      )
+      const indirectCalls = sources.reduce(
+        (total, source) => total + countMatches(source, HELPER_INDIRECT_CALL),
+        0,
+      )
+      const parsed =
+        sources.flatMap((source) => extractRouteCalls(source)).length +
+        sources.flatMap((source) => extractTemplateCalls(source)).length
 
-      expect(calls.length).toBeGreaterThan(0)
+      expect(callSites).toBeGreaterThan(0)
+      expect(parsed + indirectCalls).toBeGreaterThanOrEqual(callSites)
     })
   })
 

--- a/tests/unit/api-route-guards.test.ts
+++ b/tests/unit/api-route-guards.test.ts
@@ -16,9 +16,9 @@ interface Surface {
 // The call-site half of the API contract: webview sources may only call
 // routes their own surface declares — the settings page hits the app
 // API, each widget hits its own widget API (the shared `public/`
-// modules are bundled into both widgets). Literal paths are extracted
-// from the sources and checked against the declared table;
-// template-built paths are out of scope by design. The declaration half
+// modules are bundled into both widgets). Paths are extracted from the
+// sources — literal ones exactly, template-built ones by their fixed
+// chunks — and checked against the declared table. The declaration half
 // (manifest ids ↔ handlers, both directions, type level) lives in
 // tests/integration/api-contract.test.ts.
 const SURFACES: readonly Surface[] = [
@@ -80,7 +80,7 @@ const extractPathLiterals = (source: string): string[] =>
 // `/classic/sessions` alone is declared under POST, GET and DELETE. The
 // helper name must be followed immediately by its generic or its paren,
 // so the import list is not read as a call site. Template-built paths
-// (`/${api}/sessions`) and paths passed as a variable stay out of
+// are swept separately below; a path passed as a variable stays out of
 // scope, exactly as for the bare-path sweep above.
 const HELPER_CALL =
   /homeyApi(?<verb>Get|Put|Post|Delete)(?:<[^\(\)]*>)?\(\s*[\w.#]+\s*,\s*['"](?<path>\/[a-z][\w\-\/]*)['"]/gv
@@ -100,6 +100,84 @@ const extractRouteCalls = (source: string): DeclaredRoute[] => {
     })),
   ]
 }
+
+// Every PUT and DELETE call site builds its path from a template, so the
+// literal sweeps above see none of them — the verbs carrying the whole
+// settings surface would go unchecked. A template is still partly known
+// at build time: its literal chunks are fixed and ordered, and only the
+// `${…}` holes float (one may expand to nothing, as an optional query
+// string does). Keeping the chunks and letting the holes float is enough
+// to require that some declared route of the same method could serve the
+// call, which is the pair check's whole point.
+const HELPER_TEMPLATE_CALL =
+  /homeyApi(?<verb>Get|Put|Post|Delete)(?:<[^\(\)]*>)?\(\s*[\w.#]+\s*,\s*`(?<template>[^`]*)`/gv
+
+const escapeRegExp = (chunk: string): string =>
+  chunk.replaceAll(/[$\(\)*+.?\[\\\]^\{\|\}]/gv, String.raw`\$&`)
+
+// A hole can nest braces — `${new URLSearchParams({ … })}` does — so the
+// literal chunks are found by tracking depth, not by a regex that would
+// stop at the first inner `}`. `${` is folded to one sentinel first so
+// the scan reads a single character per step.
+const HOLE = ''
+
+const toTemplateChunks = (template: string): string[] => {
+  const chunks: string[] = []
+  let literal = ''
+  let depth = 0
+  for (const char of template.replaceAll('${', '')) {
+    if (char === HOLE) {
+      if (depth === 0) {
+        chunks.push(literal)
+        literal = ''
+      }
+      depth += 1
+    } else if (char === '{' && depth > 0) {
+      depth += 1
+    } else if (char === '}' && depth > 0) {
+      depth -= 1
+    } else if (depth === 0) {
+      literal += char
+    }
+  }
+  chunks.push(literal)
+  return chunks
+}
+
+// Declared paths carry no query string, so anything from the first `?`
+// of a literal chunk on is dropped — a `?` inside a hole is part of the
+// hole and never reaches here.
+const toTemplatePattern = (template: string): RegExp => {
+  const chunks = toTemplateChunks(template)
+  const queryIndex = chunks.findIndex((chunk) => chunk.includes('?'))
+  const pathChunks =
+    queryIndex === -1
+      ? chunks
+      : [
+          ...chunks.slice(0, queryIndex),
+          (chunks[queryIndex] ?? '').split('?', 1)[0] ?? '',
+        ]
+  return new RegExp(
+    `^${pathChunks.map((chunk) => escapeRegExp(chunk)).join('.*')}$`,
+    'v',
+  )
+}
+
+interface TemplateCall {
+  readonly method: string
+  readonly pattern: RegExp
+  readonly template: string
+}
+
+const extractTemplateCalls = (source: string): TemplateCall[] =>
+  stripComments(source)
+    .matchAll(HELPER_TEMPLATE_CALL)
+    .map((match) => ({
+      method: (match.groups?.verb ?? '').toUpperCase(),
+      pattern: toTemplatePattern(match.groups?.template ?? ''),
+      template: match.groups?.template ?? '',
+    }))
+    .toArray()
 
 const dedupeCalls = (calls: DeclaredRoute[]): DeclaredRoute[] => {
   const byPair = new Map<string, DeclaredRoute>()
@@ -159,12 +237,40 @@ describe('api route guards', () => {
 
       expect(unmatched).toStrictEqual([])
     })
+
+    it('should declare a route of the same method for every template-built call', async () => {
+      const routes = await readRoutes(manifest)
+      const sources = await readSurfaceSources(sourceDirs)
+      const calls = sources.flatMap((source) => extractTemplateCalls(source))
+      const unmatched = calls
+        .filter((call) =>
+          routes.every(
+            (route) =>
+              route.method !== call.method || !call.pattern.test(route.path),
+          ),
+        )
+        .map(({ method, template }) => `${method} ${template}`)
+
+      expect(unmatched).toStrictEqual([])
+    })
+
+    // Both checks above pass vacuously on an empty call list, which is
+    // how the verb went unchecked in the first place. Every surface
+    // calls its own API, so recovering nothing means the extractors
+    // stopped matching rather than the sources stopping calling.
+    it('should recover at least one call from its own sources', async () => {
+      const sources = await readSurfaceSources(sourceDirs)
+      const calls = [
+        ...sources.flatMap((source) => extractRouteCalls(source)),
+        ...sources.flatMap((source) => extractTemplateCalls(source)),
+      ]
+
+      expect(calls.length).toBeGreaterThan(0)
+    })
   })
 
-  // The pair check above would pass vacuously if its regex stopped
-  // matching, which is exactly how the verb went unchecked in the first
-  // place. Pinning that several distinct methods are recovered proves
-  // the extractor still reads both halves.
+  // Pinning that several distinct methods are recovered proves the
+  // extractors still read the verb, not just the path.
   it('should recover several distinct methods from the call sites', async () => {
     const sources = await Promise.all(
       SURFACES.map(async ({ sourceDirs }) => readSurfaceSources(sourceDirs)),
@@ -173,5 +279,23 @@ describe('api route guards', () => {
     const methods = new Set(calls.map(({ method }) => method))
 
     expect(methods.size).toBeGreaterThan(1)
+  })
+
+  // The template sweep is the only cover the PUT and DELETE call sites
+  // have: every one of them builds its path. Were its regex to stop
+  // matching, the per-surface clause above would still be satisfied by
+  // the literal GET calls, so the loss is pinned on its own.
+  it('should recover the template-built calls, PUT and DELETE among them', async () => {
+    const sources = await Promise.all(
+      SURFACES.map(async ({ sourceDirs }) => readSurfaceSources(sourceDirs)),
+    )
+    const calls = sources
+      .flat()
+      .flatMap((source) => extractTemplateCalls(source))
+    const methods = new Set(calls.map(({ method }) => method))
+
+    expect(
+      [...methods].toSorted((left, right) => left.localeCompare(right)),
+    ).toStrictEqual(['DELETE', 'GET', 'POST', 'PUT'])
   })
 })


### PR DESCRIPTION
## What

Closes the two blind spots the contract review found in the route guard, and drops a redundant clause from the contract test.

## The blind spots

**1. No PUT or DELETE call site was checked.** Every one of them builds its path from a template, and the literal regexes skip templates. The manifest declares **9 PUT and 2 DELETE** routes — so the verbs carrying the whole settings surface (`frost-protection`, `holiday-mode`, `overheat-protection`, `/settings/devices`, the session teardown) went unchecked, which is exactly the gap the method pinning was added to close.

Templates are now swept by their fixed chunks with the holes floating, so a call must still name a declared route **of the same method**. Two shapes had to be handled for that to hold, both found by the test failing on real sources:

- a hole can nest braces — `${new URLSearchParams({ … })}` — so chunks are scanned by depth, not by a regex that stops at the first inner `}`;
- a template may carry a query string, which declared paths never do, so anything from the first `?` of a literal chunk on is dropped.

Verified by mutation: turning the zone-settings `homeyApiPut` into `homeyApiPost` now fails the sweep. Before this change it was invisible.

**2. Vacuity was pinned globally, not per surface.** `methods.size > 1` was satisfied by the settings page alone, so both widget surfaces could have stopped matching entirely and still passed — the exact silent-vacuity failure the guard exists to prevent. Each surface now has to recover at least one call, and the template sweep gets its own clause, since literal GET calls would otherwise keep the per-surface clause green while it quietly died.

## Also

The per-id existence sweep in `api-contract.test.ts` is removed: it could only ever fail together with the key equality beside it, which already pins the mapping in both directions and names the offender in its diff. Test count drops (~52 generated cases) with no loss of coverage — the equality does the work.

## Checklist

- [x] `npm run format` passes
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes (710 tests, coverage 100% on statements, branches, functions and lines)