### PR TITLE
fix(types): declare the two settings keys the library already writes

### DIFF
--- a/tests/unit/app-settings-contract.test.ts
+++ b/tests/unit/app-settings-contract.test.ts
@@ -1,0 +1,31 @@
+import type {
+  ClassicAPISettings,
+  HomeAPISettings,
+} from '@olivierzal/melcloud-api'
+import { describe, expectTypeOf, it } from 'vitest'
+
+import type { HomeySettings } from '../../types/app-settings.mts'
+
+// Every key the library can write, under the two namespaces the app
+// hands it: Classic unprefixed, Home prefixed.
+type ApiSettingKey = Prefixed<keyof HomeAPISettings> | keyof ClassicAPISettings
+
+// The Home namespace app.mts gives the library, expressed at the type
+// level. `Capitalize` uppercases the first character only, which is
+// exactly what #createSettingManager's prefixKey does at runtime.
+type Prefixed<TKey extends string> = `home${Capitalize<TKey>}`
+
+// The app hand-maintains HomeySettings while melcloud-api owns the key
+// names, so the union drifts silently — loginBackoffUntil and its Home
+// twin were written for releases without ever being declared, which
+// only compiled through the permissive `(key: string) => unknown`
+// overload in homey-override.d.ts. This fails at typecheck the day a
+// release adds a @setting accessor.
+//
+// One-way on purpose: HomeySettings legitimately carries the app's own
+// notifiedVersion, which the library knows nothing about.
+describe('app settings contract', () => {
+  it('should declare every key the library can write', () => {
+    expectTypeOf<ApiSettingKey>().toExtend<keyof HomeySettings>()
+  })
+})

--- a/tests/unit/app.test.ts
+++ b/tests/unit/app.test.ts
@@ -2335,6 +2335,20 @@ describe('melCloudApp', () => {
       expect(mockSettingsUnset).toHaveBeenCalledWith('homeAccessToken')
     })
 
+    // The runtime half of the contract app-settings-contract.test.ts
+    // pins statically: loginBackoffUntil went undeclared for releases
+    // while the library wrote it under both namespaces.
+    it('should prefix the login backoff key like any other', async () => {
+      await app.onInit()
+
+      const { settingManager } = getMockCallArg<{
+        settingManager: { get: (key: string) => unknown }
+      }>(mockHomeCreate, 0, 0)
+      settingManager.get('loginBackoffUntil')
+
+      expect(mockSettingsGet).toHaveBeenCalledWith('homeLoginBackoffUntil')
+    })
+
     it('should create classic setting manager without key prefixing', async () => {
       await app.onInit()
 
@@ -2356,6 +2370,17 @@ describe('melCloudApp', () => {
       settingManager.unset('contextKey')
 
       expect(mockSettingsUnset).toHaveBeenCalledWith('contextKey')
+    })
+
+    it('should leave the login backoff key unprefixed', async () => {
+      await app.onInit()
+
+      const { settingManager } = getMockCallArg<{
+        settingManager: { get: (key: string) => unknown }
+      }>(mockCreate, 0, 0)
+      settingManager.get('loginBackoffUntil')
+
+      expect(mockSettingsGet).toHaveBeenCalledWith('loginBackoffUntil')
     })
 
     it('should pass through string and null settings and coerce the rest to undefined', async () => {

--- a/types/app-settings.mts
+++ b/types/app-settings.mts
@@ -1,11 +1,20 @@
+/**
+ * Keys the app persists through `homey.settings`: the melcloud-api
+ * session material of both dialects (written via the lib's
+ * `SettingManager`, Home's namespaced by the `home` prefix) plus the
+ * app's own bookkeeping. `tests/unit/app-settings-contract.test.ts`
+ * pins this union against what the library actually writes.
+ */
 export interface HomeySettings {
   readonly contextKey?: string | null
   readonly expiry?: string | null
   readonly homeAccessToken?: string | null
   readonly homeExpiry?: string | null
+  readonly homeLoginBackoffUntil?: string | null
   readonly homePassword?: string | null
   readonly homeRefreshToken?: string | null
   readonly homeUsername?: string | null
+  readonly loginBackoffUntil?: string | null
   readonly notifiedVersion?: string | null
   readonly password?: string | null
   readonly username?: string | null


### PR DESCRIPTION
## What

Adds `loginBackoffUntil` and `homeLoginBackoffUntil` to `HomeySettings`, and pins the union against the library with a type-level contract.

## Why

`types/app-settings.mts` declared **10** keys; the runtime writes **12**. melcloud-api persists `loginBackoffUntil` through its `SettingManager` (`src/api/base.ts`), and `app.mts` instantiates that manager twice — Classic unprefixed (`app.mts:1471`), Home prefixed (`app.mts:1505`) — so both spellings have been written for releases without ever being declared.

It compiled only through the permissive `(key: string) => unknown` overload in `homey-override.d.ts`. No runtime leak (logout clears via the library, not by iterating declared keys), but `settings/index.mts` types the whole `homey.get()` payload as `HomeySettings`, so that payload was under-typed.

Verified exhaustively rather than guessed: the 7 `@setting` accessors in melcloud-api, the key derivation (`src/decorators/setting.ts` — `String(context.name)`, verbatim) and the prefix rule. **Exactly two keys were missing; no declared key is stale.**

## The part that matters

The union is hand-maintained while the library owns the names, so it drifts silently — which is how this got here. The library **already exports** `ClassicAPISettings` and `HomeAPISettings`, which nothing in this app referenced. `tests/unit/app-settings-contract.test.ts` now closes the loop:

```ts
type ApiSettingKey = Prefixed<keyof HomeAPISettings> | keyof ClassicAPISettings
expectTypeOf<ApiSettingKey>().toExtend<keyof HomeySettings>()
```

`Capitalize` is byte-identical to `prefixKey`. One-way on purpose — `notifiedVersion` is the app's own.

**Verified by mutation**: dropping `loginBackoffUntil` from the union fails `npm run typecheck` and the error names the missing key. Note it does *not* fail `vitest run` alone — `expectTypeOf` is erased at runtime — so `typecheck` is the gate, and it is already a required check.

Two runtime tests pin the same contract from the other side: the backoff key prefixes on Home and stays bare on Classic.

## Kept deliberately

The permissive `(key: string) => unknown` overload. `SettingManager`'s contract hands keys over as plain `string`, and narrowing that would need an assertion `no-unsafe-type-assertion` forbids. It would not have caught this drift anyway — `prefixKey` returns `string` — which is why the contract test is what actually closes the hole. com.heatzy carries the identical overload for the identical reason.

## Checklist

- [x] `npm run format` passes
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes (711 tests, coverage 100% on statements, branches, functions and lines)
- [x] `npm run homey:validate` passes at `publish` level

Types-only: no changelog entry, no version bump.