### PR TITLE
test: share one api-contract kernel across the three apps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,7 +85,10 @@ coverage.
   test-pinned in two halves, one file each — extend BOTH when touching
   a route: `tests/integration/api-contract.test.ts` (since #1261) pins
   manifest ids ↔ handlers both ways plus the handlers' function type,
-  on all three surfaces; `tests/unit/api-route-guards.test.ts` pins the
+  on all three surfaces — and like the route guard, everything below its
+  own `SURFACES` table is byte-identical in the two sibling apps, only
+  the table and the `Handler` union naming what each app exposes differ;
+  `tests/unit/api-route-guards.test.ts` pins the
   call sites — every path a webview writes, literal or template-built,
   must match a declared route of its own surface, under a declared
   method. Everything below its `SURFACES` table is byte-identical in

--- a/tests/integration/api-contract.test.ts
+++ b/tests/integration/api-contract.test.ts
@@ -7,49 +7,51 @@ import ataGroupSettingConfig from '../../widgets/ata-group-setting/widget.compos
 import chartsApi from '../../widgets/charts/api.mts'
 import chartsConfig from '../../widgets/charts/widget.compose.json' with { type: 'json' }
 
+// The declaration half of the API contract: what each surface exposes
+// against what its manifest declares. The call-site half (every path a
+// webview writes, under a declared method) lives in
+// tests/unit/api-route-guards.test.ts.
+const SURFACES = [
+  { api, config: appConfig, name: 'app API' },
+  {
+    api: ataGroupSettingApi,
+    config: ataGroupSettingConfig,
+    name: 'ata-group-setting widget API',
+  },
+  { api: chartsApi, config: chartsConfig, name: 'charts widget API' },
+]
+
+// Every surface's handler union, so the compile-time half is asserted
+// once rather than per surface.
+type Handler =
+  | (typeof api)[keyof typeof api]
+  | (typeof ataGroupSettingApi)[keyof typeof ataGroupSettingApi]
+  | (typeof chartsApi)[keyof typeof chartsApi]
+
+// Everything below the SURFACES table is the shared contract test,
+// byte-identical in com.melcloud, com.heatzy and com.melcloud.extension
+// — edit all three together. Only the table and the Handler union above
+// differ: they name what each app exposes.
+
 const sortedKeys = (object: object): string[] =>
   Object.keys(object).toSorted((left, right) => left.localeCompare(right))
 
-// One equality per surface pins the ids ↔ handlers mapping in both
-// directions at once: a handler with no declaration and a declaration
-// with no handler both break it, and the diff names the offender. A
-// per-id existence sweep alongside it could only ever fail together
-// with the equality, so it is not kept.
 describe('api contract', () => {
-  describe('app API', () => {
-    // The compile-time half of the contract, asserted on the whole
-    // union at once: no per-name method reference ever leaves its
-    // object (unbound-method).
-    it('should expose only function handlers', () => {
-      expectTypeOf<(typeof api)[keyof typeof api]>().toBeFunction()
-    })
-
-    it('should declare exactly the handlers app.json names', () => {
-      expect(sortedKeys(api)).toStrictEqual(sortedKeys(appConfig.api))
-    })
+  // Asserted on the whole union at once: no per-name method reference
+  // ever leaves its object (unbound-method).
+  it('should expose only function handlers', () => {
+    expectTypeOf<Handler>().toBeFunction()
   })
 
-  describe('ata-group-setting widget API', () => {
-    it('should expose only function handlers', () => {
-      expectTypeOf<
-        (typeof ataGroupSettingApi)[keyof typeof ataGroupSettingApi]
-      >().toBeFunction()
-    })
-
-    it('should declare exactly the handlers widget.compose.json names', () => {
-      expect(sortedKeys(ataGroupSettingApi)).toStrictEqual(
-        sortedKeys(ataGroupSettingConfig.api),
-      )
-    })
-  })
-
-  describe('charts widget API', () => {
-    it('should expose only function handlers', () => {
-      expectTypeOf<(typeof chartsApi)[keyof typeof chartsApi]>().toBeFunction()
-    })
-
-    it('should declare exactly the handlers widget.compose.json names', () => {
-      expect(sortedKeys(chartsApi)).toStrictEqual(sortedKeys(chartsConfig.api))
-    })
-  })
+  // One equality per surface pins the ids ↔ handlers mapping in both
+  // directions at once: a handler with no declaration and a declaration
+  // with no handler both break it, and the diff names the offender. A
+  // per-id existence sweep alongside it could only ever fail together
+  // with the equality, so it is not kept.
+  it.each(SURFACES)(
+    '$name should declare exactly the handlers its manifest names',
+    ({ api: surfaceApi, config }) => {
+      expect(sortedKeys(surfaceApi)).toStrictEqual(sortedKeys(config.api))
+    },
+  )
 })

--- a/tests/unit/app-settings-contract.test.ts
+++ b/tests/unit/app-settings-contract.test.ts
@@ -1,0 +1,31 @@
+import type {
+  ClassicAPISettings,
+  HomeAPISettings,
+} from '@olivierzal/melcloud-api'
+import { describe, expectTypeOf, it } from 'vitest'
+
+import type { HomeySettings } from '../../types/app-settings.mts'
+
+// Every key the library can write, under the two namespaces the app
+// hands it: Classic unprefixed, Home prefixed.
+type ApiSettingKey = Prefixed<keyof HomeAPISettings> | keyof ClassicAPISettings
+
+// The Home namespace app.mts gives the library, expressed at the type
+// level. `Capitalize` uppercases the first character only, which is
+// exactly what #createSettingManager's prefixKey does at runtime.
+type Prefixed<TKey extends string> = `home${Capitalize<TKey>}`
+
+// The app hand-maintains HomeySettings while melcloud-api owns the key
+// names, so the union drifts silently — loginBackoffUntil and its Home
+// twin were written for releases without ever being declared, which
+// only compiled through the permissive `(key: string) => unknown`
+// overload in homey-override.d.ts. This fails at typecheck the day a
+// release adds a @setting accessor.
+//
+// One-way on purpose: HomeySettings legitimately carries the app's own
+// notifiedVersion, which the library knows nothing about.
+describe('app settings contract', () => {
+  it('should declare every key the library can write', () => {
+    expectTypeOf<ApiSettingKey>().toExtend<keyof HomeySettings>()
+  })
+})

--- a/tests/unit/app.test.ts
+++ b/tests/unit/app.test.ts
@@ -2335,6 +2335,20 @@ describe('melCloudApp', () => {
       expect(mockSettingsUnset).toHaveBeenCalledWith('homeAccessToken')
     })
 
+    // The runtime half of the contract app-settings-contract.test.ts
+    // pins statically: loginBackoffUntil went undeclared for releases
+    // while the library wrote it under both namespaces.
+    it('should prefix the login backoff key like any other', async () => {
+      await app.onInit()
+
+      const { settingManager } = getMockCallArg<{
+        settingManager: { get: (key: string) => unknown }
+      }>(mockHomeCreate, 0, 0)
+      settingManager.get('loginBackoffUntil')
+
+      expect(mockSettingsGet).toHaveBeenCalledWith('homeLoginBackoffUntil')
+    })
+
     it('should create classic setting manager without key prefixing', async () => {
       await app.onInit()
 
@@ -2356,6 +2370,17 @@ describe('melCloudApp', () => {
       settingManager.unset('contextKey')
 
       expect(mockSettingsUnset).toHaveBeenCalledWith('contextKey')
+    })
+
+    it('should leave the login backoff key unprefixed', async () => {
+      await app.onInit()
+
+      const { settingManager } = getMockCallArg<{
+        settingManager: { get: (key: string) => unknown }
+      }>(mockCreate, 0, 0)
+      settingManager.get('loginBackoffUntil')
+
+      expect(mockSettingsGet).toHaveBeenCalledWith('loginBackoffUntil')
     })
 
     it('should pass through string and null settings and coerce the rest to undefined', async () => {

--- a/types/app-settings.mts
+++ b/types/app-settings.mts
@@ -1,11 +1,20 @@
+/**
+ * Keys the app persists through `homey.settings`: the melcloud-api
+ * session material of both dialects (written via the lib's
+ * `SettingManager`, Home's namespaced by the `home` prefix) plus the
+ * app's own bookkeeping. `tests/unit/app-settings-contract.test.ts`
+ * pins this union against what the library actually writes.
+ */
 export interface HomeySettings {
   readonly contextKey?: string | null
   readonly expiry?: string | null
   readonly homeAccessToken?: string | null
   readonly homeExpiry?: string | null
+  readonly homeLoginBackoffUntil?: string | null
   readonly homePassword?: string | null
   readonly homeRefreshToken?: string | null
   readonly homeUsername?: string | null
+  readonly loginBackoffUntil?: string | null
   readonly notifiedVersion?: string | null
   readonly password?: string | null
   readonly username?: string | null


### PR DESCRIPTION
## What

Gives the contract test the same shared-kernel shape the route guard got in #1497, and collapses this repo's three per-surface blocks into one loop.

Companion PRs: OlivierZal/com.heatzy#1053 and OlivierZal/com.melcloud.extension#1231.

## Why

The route guard was unified; its twin was left behind — and this file is where the real duplication sat: **three near-identical blocks**, each repeating the same two assertions for a different surface.

- A `SURFACES` table collapses them into one `it.each`, with the surface named in the failing test title.
- The compile-time half is asserted **once** over a `Handler` union rather than per surface.

55 lines to 30. Everything below the table is byte-identical in the two sibling apps — the idiom already used for the route guard, `settings/callback-api.mts` and `public/dirty-gate.mts`, and now recorded in `CLAUDE.md`.

## Honest sizing

For the two sibling apps this is a modest win (25 lines to 16) — they were already byte-identical with each other, so nothing had drifted there. The gain that justified the change is this repo's three repeated blocks, plus the family reading alike.

## Verification

**Mutation-tested**: removing a route from `.homeycompose/app.json` fails the equality, and the test title names the surface that drifted.

- [x] `npm run format` / `lint` / `typecheck` pass
- [x] `npm test` passes (coverage 100%)
- [x] `npm run homey:validate` passes at `publish` level

Tests and docs only.