### PR TITLE
refactor: lift syncFromDevice into the base device class

### DIFF
--- a/drivers/base-device.mts
+++ b/drivers/base-device.mts
@@ -1,4 +1,9 @@
-import { isAPIError, NoChangesError } from '@olivierzal/melcloud-api'
+import {
+  type AvailabilityAware,
+  EntityNotFoundError,
+  isAPIError,
+  NoChangesError,
+} from '@olivierzal/melcloud-api'
 import { Temporal } from 'temporal-polyfill'
 
 import type { CapabilityConverter } from '../types/capabilities.mts'
@@ -40,7 +45,8 @@ const modes: EnergyReportMode[] = ['regular', 'total']
 const STATUS_INDICATOR_SETTING = 'custom_status_indicator'
 
 export abstract class BaseMELCloudDevice<
-  TFacade extends ClassicDeviceFacade = ClassicDeviceFacade,
+  TFacade extends AvailabilityAware & ClassicDeviceFacade = AvailabilityAware &
+    ClassicDeviceFacade,
   TId extends number | string = number | string,
 > extends Device {
   declare public readonly driver: BaseMELCloudDriver
@@ -54,6 +60,11 @@ export abstract class BaseMELCloudDevice<
   protected abstract readonly capabilityToDevice: Partial<
     Record<string, CapabilityConverter>
   >
+
+  // The message a stale unit shows: the two dialects word it differently
+  // ('unitStale' reads a last-communication timestamp, 'unitOffline' a
+  // disconnection streak) even though they answer the same contract.
+  protected abstract readonly unreachableWarning: string
 
   public get id(): TId {
     return this.getData().id
@@ -161,7 +172,8 @@ export abstract class BaseMELCloudDevice<
 
   protected abstract getRequiredCapabilities(): string[]
 
-  public abstract syncFromDevice(): Promise<void>
+  // Where the dialects genuinely differ: each reads its own payload shape.
+  protected abstract syncCapabilityValues(facade: TFacade): Promise<void>
 
   public override async addCapability(capability: string): Promise<void> {
     if (!this.hasCapability(capability)) {
@@ -243,6 +255,35 @@ export abstract class BaseMELCloudDevice<
       await super.setWarning(getErrorMessage(error))
     }
     await super.setWarning(null)
+  }
+
+  // One skeleton for both dialects, which the facades' neutral
+  // `isAvailable` contract makes possible: before it, Classic read a raw
+  // `Offline` flag and Home a disconnection streak, so each intermediate
+  // class carried its own copy of this method — identical but for the
+  // warning key and the payload read, and each commented "mirrors the
+  // other contract". The contract is pinned in melcloud-api's
+  // tests/contracts/is-available.test.ts.
+  public async syncFromDevice(): Promise<void> {
+    const device = await this.ensureDevice()
+    if (device === null) {
+      return
+    }
+    try {
+      await this.syncAvailability(
+        device.isAvailable,
+        this.homey.__(this.unreachableWarning),
+      )
+      await this.syncCapabilityValues(device)
+    } catch (error) {
+      if (!(error instanceof EntityNotFoundError)) {
+        throw error
+      }
+      // A cached facade over a pruned id (the registry rebuilds on logout)
+      // warns and keeps the last known availability; the next sync after
+      // re-login resolves the fresh model transparently.
+      await this.setWarning(this.homey.__('errors.deviceNotFound'))
+    }
   }
 
   protected async applyCapabilitiesOptions(): Promise<void> {

--- a/drivers/classic-device.mts
+++ b/drivers/classic-device.mts
@@ -1,5 +1,4 @@
 import type * as Classic from '@olivierzal/melcloud-api/classic'
-import { EntityNotFoundError } from '@olivierzal/melcloud-api'
 
 import type {
   Capabilities,
@@ -63,35 +62,15 @@ export abstract class ClassicMELCloudDevice<
     Record<keyof OperationalCapabilities<T>, ConvertFromDevice<T>>
   >
 
+  // A stale unit is one whose last-communication timestamp has aged out.
+  protected override readonly unreachableWarning = 'errors.unitStale'
+
   protected get facade(): Classic.DeviceFacade<T> | undefined {
     return this.cachedFacade
   }
 
   get #data(): Readonly<Classic.ListDeviceData<T>> | undefined {
     return this.facade?.data
-  }
-
-  public override async syncFromDevice(): Promise<void> {
-    const device = await this.ensureDevice()
-    if (device === null) {
-      return
-    }
-    try {
-      await this.syncAvailability(
-        device.isAvailable,
-        this.homey.__('errors.unitStale'),
-      )
-      await this.setCapabilityValues(device.data)
-    } catch (error) {
-      if (!(error instanceof EntityNotFoundError)) {
-        throw error
-      }
-      // Mirrors the Home contract: a cached facade over a pruned id (the
-      // registry rebuilds on logout) warns and keeps the last known
-      // availability; the next sync after re-login resolves the fresh
-      // model transparently.
-      await this.setWarning(this.homey.__('errors.deviceNotFound'))
-    }
   }
 
   protected override readonly createEnergyReport = (
@@ -131,6 +110,12 @@ export abstract class ClassicMELCloudDevice<
         }
       }),
     )
+  }
+
+  protected override async syncCapabilityValues(
+    facade: Classic.DeviceFacade<T>,
+  ): Promise<void> {
+    await this.setCapabilityValues(facade.data)
   }
 
   #convertFromDevice<TKey extends keyof Capabilities<T>>(

--- a/drivers/home-device.mts
+++ b/drivers/home-device.mts
@@ -1,5 +1,4 @@
 import type * as Home from '@olivierzal/melcloud-api/home'
-import { EntityNotFoundError } from '@olivierzal/melcloud-api'
 
 import type {
   HomeConvertFromDevice,
@@ -30,28 +29,9 @@ export abstract class HomeMELCloudDevice<
     Record<string, HomeConvertFromDevice<T>>
   >
 
-  public override async syncFromDevice(): Promise<void> {
-    const device = await this.ensureDevice()
-    if (device === null) {
-      return
-    }
-    try {
-      await this.syncAvailability(
-        device.isAvailable,
-        this.homey.__('errors.unitOffline'),
-      )
-      await this.#setCapabilityValues(device)
-    } catch (error) {
-      if (!(error instanceof EntityNotFoundError)) {
-        throw error
-      }
-      // Mirrors the Classic contract: a cached facade over a pruned id
-      // (the registry rebuilds on logout) warns and keeps the last known
-      // availability; the next sync after re-login resolves the fresh
-      // model transparently.
-      await this.setWarning(this.homey.__('errors.deviceNotFound'))
-    }
-  }
+  // An offline unit is one whose disconnection streak has passed the
+  // stale window.
+  protected override readonly unreachableWarning = 'errors.unitOffline'
 
   protected override getCapabilitiesOptions(): Partial<
     Record<string, unknown>
@@ -73,7 +53,9 @@ export abstract class HomeMELCloudDevice<
       : this.driver.getRequiredCapabilities(facade)
   }
 
-  async #setCapabilityValues(device: HomeDeviceFacade<T>): Promise<void> {
+  protected override async syncCapabilityValues(
+    device: HomeDeviceFacade<T>,
+  ): Promise<void> {
     await Promise.all(
       typedEntries(this.deviceToCapability).map(
         async ([capability, convert]) => {


### PR DESCRIPTION
## What

`syncFromDevice` moves from both intermediate classes into `BaseMELCloudDevice`. Net −24 duplicated lines; the two subclasses keep only what actually differs.

## Why now — the neutral contract is what makes it possible

The two copies were identical line for line except for a warning key and which payload read follows. Their own comments admitted it:

```
// Mirrors the Home contract: a cached facade over a pruned id …
// Mirrors the Classic contract: a cached facade over a pruned id …
```

That duplication was not laziness — it predated the contract. Classic used to read a raw `Offline` flag (which flaps on healthy units, #1479/#1481) and Home a disconnection streak, so neither class could speak for the other. melcloud-api's neutral `isAvailable` contract removed the difference and pinned it in `tests/contracts/is-available.test.ts`, so one skeleton now serves both.

**This is the concrete answer to "did the mutualised contracts simplify com.melcloud?"** — until now they had not: the app consumed the neutral types (`ProtectionState`, `HolidayModeState`, `isAvailable`) without collapsing the duplication they enabled. This collapses it.

## Shape

The base owns the method and declares two hooks for what genuinely differs:

- `unreachableWarning` — the locale key. Classic ages out a last-communication timestamp (`errors.unitStale`), Home a disconnection streak (`errors.unitOffline`). Same contract, different wording, and the comments now say which is which.
- `syncCapabilityValues(facade)` — each dialect reads its own payload shape (`facade.data` vs the facade itself).

The generic constraint gains `AvailabilityAware`, **the library's own name for the contract** (`{ readonly isAvailable: boolean }`, exported from `@olivierzal/melcloud-api`). That is what makes the lift type-safe instead of assumed: the app-side `ClassicDeviceFacade` interface only declares `updateValues`, so before this the base had no type-level guarantee that a facade answers availability at all.

## Verification

Behaviour-preserving, and mutation-verified rather than asserted:

| mutation | result |
|---|---|
| invert the availability sense (`!device.isAvailable`) | **3 tests fail** |
| swap the two dialects' warning keys | **1 test fails** |

One detail worth flagging: the subclasses caught `EntityNotFoundError` (from melcloud-api), not the app's own `NotFoundError`. I wrote the latter first; using it would have been a silent behaviour change, since the base catches `NotFoundError` elsewhere for a different purpose. The lifted method keeps `EntityNotFoundError`.

## Checklist

- [x] `npm run format` / `lint` / `typecheck` pass
- [x] `npm run test:coverage` passes — 709 tests, 100%
- [x] `npm run homey:validate` passes at `publish` level