### PR TITLE
ci: pin conventional PR titles as the single squash source

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,16 @@ registries:
     type: npm-registry
     url: https://npm.pkg.github.com
 updates:
-  - directory: /
+  # Both ecosystems share the `build(deps)` type: it keeps every bump under
+  # one `git log --grep` and leaves `ci` to mean hand-written CI changes.
+  # Pinned rather than left to Dependabot, which otherwise infers prefix and
+  # capitalization from each repo's history and lands a different style per
+  # repo.
+  - commit-message:
+      prefix: build(deps)
+    cooldown:
+      default-days: 7
+    directory: /
     groups:
       actions:
         patterns:
@@ -12,7 +21,10 @@ updates:
     package-ecosystem: github-actions
     schedule:
       interval: weekly
-  - cooldown:
+  - commit-message:
+      prefix: build(deps)
+      prefix-development: build(deps-dev)
+    cooldown:
       default-days: 7
     directory: /
     groups:

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,33 @@
+concurrency:
+  cancel-in-progress: true
+  group: pr-title-${{ github.ref }}
+jobs:
+  pr-title:
+    name: PR title
+    permissions:
+      pull-requests: read
+    runs-on: ubuntu-24.04
+    steps:
+      # No `types`: the action defaults to the conventional-commit-types set
+      # (build, chore, ci, docs, feat, fix, perf, refactor, revert, style,
+      # test), which is exactly the set in use here. No `scopes` allowlist:
+      # house scopes are free-form. And deliberately no `subjectPattern`:
+      # subjects legitimately open on a proper noun (`feat: MELCloud Home
+      # frost protection`), so a lowercase-first regex would reject correct
+      # titles.
+      - env:
+          # The action re-reads the title over REST rather than trusting the
+          # event payload, so it needs a token even to read its own PR.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50
+    timeout-minutes: 5
+name: PR title
+# `edited` is load-bearing: without it, fixing a rejected title in place
+# would never re-run the check. `reopened`/`synchronize` keep the status
+# present on every head commit — for a required check, a missing status
+# blocks the merge as hard as a failing one. No `merge_group`: the action
+# reads a pull_request context and throws without one.
+on:
+  pull_request:
+    types: [edited, opened, reopened, synchronize]
+permissions: {}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -305,6 +305,21 @@ coverage.
 - `main` is protected (PRs only, squash merges, 6 required contexts,
   `strict=false`); merge queue is impossible (user-owned repo, org-only
   feature).
+- The PR title IS the commit that lands: `squash_merge_commit_title` is
+  `PR_TITLE` on all five repos, so the title is the single source (under
+  the former `COMMIT_OR_PR_TITLE`, a one-commit PR silently took its
+  commit subject instead). It must follow Conventional Commits, which
+  the required `PR title` check enforces
+  (`.github/workflows/pr-title.yml`, byte-identical in the five). The
+  default type set is the convention's own — no custom list, no scope
+  allowlist (house scopes are free-form), and deliberately no
+  `subjectPattern`: subjects legitimately open on a proper noun
+  (`feat: MELCloud Home frost protection`). Dependabot's prefixes are
+  pinned to `build(deps)` / `build(deps-dev)` in `dependabot.yml`
+  rather than inferred — left to infer, it read each repo's history and
+  landed a different style per repo (`Build(deps): Bump …` here,
+  bare `Bump …` there). No commitlint: in squash-only repos the title
+  check already covers everything that reaches `main`.
 - After every push, monitor the triggered pipelines to completion — the
   PR checks after a push, the publish run after a release tag — and act
   on the outcome: rerun transient infra failures (a SonarCloud 504 is


### PR DESCRIPTION
## What

Makes the PR title the one thing that lands on `main`, and guards it.

1. `squash_merge_commit_title` → `PR_TITLE` (already applied via the API on all five repos).
2. New `.github/workflows/pr-title.yml` — byte-identical in the five — running [`amannn/action-semantic-pull-request`](https://github.com/amannn/action-semantic-pull-request) at `48f2562` (v6.1.1), SHA-pinned.
3. Dependabot prefixes pinned to `build(deps)` / `build(deps-dev)` instead of inferred.
4. `cooldown: default-days: 7` added to the `github-actions` entry where it was missing (the three apps had it on the npm entry only).
5. CLAUDE.md records the doctrine.

## Why the title source had to change first

Under `COMMIT_OR_PR_TITLE` the landed title comes from **the commit** when the PR has exactly one, and from **the PR title** otherwise. Two sources depending on commit count is what made the convention unenforceable: a reviewed, validated PR title was discarded precisely when the PR was simplest. With `PR_TITLE` there is one source, so a required check can guard it — and the action's own `validateSingleCommit` escape hatch, which exists for this exact trap, becomes unnecessary.

## Why nothing is configured beyond the defaults

Each input was checked against history rather than assumed:

- **No `types`.** The action defaults to the `conventional-commit-types` set. Measured over the last 300 commits of `main` in each repo, the types actually in use are `build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test` — that set exactly, nothing outside it.
- **No `scopes` allowlist.** House scopes are free-form (`test(api)`, `feat(home)`, `fix(types)`); a list would be maintenance for no gain.
- **No `subjectPattern`.** I had proposed `^(?![A-Z]).+$` to pin lowercase subjects. The data refutes it: **12 correct historical titles** open on a proper noun — `feat: MELCloud Home frost protection`, `feat: Home ATA overheat protection`, `docs: CLAUDE.md describes the canonical webview lifecycle`, `docs: SonarCloud spotless required for any merge`, `fix: ATW operational states from live observation`. The real convention is "sentence case except proper nouns", which no regex expresses, so the check stays out of it.

## Trigger set

`types: [edited, opened, reopened, synchronize]`.

`edited` is load-bearing: without it, fixing a rejected title in place would never re-run the check, leaving the PR permanently red. `reopened`/`synchronize` keep the status present on every head commit — for a required check, a **missing** status blocks a merge as hard as a failing one.

No `merge_group`: the action reads a `pull_request` context and throws without one (and the merge queue is an org-only feature, unavailable here anyway).

## Dependabot

Left to infer, Dependabot read each repo's history and landed a different style in each:

| repo | what it produced |
|---|---|
| com.melcloud | `build(deps): bump the actions group with 3 updates` ✅ |
| melcloud-api | `Build(deps-dev): Bump @swc/core in the minor-and-patch group` ❌ |
| heatzy-api | `Bump anthropics/claude-code-action in the actions group` ❌ |

Both ecosystems get `build(deps)` so one `git log --grep '^build(deps'` finds every bump regardless of ecosystem, and `ci` keeps meaning hand-written CI changes.

## Not done, deliberately

**No commitlint / commit-msg hook.** These repos are squash-only (`allow_merge_commit=false`, `allow_rebase_merge=false`), so only the squash title reaches `main` — the title check already covers everything that lands. A local hook would only add friction on intermediate messages that get discarded.

## Follow-up (needs the workflow on `main` first)

- Add `PR title` to each repo's required-status-checks ruleset. For com.melcloud this brings the count to the 6 its CLAUDE.md already claims (it is at 5 today).
- Drop `Test (Node latest)` from com.melcloud.extension's ruleset: `ci.yml` marks that leg `continue-on-error` on purpose so a brand-new Node release cannot red the pipeline, and no other repo requires it. It is inert today (a `continue-on-error` job reports success), but it silently becomes blocking the day that flag is removed.

## Checklist

- [x] `npm run format` passes
- [x] `npm run lint` passes (the yaml plugin's `sort-keys` caught `uses` before `env`)
- [x] `zizmor` clean on the new workflow
- [x] The workflow is byte-identical in the five repos
