### PR TITLE
refactor: derive the day-chart window once

### DIFF
--- a/app.mts
+++ b/app.mts
@@ -556,11 +556,10 @@ export default class MELCloudApp extends App {
     days: number
     deviceId: string
   }): Promise<ReportChartLineOptions> {
-    const from = chartDaysStart(days, getTimeZone(this.homey))
     return unwrapResult(
-      await this.getClassicFacade('devices', deviceId).getEnergyReport({
-        from,
-      }),
+      await this.getClassicFacade('devices', deviceId).getEnergyReport(
+        this.#chartDaysQuery(days),
+      ),
     )
   }
 
@@ -630,11 +629,10 @@ export default class MELCloudApp extends App {
     days: number
     deviceId: string
   }): Promise<ReportChartPieOptions> {
-    const from = chartDaysStart(days, getTimeZone(this.homey))
     return unwrapResult(
-      await this.getClassicFacade('devices', deviceId).getOperationModes({
-        from,
-      }),
+      await this.getClassicFacade('devices', deviceId).getOperationModes(
+        this.#chartDaysQuery(days),
+      ),
     )
   }
 
@@ -665,11 +663,10 @@ export default class MELCloudApp extends App {
     days: number
     deviceId: string
   }): Promise<ReportChartLineOptions> {
-    const from = chartDaysStart(days, getTimeZone(this.homey))
     return unwrapResult(
-      await this.getClassicFacade('devices', deviceId).getTemperatures({
-        from,
-      }),
+      await this.getClassicFacade('devices', deviceId).getTemperatures(
+        this.#chartDaysQuery(days),
+      ),
     )
   }
 
@@ -874,9 +871,10 @@ export default class MELCloudApp extends App {
     days: number
     deviceId: string
   }): Promise<ReportChartLineOptions> {
-    const from = chartDaysStart(days, getTimeZone(this.homey))
     return unwrapResult(
-      await this.#getHomeDeviceFacade(deviceId).getEnergyReport({ from }),
+      await this.#getHomeDeviceFacade(deviceId).getEnergyReport(
+        this.#chartDaysQuery(days),
+      ),
     )
   }
 
@@ -930,10 +928,9 @@ export default class MELCloudApp extends App {
     days: number
     deviceId: string
   }): Promise<ReportChartPieOptions> {
-    const from = chartDaysStart(days, getTimeZone(this.homey))
     return unwrapResult(
       await this.getHomeFacade(deviceId, Home.DeviceType.Atw).getOperationModes(
-        { from },
+        this.#chartDaysQuery(days),
       ),
     )
   }
@@ -974,9 +971,10 @@ export default class MELCloudApp extends App {
     days: number
     deviceId: string
   }): Promise<ReportChartLineOptions> {
-    const from = chartDaysStart(days, getTimeZone(this.homey))
     return unwrapResult(
-      await this.#getHomeDeviceFacade(deviceId).getTemperatures({ from }),
+      await this.#getHomeDeviceFacade(deviceId).getTemperatures(
+        this.#chartDaysQuery(days),
+      ),
     )
   }
 
@@ -1148,6 +1146,16 @@ export default class MELCloudApp extends App {
     if (this.#sessionLossStates.get(api) === 'pending') {
       this.#sessionLossStates.set(api, 'shown')
     }
+  }
+
+  // Type-agnostic device facade lookup for the chart surfaces shared by
+  // both Home device types (temperatures, signal, energy report).
+  // The day-chart query every dialect's report reads. Derived once: the
+  // window anchor and the timezone source must not drift between the six
+  // call sites, which the facades' shared `(query?: ReportQuery)` contract
+  // lets us state in a single place.
+  #chartDaysQuery(days: number): { from: string } {
+    return { from: chartDaysStart(days, getTimeZone(this.homey)) }
   }
 
   async #classicSyncDevices(
@@ -1363,8 +1371,6 @@ export default class MELCloudApp extends App {
     }))
   }
 
-  // Type-agnostic device facade lookup for the chart surfaces shared by
-  // both Home device types (temperatures, signal, energy report).
   #getHomeDeviceFacade(
     deviceId: string,
   ): Home.DeviceAtaFacade | Home.DeviceAtwFacade {

--- a/tests/unit/app.test.ts
+++ b/tests/unit/app.test.ts
@@ -2014,6 +2014,12 @@ describe('melCloudApp', () => {
         expect(getEnergyReport).toHaveBeenCalledWith({
           from: '2026-07-18T00:00:00',
         })
+        // The anchor must come from Homey's clock, not a hardcoded zone:
+        // the mocked `Temporal.Now` ignores its argument, so without this
+        // the timezone source is unpinned.
+        expect(Temporal.Now.zonedDateTimeISO).toHaveBeenCalledWith(
+          'Europe/Paris',
+        )
       } finally {
         vi.mocked(Temporal.Now.zonedDateTimeISO).mockRestore()
       }


### PR DESCRIPTION
## What

Six report methods on the app — `getEnergyReport`, `getOperationModes`, `getTemperatures`, once per dialect — each opened with the same line:

```ts
const from = chartDaysStart(days, getTimeZone(this.homey))
```

They now share `#chartDaysQuery(days)`.

Second in a pair with #1505: both answer *"did the mutualised API contracts simplify com.melcloud?"* by collapsing duplication the contracts had already made collapsible.

## Why the neutral contract is what allows it

`getEnergyReport`, `getTemperatures` and `getOperationModes` carry **one signature across all four facade families** — `(query?: ReportQuery) => Promise<Result<ReportChart*Options>>`, verified in `classic-base-device.ts`, `classic-device-atw.ts`, `home-device-ata.ts`, `home-device-atw.ts`. Because the query type is dialect-neutral, one builder serves all six call sites.

## The real finding: the derivation was unpinned

The line count barely moves (26 insertions, 20 deletions). The value is the drift risk, and measuring it turned up something worse than duplication:

**Mutating the shared helper's timezone to a hardcoded `'UTC'` passed all 709 tests.**

The chart tests mock `Temporal.Now.zonedDateTimeISO` with a fixed `ZonedDateTime`, so the mock ignores the timezone argument entirely. Coverage was 100% — the line executed, its input was simply never asserted. Six unpinned copies of a derivation is strictly worse than one, since a drift in any single copy had nothing to catch it.

So the window test now also pins the source:

```ts
expect(Temporal.Now.zonedDateTimeISO).toHaveBeenCalledWith('Europe/Paris')
```

With that one line the `'UTC'` mutation **fails**. That is what makes this refactor verified rather than merely typechecked.

## What I checked and left alone

- **The two hour-based pairs** (`getHourlyTemperatures`, `getSignalStrength`) are already one-liners — `unwrapResult(await facade.method(hour))`. Nothing to factor.
- **The report classes** are already properly factored: `ScheduledEnergyReport` owns the schedule and exposes exactly two hooks (`fetchAndApply`, `hasEnabledCapabilities`). No duplication between `classic-report.mts` and `home-report.mts` to collapse.
- **No callback-taking helper.** Passing a reader lambda per site would have folded the `unwrapResult` too, at the cost of indirection at six call sites. Extracting only the part that must not diverge keeps every site a direct, readable call.

## Checklist

- [x] `npm run format` / `lint` / `typecheck` pass
- [x] `npm run test:coverage` passes — 709 tests, 100%
- [x] `npm run homey:validate` passes at `publish` level