### PR TITLE
refactor: stop exporting three file-local types

### DIFF
--- a/drivers/home-report.mts
+++ b/drivers/home-report.mts
@@ -36,6 +36,27 @@ const WIRE_TIME_SECONDS_LENGTH = 19
 
 type EnergyEntry = readonly [string, readonly HomeEnergyMeasureName[]]
 
+interface HomeEnergyQuery {
+  readonly from: string
+  readonly measure: HomeEnergyMeasureName
+  readonly to: string
+}
+
+// Per-type telemetry dialect: how to fetch a measure's points, convert wire
+// sums to kWh, and derive an instantaneous power reading. Injected by the
+// concrete reports so the engine stays type-agnostic.
+interface HomeEnergyStrategy<T extends Home.DeviceType> {
+  readonly fetchPoints: (
+    facade: HomeDeviceFacade<T>,
+    query: HomeEnergyQuery,
+  ) => Promise<EnergyPoint[]>
+  readonly kilowattHours: (wireSum: number) => number
+  readonly watts: (
+    points: readonly EnergyPoint[],
+    now: Temporal.Instant,
+  ) => number
+}
+
 type MeasurePoints = Partial<
   Record<HomeEnergyMeasureName, readonly EnergyPoint[]>
 >
@@ -48,27 +69,6 @@ interface RegularBoundaries {
 export interface EnergyPoint {
   readonly instant: Temporal.Instant
   readonly value: number
-}
-
-export interface HomeEnergyQuery {
-  readonly from: string
-  readonly measure: HomeEnergyMeasureName
-  readonly to: string
-}
-
-// Per-type telemetry dialect: how to fetch a measure's points, convert wire
-// sums to kWh, and derive an instantaneous power reading. Injected by the
-// concrete reports so the engine stays type-agnostic.
-export interface HomeEnergyStrategy<T extends Home.DeviceType> {
-  readonly fetchPoints: (
-    facade: HomeDeviceFacade<T>,
-    query: HomeEnergyQuery,
-  ) => Promise<EnergyPoint[]>
-  readonly kilowattHours: (wireSum: number) => number
-  readonly watts: (
-    points: readonly EnergyPoint[],
-    now: Temporal.Instant,
-  ) => number
 }
 
 const cursorKey = (measure: HomeEnergyMeasureName): string =>

--- a/types/home-atw.mts
+++ b/types/home-atw.mts
@@ -77,6 +77,16 @@ export const homeTagMappingsAtw: {
   set: homeSetCapabilityTagMappingAtw,
 }
 
+interface HomeCapabilitiesOptionsAtw {
+  readonly thermostat_mode: {
+    readonly values: readonly CapabilitiesOptionsValues<Home.AtwZoneMode>[]
+  }
+  readonly 'thermostat_mode.zone2': {
+    readonly title: LocalizedStrings
+    readonly values: readonly CapabilitiesOptionsValues<Home.AtwZoneMode>[]
+  }
+}
+
 /**
  * Structural slice of {@link Home.DeviceAtwFacade} driving which capabilities
  * a Home ATW device gets and their options. Satisfied by the facade itself;
@@ -89,16 +99,6 @@ export type HomeAtwDeviceProfile = Pick<
   Home.DeviceAtwFacade,
   'capabilities' | 'hasCoolingMode'
 >
-
-export interface HomeCapabilitiesOptionsAtw {
-  readonly thermostat_mode: {
-    readonly values: readonly CapabilitiesOptionsValues<Home.AtwZoneMode>[]
-  }
-  readonly 'thermostat_mode.zone2': {
-    readonly title: LocalizedStrings
-    readonly values: readonly CapabilitiesOptionsValues<Home.AtwZoneMode>[]
-  }
-}
 
 // Only complete option objects, and only for capabilities the device will
 // actually have: device-level options shadow the manifest's per capability


### PR DESCRIPTION
## What

`HomeCapabilitiesOptionsAtw`, `HomeEnergyQuery` and `HomeEnergyStrategy` are no longer exported. They keep their declarations — only the keyword goes.

## Why

Each is used **only inside its declaring file**:

| type | sole use |
|---|---|
| `HomeCapabilitiesOptionsAtw` | return type of a function in `types/home-atw.mts` |
| `HomeEnergyQuery` | parameter type inside `HomeEnergyStrategy` |
| `HomeEnergyStrategy` | a field and the `protected` constructor of `HomeEnergyReport` |

`HomeEnergyStrategy` reaches the outside only through a **protected** constructor, so no consumer could name it in the first place.

## Method

Found by scanning every `export`ed symbol in `**/*.mts` and keeping those nothing outside their declaring file mentions. That method matters: a barrel re-export or a sibling import counts as a reference, so what survives really is unreferenced.

## What the scan flagged and I kept

`public/dirty-gate.mts`'s `DirtyGateOptions`. That file is **byte-identical** with `settings/dirty-gate.mts` in com.heatzy and com.melcloud.extension — verified with `diff` — and CLAUDE.md mandates the three be edited together. An export unused *here* is used *there*; touching it would break the invariant for nothing.

Companion sweeps: OlivierZal/com.heatzy#1056 (two genuinely dead types from the 23.0.0 rewrite), OlivierZal/melcloud-api#1659 (a type that was dead *and* described a shape the wire does not use), OlivierZal/heatzy-api#1160. com.melcloud.extension needed nothing — all five of its flagged exports were shared-kernel.

## Checklist

- [x] `npm run format` / `lint` / `typecheck` pass
- [x] `npm run test:coverage` passes (100%)
- [x] `npm run homey:validate` passes at `publish` level