### PR TITLE
fix: take melcloud-api 45.1.0 so a lockout is waited, not guessed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "46.0.0",
       "license": "GPL-3.0-only",
       "dependencies": {
-        "@olivierzal/melcloud-api": "45.0.2",
+        "@olivierzal/melcloud-api": "45.1.0",
         "source-map-support": "^0.5.21",
         "temporal-polyfill": "^1.0.1"
       },
@@ -1065,9 +1065,9 @@
       }
     },
     "node_modules/@olivierzal/melcloud-api": {
-      "version": "45.0.2",
-      "resolved": "https://npm.pkg.github.com/download/@olivierzal/melcloud-api/45.0.2/ad68176357ca0867d57025ed2bd8b9e21d961cb6",
-      "integrity": "sha512-jld8dVXg6CBmwxTFTDAdw1hWHmfMqMccQVmOy34tRLAUZr+FjlWVjXPn79js5QKLwHxDejwDcUUlH3V8AtFtaw==",
+      "version": "45.1.0",
+      "resolved": "https://npm.pkg.github.com/download/@olivierzal/melcloud-api/45.1.0/fb63ae5bc7750fa38a25fc8e9fab9da264c4727d",
+      "integrity": "sha512-gufRGGWeUNcGV3d99M1Cf3bJPgZblqM/RXdjTVxRYi8mDKh5e8O1Cs8q1GKyWxVmIKOJ8ZFuknmnUiVrcCaZnQ==",
       "license": "MIT",
       "dependencies": {
         "temporal-polyfill": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "typecheck": "node ./node_modules/@typescript/native/bin/tsc --noEmit"
   },
   "dependencies": {
-    "@olivierzal/melcloud-api": "45.0.2",
+    "@olivierzal/melcloud-api": "45.1.0",
     "source-map-support": "^0.5.21",
     "temporal-polyfill": "^1.0.1"
   },


### PR DESCRIPTION
## What

Bumps the exact pin `@olivierzal/melcloud-api` from `45.0.2` to `45.1.0`.

## Why

From a user report on 45.11.0 — *"its not cooling anymore"*. MELCloud had locked the account out and announced the remaining window on every rejection:

```
"ErrorId": 6, "LoginMinutes": 60,   ← then 59 on the next attempt
```

The library read neither `LoginMinutes` nor `LoginStatus` and held sign-ins for a flat two hours, so the app stayed mute for **an extra hour past the point MELCloud would have taken it back**. 45.1.0 waits the announced window, keeping the two-hour constant as the cap and the fallback.

The pin is exact, so the fix cannot reach the app without this bump.

## Also in 45.1.0

`AuthenticationThrottledError.retryAfter` now carries that window as a `Temporal.Duration`, mirroring `RateLimitError.retryAfter`. This app does not read it yet — the settings page already distinguishes a throttle from a rejection via the error class, and phrasing the exact wait is a separate, optional improvement.

## What was *not* the bug

The classification was already right: the app told the user MELCloud was blocking sign-ins rather than asking them to re-enter credentials. Probing the live endpoint settled the rest — `ErrorId 1` covers both an unknown email and a wrong password, so the report's earlier rejection was a genuine credential failure and disarming the sync was correct.

## Checklist

- [x] `npm run format` passes
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes (708 tests, coverage 100%)
- [x] `npm run build` passes
- [x] `npm run homey:validate` passes at `publish` level