### PR TITLE
test: share one route-guard kernel across the three apps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,8 +86,15 @@ coverage.
   a route: `tests/integration/api-contract.test.ts` (since #1261) pins
   manifest ids ↔ handlers both ways plus the handlers' function type,
   on all three surfaces; `tests/unit/api-route-guards.test.ts` pins the
-  call sites (every webview path literal must match a declared route of
-  its own surface).
+  call sites — every path a webview writes, literal or template-built,
+  must match a declared route of its own surface, under a declared
+  method. Everything below its `SURFACES` table is byte-identical in
+  com.heatzy and com.melcloud.extension (only that table differs) —
+  edit all three together. Its load-bearing clause is the call-site
+  accounting: every `homeyApi*` site must be parsed or hand over a path
+  it does not spell, which is what makes a broken extractor a failure
+  instead of a silent pass, and what makes separate "the regex still
+  matches" clauses redundant.
 - Dirty-gating: `public/dirty-gate.mts` is the ONE primitive behind every
   webview Apply/Refresh pair (settings sections, frost/holiday panels, the
   ATA group widget) — never re-derive its invariant at a call site. Its

--- a/tests/unit/api-route-guards.test.ts
+++ b/tests/unit/api-route-guards.test.ts
@@ -39,6 +39,10 @@ const SURFACES: readonly Surface[] = [
   },
 ]
 
+// Everything below the SURFACES table is the shared guard, byte-identical
+// in com.melcloud, com.heatzy and com.melcloud.extension — edit all three
+// together. Only the table above differs: it names what each app exposes.
+
 const readRoutes = async (manifestPath: string): Promise<DeclaredRoute[]> => {
   const manifest = JSON.parse(await readFile(manifestPath, 'utf8')) as {
     api?: Record<string, DeclaredRoute>
@@ -294,8 +298,10 @@ describe('api route guards', () => {
 
     // Both checks above pass vacuously on a call the extractors cannot
     // read, which is how the verb went unchecked in the first place.
-    // Accounting for every call site — parsed, or one of the two
-    // parameterised list helpers — turns that silence into a failure.
+    // Accounting for every call site — parsed, or handing over a path it
+    // does not spell — turns that silence into a failure, and subsumes
+    // any "the extractor still matches something" clause: a regex that
+    // stopped matching leaves its calls counted here and nowhere else.
     it('should account for every helper call site in its own sources', async () => {
       const sources = await readSurfaceSources(sourceDirs)
       const callSites = sources.reduce(
@@ -313,35 +319,5 @@ describe('api route guards', () => {
       expect(callSites).toBeGreaterThan(0)
       expect(parsed + indirectCalls).toBeGreaterThanOrEqual(callSites)
     })
-  })
-
-  // Pinning that several distinct methods are recovered proves the
-  // extractors still read the verb, not just the path.
-  it('should recover several distinct methods from the call sites', async () => {
-    const sources = await Promise.all(
-      SURFACES.map(async ({ sourceDirs }) => readSurfaceSources(sourceDirs)),
-    )
-    const calls = sources.flat().flatMap((source) => extractRouteCalls(source))
-    const methods = new Set(calls.map(({ method }) => method))
-
-    expect(methods.size).toBeGreaterThan(1)
-  })
-
-  // The template sweep is the only cover the PUT and DELETE call sites
-  // have: every one of them builds its path. Were its regex to stop
-  // matching, the per-surface clause above would still be satisfied by
-  // the literal GET calls, so the loss is pinned on its own.
-  it('should recover the template-built calls, PUT and DELETE among them', async () => {
-    const sources = await Promise.all(
-      SURFACES.map(async ({ sourceDirs }) => readSurfaceSources(sourceDirs)),
-    )
-    const calls = sources
-      .flat()
-      .flatMap((source) => extractTemplateCalls(source))
-    const methods = new Set(calls.map(({ method }) => method))
-
-    expect(
-      [...methods].toSorted((left, right) => left.localeCompare(right)),
-    ).toStrictEqual(['DELETE', 'GET', 'POST', 'PUT'])
   })
 })


### PR DESCRIPTION
## What

Makes everything below the `SURFACES` table byte-identical in `com.melcloud`, `com.heatzy` and `com.melcloud.extension`, and drops two clauses the call-site accounting already subsumes.

Companion PRs: OlivierZal/com.heatzy#1051 and OlivierZal/com.melcloud.extension#1225.

## Why

The guard lived in three copies with ~10 helpers triplicated (`stripComments`, `routeMatches`, `readRoutes`, `extractPathLiterals`, `dedupeCalls`, `extractRouteCalls`, `HELPER_CALL`, `SDK_CALL`, `HELPER_CALL_SITE`, `listSourceFiles`). **This session widened the drift instead of closing it**: the template sweep landed in one app, the call-site accounting in two, `toTemplatePattern` in one — so the same check had three shapes and nothing detects that across repos.

The fix is the idiom the family already uses for `callback-api.mts` and `dirty-gate.mts`: byte-identical copies, edit all three together, said so in `CLAUDE.md`. Only the `SURFACES` table differs — the two sibling apps pass a single entry where this one passes three.

## Two clauses removed

- "should recover several distinct methods from the call sites"
- "should recover the template-built calls, PUT and DELETE among them"

Both asserted **this app's inventory** rather than an invariant — `com.heatzy` has no template call at all, so the second is simply false there — and both are subsumed by the accounting: a regex that stops matching leaves its calls counted as sites and parsed nowhere, which is a shortfall. Verified by mutation: breaking the template regex fails the accounting on all three surfaces, so nothing was lost.

## Checklist

- [x] `npm run format` passes
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes (708 tests, coverage 100%)
- [x] `npm run homey:validate` passes at `publish` level