### PR TITLE
test: type the test doubles instead of asserting them

### DIFF
--- a/tests/unit/api.test.ts
+++ b/tests/unit/api.test.ts
@@ -119,8 +119,8 @@ describe('api', () => {
   describe('building retrieval', () => {
     it('should delegate to getClassicBuildings', () => {
       const buildings = [
-        { id: 1, name: 'ClassicBuilding 1' },
-      ] as unknown as Classic.BuildingZone[]
+        mock<Classic.BuildingZone>({ id: 1, name: 'ClassicBuilding 1' }),
+      ]
       mockGetBuildings.mockReturnValue(buildings)
 
       const result = api.getClassicBuildings()

--- a/tests/unit/api.test.ts
+++ b/tests/unit/api.test.ts
@@ -21,7 +21,7 @@ import type {
   HomeDeviceZone,
   ZoneData,
 } from '../../types/zone.mts'
-import { mock } from '../helpers.js'
+import { mock } from '../helpers.ts'
 
 const mockGetBuildings =
   vi.fn<

--- a/tests/unit/app.test.ts
+++ b/tests/unit/app.test.ts
@@ -23,7 +23,7 @@ import type * as HomeyLib from '../../lib/homey.mts'
 import type { ClassicMELCloudDevice } from '../../types/classic.mts'
 import type { Settings } from '../../types/device-settings.mts'
 import type { ManifestDriver } from '../../types/manifest.mts'
-import { getMockCallArg, mock, settleDetached } from '../helpers.js'
+import { getMockCallArg, mock, settleDetached } from '../helpers.ts'
 
 const mockSetFacadeManager = vi.fn<() => void>()
 

--- a/tests/unit/ata-group-setting-api.test.ts
+++ b/tests/unit/ata-group-setting-api.test.ts
@@ -11,7 +11,7 @@ import type {
   HomeDeviceZone,
   ZoneData,
 } from '../../types/zone.mts'
-import { mock } from '../helpers.js'
+import { mock } from '../helpers.ts'
 
 const mockGetBuildings = vi.fn<() => Classic.BuildingZone[]>()
 

--- a/tests/unit/charts-api.test.ts
+++ b/tests/unit/charts-api.test.ts
@@ -5,7 +5,7 @@ import type {
 import type { Homey } from 'homey/lib/Homey'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { mock } from '../helpers.js'
+import { mock } from '../helpers.ts'
 
 const { default: api } = await import('../../widgets/charts/api.mts')
 

--- a/tests/unit/classic-report.test.ts
+++ b/tests/unit/classic-report.test.ts
@@ -117,18 +117,25 @@ const mockFailingFetch = (): void => {
   })
 }
 
+type SyntheticTagMapping = Readonly<Record<string, readonly string[]>>
+
 const createCopMocks = (
   hasTagMappings = true,
 ): ClassicMELCloudDevice<TestDeviceType> => {
-  const copConsumed = {
+  // The COP arithmetic is capability-name agnostic — `cleanMapping` is
+  // mocked to hand it this key — so these mappings are synthetic on
+  // purpose and typed as such. Claiming they are
+  // `EnergyCapabilityTagMapping` would need an assertion to hide a key
+  // no device declares.
+  const copConsumed: SyntheticTagMapping = {
     'measure_power.cop': ['ConsumedTag'],
-  } as unknown as Partial<EnergyCapabilityTagMapping<TestDeviceType>>
-  const copProduced = {
+  }
+  const copProduced: SyntheticTagMapping = {
     'measure_power.cop': ['ProducedTag'],
-  } as unknown as Partial<EnergyCapabilityTagMapping<TestDeviceType>>
-  const copEnergyMapping = {
+  }
+  const copEnergyMapping: SyntheticTagMapping = {
     'measure_power.cop': ['ProducedTag', 'ConsumedTag'],
-  } as unknown as EnergyCapabilityTagMapping<TestDeviceType>
+  }
   const copDriver = mock<ClassicMELCloudDriver<TestDeviceType>>({
     consumedTagMapping: hasTagMappings ? copConsumed : {},
     producedTagMapping: hasTagMappings ? copProduced : {},

--- a/tests/unit/classic-report.test.ts
+++ b/tests/unit/classic-report.test.ts
@@ -459,7 +459,7 @@ describe(EnergyReport, () => {
       mockEnergyFetch(
         mock<Classic.EnergyDataAta>({
           TotalAutoConsumed: 100,
-          TotalCoolingConsumed: undefined as unknown as number,
+          TotalCoolingConsumed: undefined,
         }),
       )
       const report = new EnergyReport(mockDevice, {

--- a/tests/unit/dirty-gate.test.ts
+++ b/tests/unit/dirty-gate.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import { createDirtyGate } from '../../public/dirty-gate.mts'
+import { mock } from '../helpers.ts'
 
 // The gate is headless: buttons only need a `disabled` slot, and wired
 // targets only need to dispatch events, so plain doubles are enough.
@@ -10,8 +11,8 @@ const setup = (): {
   gate: ReturnType<typeof createDirtyGate>
   refreshElement: HTMLButtonElement
 } => {
-  const applyElement = { disabled: false } as unknown as HTMLButtonElement
-  const refreshElement = { disabled: false } as unknown as HTMLButtonElement
+  const applyElement = mock<HTMLButtonElement>({ disabled: false })
+  const refreshElement = mock<HTMLButtonElement>({ disabled: false })
   const form = { value: 'pristine' }
   const gate = createDirtyGate({
     applyElement,

--- a/tests/unit/home-base-device.test.ts
+++ b/tests/unit/home-base-device.test.ts
@@ -3,7 +3,6 @@ import type HomeyModule from 'homey'
 import { EntityNotFoundError } from '@olivierzal/melcloud-api'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { InteropModule } from '../helpers.ts'
 import { BaseMELCloudDevice } from '../../drivers/base-device.mts'
 import { NotFoundError } from '../../lib/errors.mts'
 import {
@@ -13,6 +12,7 @@ import {
   testSetValuesErrorHandling,
   testThermostatModeOff,
 } from '../device-descriptors.ts'
+import { type InteropModule, mock } from '../helpers.ts'
 import {
   type TestHomeDevice,
   createTestHomeDevice,
@@ -58,7 +58,7 @@ const requiredCapabilities = vi.hoisted(() => [
 ])
 
 const createMockFacade = (): Home.DeviceAtaFacade =>
-  ({
+  mock<Home.DeviceAtaFacade>({
     capabilities: {
       hasAutomaticFanSpeed: true,
       numberOfFanSpeeds: 5,
@@ -79,7 +79,7 @@ const createMockFacade = (): Home.DeviceAtaFacade =>
     get setTemperature(): number {
       return 22
     },
-  }) as unknown as Home.DeviceAtaFacade
+  })
 
 vi.mock(import('homey'), async () => {
   const { createMockDeviceClass, mock: mockModule } =

--- a/tests/unit/home-melcloud-atw-device.test.ts
+++ b/tests/unit/home-melcloud-atw-device.test.ts
@@ -2,7 +2,6 @@ import type * as Home from '@olivierzal/melcloud-api/home'
 import type HomeyModule from 'homey'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { InteropModule } from '../helpers.ts'
 import { HomeEnergyReportAtw } from '../../drivers/home-report-atw.mts'
 import { NotFoundError } from '../../lib/errors.mts'
 import { homeTagMappingsAtw } from '../../types/home-atw.mts'
@@ -10,6 +9,7 @@ import {
   testEnergyReportConfig,
   testThermostatMode,
 } from '../device-descriptors.ts'
+import { type InteropModule, mock } from '../helpers.ts'
 import HomeMELCloudDeviceAtw from '../../drivers/home-melcloud_atw/device.mts'
 import { createInstance } from './create-test-instance.ts'
 
@@ -86,7 +86,7 @@ vi.mock(import('homey'), async () => {
 const mockFacade = (
   overrides: Partial<Record<keyof Home.DeviceAtwFacade, unknown>> = {},
 ): Home.DeviceAtwFacade =>
-  ({
+  mock<Home.DeviceAtwFacade>({
     capabilities: {
       hasHotWater: true,
       hasZone2: true,
@@ -115,7 +115,7 @@ const mockFacade = (
     tankWaterTemperature: 48,
     updateValues: vi.fn<() => Promise<void>>().mockResolvedValue(),
     ...overrides,
-  }) as unknown as Home.DeviceAtwFacade
+  })
 
 const defineEnergyContext = (
   device: object,


### PR DESCRIPTION
## What

Halves the double assertions in `tests/` — **18 → 9** — by routing mock construction through the typed `mock<T>()` factory this repo already has, and by typing one set of fixtures as what it really is. No `as unknown as` added, no `never`, no disable.

Companion: OlivierZal/com.heatzy#1055 (the `dirty-gate` twin, one import line apart).

## Why — measured, not asserted

This PR opened as "adopt the `cast` helper", the last open audit item. Two rounds of measurement replaced it with something better.

Three candidate forms, two mutations, real `typecheck` runs:

| mutation | `as unknown as T` | `cast(...)` | `mock<T>({...})` |
|---|---|---|---|
| a key absent from the target type | not caught | not caught | **TS2353** |
| a wrong declared return type | **TS2322** | not caught | **TS2322** |

So the two forms I had been comparing were **both hacks**, and the repo already owned the non-hack answer. `mock<T>(overrides: Partial<Record<keyof T, unknown>>): T` keeps the assignability check *and* adds key checking. `cast` is the weakest of the three — it stays out of this repo, and out of com.heatzy.

## Converted

- **The two facade builders** — their assertions merely restated the type written on their own signature.
- **The `BuildingZone[]` literal** — now one typed mock per element.
- **The `dirty-gate` button doubles** — mirrored in com.heatzy.
- **`TotalCoolingConsumed: undefined`** — needed no assertion at all; `mock`'s parameter is already `Partial<Record<keyof T, unknown>>`.

## The interesting one: the COP tag mappings

The factory **rejected** them — `measure_power.cop` is a key no device declares (the real ones are `meter_power.cop*`, and they live on ATW while this test types itself as ATA).

That is deliberate, not a bug: `cleanMapping` is mocked to hand the COP arithmetic that exact key, so the mappings are synthetic and the name is opaque to the code under test. The 29 tests exercise the arithmetic, not the capability.

But the old form claimed they were `EnergyCapabilityTagMapping`, and needed an assertion to make that lie compile. They are now typed `SyntheticTagMapping = Readonly<Record<string, readonly string[]>>`, which says what they are. Same behaviour, honest type, zero assertions left in that file.

## What remains, and why it is honest

The 9 survivors are two categories where no non-assertion form exists:

- **Constructor re-typing** (`create-test-instance.ts`, `mock-device-class.ts`): `new` on an abstract constructor is forbidden by design. `mock-device-class.ts` additionally *cannot* import from `helpers.ts` — `helpers.ts` re-exports from it.
- **Test seams** (`device-descriptors.ts`, `classic-device.test.ts` ×2, `melcloud-atw-device.test.ts`, `home-base-device.test.ts`, `home-base-device-test-device.ts` ×2): these re-type an **existing** instance to reach an internal member. No double is being built, so no factory applies, and the inline shape documents exactly what the test reaches into.

## Checklist

- [x] `npm run format` / `lint` / `typecheck` pass
- [x] `npm run test:coverage` passes (100%)
- [x] `npm run homey:validate` passes at `publish` level

Tests only, no source change.