### PR TITLE
build: typecheck the config files

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'eslint/config'
+import { type Config, defineConfig } from 'eslint/config'
 import { flatConfigs as importXConfigs } from 'eslint-plugin-import-x'
 import { jsdoc } from 'eslint-plugin-jsdoc'
 import { configs as packageJsonConfigs } from 'eslint-plugin-package-json'
@@ -49,7 +49,7 @@ const typeLikeSortOptions = {
   ],
 }
 
-const config = defineConfig([
+const config: Config[] = defineConfig([
   {
     ignores: [
       '.homeybuild/',
@@ -79,9 +79,7 @@ const config = defineConfig([
     files: ['**/*.{ts,mts}'],
     languageOptions: {
       parserOptions: {
-        projectService: {
-          allowDefaultProject: ['*.config.ts'],
-        },
+        projectService: true,
         warnOnUnsupportedTypeScriptVersion: false,
       },
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "eslint-config-prettier": "^10.1.8",
         "eslint-import-resolver-typescript": "^4.4.5",
         "eslint-plugin-import-x": "^4.17.0",
-        "eslint-plugin-jsdoc": "^63.2.2",
+        "eslint-plugin-jsdoc": "^63.3.3",
         "eslint-plugin-package-json": "^1.6.1",
         "eslint-plugin-perfectionist": "^5.10.0",
         "eslint-plugin-unicorn": "^72.0.0",
@@ -155,9 +155,9 @@
       }
     },
     "node_modules/@es-joy/jsdoccomment": {
-      "version": "0.90.0",
-      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.90.0.tgz",
-      "integrity": "sha512-51x9KxyTAN6guZOCd+lmcDdkhgdMdP/6iMMtg9dyhCWDc3+iSUyoB7f/9WAM/yGHmGFq25Vd6bXRR7CZcB+tog==",
+      "version": "0.91.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.91.0.tgz",
+      "integrity": "sha512-vgqlMGNNhZxwDYbUNIHj3Hskb4R28iqdXx90ufHyt/NeuTQkeqjTDslAs9I0/GCAfbxP5BpH5WsL1R1fht5Lxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -165,7 +165,7 @@
         "@typescript-eslint/types": "^8.65.0",
         "comment-parser": "1.4.7",
         "esquery": "^1.7.0",
-        "jsdoc-type-pratt-parser": "~7.3.0"
+        "jsdoc-type-pratt-parser": "~8.0.0"
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
@@ -1563,9 +1563,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -1583,9 +1580,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -1603,9 +1597,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -1623,9 +1614,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -1643,9 +1631,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -1663,9 +1648,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3757,13 +3739,13 @@
       }
     },
     "node_modules/eslint-plugin-jsdoc": {
-      "version": "63.2.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-63.2.2.tgz",
-      "integrity": "sha512-xCoHKeaRwAhZ+i2ZUY11few2Lmy9qpJLDsY139c4KNJLMSZYoFJ5UMYkDjdTkO9PfkFOKmVO+7i4Yjx+x7VQWQ==",
+      "version": "63.3.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-63.3.3.tgz",
+      "integrity": "sha512-xI4IeVRzRFA2DGHrPLIxF3U+oJHU3FE+P9Zb27fVs5dPHgfcpoAs0PyCbznVhK7pwR+9BPUztFeXSgpw/CL4Yg==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@es-joy/jsdoccomment": "~0.90.0",
+        "@es-joy/jsdoccomment": "~0.91.0",
         "@es-joy/resolve.exports": "1.2.0",
         "are-docs-informative": "^0.0.2",
         "comment-parser": "1.4.7",
@@ -4676,9 +4658,9 @@
       "license": "MIT"
     },
     "node_modules/jsdoc-type-pratt-parser": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-7.3.0.tgz",
-      "integrity": "sha512-DoyJXo7x/n48M3NsGOs9QnEws0ft0tV3YsSgvWMNxz2hZtz+Q6fpqUD96lVYX4a+jcEkzHeFNDJOn68TzXfbdA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-8.0.0.tgz",
+      "integrity": "sha512-uQu/fXVqVaMg6gM8/E5G5+eygVcZ1NV0Z51CvqhNa2bDWxvHMl484ETr6vph4oPyC+KUcbP/w2W2pewfCiR9aQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-import-resolver-typescript": "^4.4.5",
     "eslint-plugin-import-x": "^4.17.0",
-    "eslint-plugin-jsdoc": "^63.2.2",
+    "eslint-plugin-jsdoc": "^63.3.3",
     "eslint-plugin-package-json": "^1.6.1",
     "eslint-plugin-perfectionist": "^5.10.0",
     "eslint-plugin-unicorn": "^72.0.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,5 @@
     "target": "es2025",
     "types": ["node"],
     "verbatimModuleSyntax": true
-  },
-  "exclude": ["*.config.ts"]
+  }
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vitest/config'
+import { type ViteUserConfig, defineConfig } from 'vitest/config'
 import swc from 'unplugin-swc'
 
 const swcPlugin = swc.vite({
@@ -14,7 +14,7 @@ const swcPlugin = swc.vite({
   },
 })
 
-const config = defineConfig({
+const config: ViteUserConfig = defineConfig({
   test: {
     coverage: {
       exclude: ['**/public/**/*.mts', 'settings/**/*.mts'],


### PR DESCRIPTION
## What

Makes `npm run typecheck` cover the three root config files (`eslint.config.ts`, `prettier.config.ts`, `vitest.config.ts`), which no project included until now.

- `tsconfig.json`: the config files enter the project (apps: drop `exclude: ["*.config.ts"]`; libraries: add `"*.config.ts"` to `include`).
- `eslint.config.ts` / `vitest.config.ts`: explicit type annotations on the exported config, which `isolatedDeclarations` requires — the same idiom `prettier.config.ts` already used (`const config: Config = …`).
- `eslint.config.ts`: `projectService.allowDefaultProject` drops to plain `projectService: true`.
- `eslint-plugin-jsdoc` → 63.3.3.

**`tsconfig.build.json` is untouched** — the configs must stay out of emission, and they do (verified: 0 config files in the build project).

## Why

An IDE reported a type error in `eslint.config.ts` that CI never saw. Root cause: the file was in no TypeScript project, so the editor opened it as an *inferred project* with its own options while `tsc` ignored it entirely.

Worth stating precisely, because I got it wrong at first: **the `exclude` entries in `tsconfig.build.json` are not typecheck exclusions, they are emission exclusions.** Measured with `tsc --noEmit --listFiles`: `tests`, `types`, `drivers`, `lib`, `widgets`, `public`, `settings` are all typechecked today. The only real gap was the root config files.

## The error was real, and upstream

`flat/recommended-tsdoc-error` exists at runtime but the `configs` record and the `jsdoc()` helper were typed as `` `flat/${ConfigGroups}${ConfigVariants}${ErrorLevelVariants}` ``, and `ConfigVariants` had no `-tsdoc`. Fixed upstream in [eslint-plugin-jsdoc 63.3.3](https://github.com/gajus/eslint-plugin-jsdoc/releases/tag/v63.3.3), hence the bump — without it, this PR would turn CI red.

## On dropping `allowDefaultProject`

Not a downgrade — it is what typescript-eslint asks for. Once a file is in the project, the parser errors outright:

> `eslint.config.ts was included by allowDefaultProject but also was found in the project service. Consider removing it from allowDefaultProject`

And the [docs](https://typescript-eslint.io/troubleshooting/typed-linting/) put it second: *"If possible, add the file to the closest `tsconfig.json`'s `include`"* — `allowDefaultProject` is the fallback for files you *cannot* add, capped at 8 and building a fresh TypeScript program per file.

Honest note: I measured lint wall-clock both ways and the difference is inside the noise (18.3–19.2 s either way). At three files the performance argument does not apply; the argument here is correctness.

## Verification

- Coverage is now real: `tsc --noEmit --listFiles | grep -c "config.ts$"` → **3** (was 0), and **0** under `tsconfig.build.json`.
- Mutation-tested rather than assumed: setting `branches: 'cent'` in `vitest.config.ts` now fails `typecheck` (TS2769) where it silently passed before.
- Full suite green.

## Checklist

- [x] `npm run format` / `lint` / `typecheck` pass
- [x] `npm run test:coverage` passes (100%)
- [x] `npm run homey:validate passes at publish level`