### PR TITLE
fix: close the build-script lint gap by making the scripts TypeScript

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,19 +17,19 @@ caught real failures that the others miss:
 - `npm run typecheck` — `tsc` from `@typescript/native` (TypeScript 7).
 - `npm test` / `npm run test:coverage` — vitest; branches are at 100%,
   keep them there.
-- `npm run build` — esbuild bundles (`scripts/bundle.mjs`) + `tsc`
+- `npm run build` — esbuild bundles (`scripts/bundle.mts`) + `tsc`
   emit, BOTH into `.homeybuild`. The Homey CLI runs `npm run build`
   when it detects TypeScript (`devDependencies.typescript`; it
   validates `outDir: .homeybuild`) — but only AFTER its pre-process
   copy into `.homeybuild`, so the source tree stays sources-only and
   everything the package needs must be emitted there: tsc does it via
-  `outDir`, and `bundle.mjs` emits the webview bundles there too (its
+  `outDir`, and `bundle.mts` emits the webview bundles there too (its
   former source-tree outfiles landed too late to be copied — the #1404
   root cause: every store install 404'd the bundles). The CLI's own
   build invocation is therefore sufficient for install, run, validate
   and publish alike; a standalone suite run (no `.homeybuild` page
   copies) still proves the bundles compile.
-- Cache-busting `?v=` — a PACKAGE-TIME transform: `bundle.mjs` stamps
+- Cache-busting `?v=` — a PACKAGE-TIME transform: `bundle.mts` stamps
   every local asset reference of the `.homeybuild` page copies with a
   content hash (`?v=<hash>`), so phone webviews (which cache assets
   across app versions) refetch an asset exactly when its bytes change.
@@ -40,7 +40,7 @@ caught real failures that the others miss:
   never comments.
 - `npm run homey:validate` — Homey validation at publish level; may
   rewrite files (see locales below), re-stage if it does.
-- `node scripts/sync-capability-definitions.mjs` — refreshes the
+- `node scripts/sync-capability-definitions.mts` — refreshes the
   vendored node-homey-lib capability JSONs under `vendor/capabilities/`
   (homey-lib is a devDependency and must not ship to the device); the
   drift test in `tests/unit/capability-definitions.test.ts` fails when
@@ -206,7 +206,7 @@ coverage.
   for two distinct phases (no overlap): the `onHomeyReady` poll's 10 s
   timeout ends it if the bundle never loads (`#init_error` / post-ready
   alert), and `runWebview`/`withInitTimeout` end it if a DATA fetch hangs
-  during init (`Homey.ready()` in a `finally`). `scripts/bundle.mjs`
+  during init (`Homey.ready()` in a `finally`). `scripts/bundle.mts`
   stamps the PACKAGED `.homeybuild` page copies — only inside an
   attribute/import context, never a comment — with a content hash
   (`?v=`): phone webviews cache assets across app versions; the source
@@ -227,7 +227,7 @@ coverage.
   (proven in the wild: a cached dynamic-import-era HTML requested
   `index.mjs?v=…` against a 45.2.6 app shipping only `index.js` → 404 →
   "Loading failed"), so shipped bundle filenames are a COMPAT CONTRACT:
-  `scripts/bundle.mjs` builds every entry twice — `index.js` (IIFE) for
+  `scripts/bundle.mts` builds every entry twice — `index.js` (IIFE) for
   the current HTML, `index.mjs` (ESM) for every cached ESM-era HTML,
   which is why the entries keep `export const start`. Never rename or
   drop a shipped bundle filename; add alongside. When a bundle still

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ npm run homey:start  # run the app on your Homey (remote)
 
 Architecture notes:
 
-- Browser code (both widgets' `public/` and the `settings/` page) is bundled by `scripts/bundle.mjs` into one self-contained `index.mjs` per entry; the outputs are gitignored and rebuilt by `npm run build`, which the Homey CLI runs automatically on validate/publish. Shared helpers live in `public/` and are imported directly by widgets and settings.
+- Browser code (both widgets' `public/` and the `settings/` page) is bundled by `scripts/bundle.mts` into one self-contained `index.mjs` per entry; the outputs are gitignored and rebuilt by `npm run build`, which the Homey CLI runs automatically on validate/publish. Shared helpers live in `public/` and are imported directly by widgets and settings.
 - Both the build and `npm run typecheck` use the native TypeScript 7 compiler (`typescript@7` aliased as `@typescript/native`) for speed; `typescript@6` remains alongside it for tools that need the JS API (typescript-eslint) until TypeScript 7.1 ships its stable programmatic API.
 - Test coverage is enforced at 100% for backend code; browser glue (`public/`, `settings/`, widget `public/`) is excluded from coverage, so the badge covers drivers, app and API layers only.
 

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -429,7 +429,12 @@ const config: Config[] = defineConfig([
           bundledDependencies: false,
           // Widget sources are bundled by esbuild, so their imports may
           // live in devDependencies.
-          devDependencies: ['*.config.ts', 'tests/**', 'widgets/**'],
+          devDependencies: [
+            '*.config.ts',
+            'scripts/**',
+            'tests/**',
+            'widgets/**',
+          ],
           optionalDependencies: false,
           peerDependencies: false,
         },
@@ -1003,7 +1008,7 @@ const config: Config[] = defineConfig([
       'unicorn/no-invalid-file-input-accept': 'error',
       // The referenced module bundles are gitignored build outputs (CI
       // lints without building); their existence is guaranteed harder by
-      // scripts/bundle.mjs, which hashes every local reference and
+      // scripts/bundle.mts, which hashes every local reference and
       // throws when one is missing.
       'unicorn/no-missing-local-resource': 'off',
       'unicorn/text-encoding-identifier-case': 'error',
@@ -1225,7 +1230,11 @@ const config: Config[] = defineConfig([
     },
   },
   {
+    // Scoped: without `files`, this block applied to every file, which
+    // made it the only one reaching `**/*.mjs` — and leaked 28 inert
+    // `yml/*` rules onto every `.mts` as well.
     extends: [ymlConfigs.standard, ymlConfigs.prettier],
+    files: ['**/*.{yaml,yml}'],
     rules: {
       'yml/file-extension': [
         'error',

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "type": "module",
   "scripts": {
     "build": "npm run build:assets && node ./node_modules/@typescript/native/bin/tsc --project tsconfig.build.json",
-    "build:assets": "node scripts/bundle.mjs",
+    "build:assets": "node scripts/bundle.mts",
     "format": "prettier . --check",
     "format:fix": "prettier . --write",
     "github:push": "npm run homey:validate && npm run lint:fix && npm run format:fix && git push",

--- a/scripts/bundle.mts
+++ b/scripts/bundle.mts
@@ -10,7 +10,7 @@ import { createHash } from 'node:crypto'
 import { readFile, rm, writeFile } from 'node:fs/promises'
 import path from 'node:path'
 
-import { build } from 'esbuild'
+import { type BuildOptions, build } from 'esbuild'
 
 // The IIFE global each page's inline `onHomeyReady` reads `start` from.
 const GLOBAL_NAME = 'MELCloudWebview'
@@ -18,6 +18,8 @@ const GLOBAL_NAME = 'MELCloudWebview'
 // The Homey CLI's packaging target: `tsc` already emits here (its
 // validated `outDir`), and the CLI packs exactly this directory.
 const OUT_ROOT = '.homeybuild'
+
+const HASH_LENGTH = 8
 
 const entryPoints = [
   'widgets/ata-group-setting/public/index.mts',
@@ -31,7 +33,12 @@ const pages = [
   'widgets/charts/public/index.html',
 ]
 
-const sharedOptions = {
+// A local asset reference: an attribute value (href/src) or a dynamic
+// import specifier, with an optional existing stamp.
+const REFERENCE =
+  /(?<prefix>href="|src="|import\('\.\/)(?<file>[^"':?\/][^"':?]*)(?:\?v=[0-9a-f]+)?(?<suffix>["'\)])/gv
+
+const sharedOptions: BuildOptions = {
   bundle: true,
   legalComments: 'none',
   logLevel: 'info',
@@ -41,7 +48,7 @@ const sharedOptions = {
 
 await Promise.all(
   entryPoints.flatMap((entryPoint) => {
-    const outBase = path.join(OUT_ROOT, entryPoint.replace(/\.mts$/u, ''))
+    const outBase = path.join(OUT_ROOT, entryPoint.replace(/\.mts$/v, ''))
     return [
       build({
         ...sharedOptions,
@@ -64,7 +71,10 @@ await Promise.all(
 await Promise.all(
   entryPoints.flatMap((entryPoint) =>
     ['.js', '.mjs'].map(async (extension) =>
-      rm(entryPoint.replace(/\.mts$/u, extension), { force: true }),
+      rm(
+        entryPoint.replace(/\.mts$/v, () => extension),
+        { force: true },
+      ),
     ),
   ),
 )
@@ -76,36 +86,66 @@ await Promise.all(
 // CLI flow (its pre-process copy runs before `npm run build`) and is
 // absent in a standalone suite run, which only proves the bundles
 // compile.
-const hashOf = async (filePath) => {
+const hashOf = async (filePath: string): Promise<string> => {
   const content = await readFile(filePath)
-  return createHash('sha256').update(content).digest('hex').slice(0, 8)
+  return createHash('sha256')
+    .update(content)
+    .digest('hex')
+    .slice(0, HASH_LENGTH)
 }
 
-const stampHtml = async (htmlPath) => {
-  let html = ''
+const collectHashes = async (
+  html: string,
+  directory: string,
+): Promise<ReadonlyMap<string, string>> => {
+  const files = new Set<string>()
+  for (const match of html.matchAll(REFERENCE)) {
+    const { file = '' } = match.groups ?? {}
+    if (file !== '') {
+      files.add(file)
+    }
+  }
+  return new Map(
+    await Promise.all(
+      [...files].map(async (file): Promise<[string, string]> => [
+        file,
+        await hashOf(path.join(directory, file)),
+      ]),
+    ),
+  )
+}
+
+// Stamp only within a reference context, so the same filename written
+// elsewhere (e.g. a comment) is never rewritten. Rebuilt cursor-wise
+// rather than through a `replaceAll` callback, whose loosely typed rest
+// arguments cannot carry the named groups safely.
+const stampReferences = (
+  html: string,
+  hashes: ReadonlyMap<string, string>,
+): string => {
+  let stamped = ''
+  let cursor = 0
+  for (const match of html.matchAll(REFERENCE)) {
+    const { file = '', prefix = '', suffix = '' } = match.groups ?? {}
+    const hash = hashes.get(file) ?? ''
+    stamped += `${html.slice(cursor, match.index)}${prefix}${file}?v=${hash}${suffix}`
+    cursor = match.index + match[0].length
+  }
+  return stamped + html.slice(cursor)
+}
+
+const stampHtml = async (htmlPath: string): Promise<void> => {
+  let html: string
   try {
     html = await readFile(htmlPath, 'utf8')
   } catch {
+    // The page copy only exists in the CLI flow; a standalone suite run
+    // has nothing to stamp.
     return
   }
-  const directory = path.dirname(htmlPath)
-  // A local asset reference: an attribute value (href/src) or a dynamic
-  // import specifier, with an optional existing stamp.
-  const reference =
-    /(href="|src="|import\('\.\/)([^"':?/][^"':?]*)(?:\?v=[0-9a-f]+)?(["')])/gu
-  // Hash each referenced asset up front — the replace below is sync.
-  const hashes = new Map()
-  for (const [, , file] of html.matchAll(reference)) {
-    if (!hashes.has(file)) {
-      hashes.set(file, await hashOf(path.join(directory, file)))
-    }
-  }
-  // Stamp only within a reference context, so the same filename written
-  // elsewhere (e.g. a comment) is never rewritten.
-  const stamped = html.replaceAll(
-    reference,
-    (_match, prefix, file, suffix) =>
-      `${prefix}${file}?v=${hashes.get(file)}${suffix}`,
+  const stamped = stampReferences(
+    html,
+    await collectHashes(html, path.dirname(htmlPath)),
   )
   if (stamped !== html) {
     await writeFile(htmlPath, stamped)

--- a/scripts/sync-capability-definitions.mts
+++ b/scripts/sync-capability-definitions.mts
@@ -11,9 +11,11 @@ const CAPABILITIES = [
   'thermostat_mode',
 ]
 
-const sortKeysDeep = (value) => {
+const JSON_INDENT = 2
+
+const sortKeysDeep = (value: unknown): unknown => {
   if (Array.isArray(value)) {
-    return value.map(sortKeysDeep)
+    return value.map((entry: unknown) => sortKeysDeep(entry))
   }
   if (value !== null && typeof value === 'object') {
     return Object.fromEntries(
@@ -27,7 +29,7 @@ const sortKeysDeep = (value) => {
 
 await Promise.all(
   CAPABILITIES.map(async (capability) => {
-    const definition = JSON.parse(
+    const definition: unknown = JSON.parse(
       await readFile(
         `node_modules/homey-lib/assets/capability/capabilities/${capability}.json`,
         'utf8',
@@ -35,7 +37,7 @@ await Promise.all(
     )
     await writeFile(
       `vendor/capabilities/${capability}.json`,
-      `${JSON.stringify(sortKeysDeep(definition), null, 2)}\n`,
+      `${JSON.stringify(sortKeysDeep(definition), undefined, JSON_INDENT)}\n`,
     )
   }),
 )

--- a/tests/unit/capability-definitions.test.ts
+++ b/tests/unit/capability-definitions.test.ts
@@ -13,7 +13,7 @@ import {
 
 // homey-lib is a devDependency: the runtime consumes the vendored copies
 // under vendor/capabilities. Refresh them with
-// `node scripts/sync-capability-definitions.mjs` when this fails.
+// `node scripts/sync-capability-definitions.mts` when this fails.
 describe('vendored capability definitions', () => {
   it.each([
     ['fan_speed', fanSpeed, libFanSpeed],

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -2,6 +2,13 @@
   "compilerOptions": {
     "rootDir": "."
   },
-  "exclude": ["*.config.ts", "tests", "public", "settings", "widgets/*/public"],
+  "exclude": [
+    "*.config.ts",
+    "scripts",
+    "tests",
+    "public",
+    "settings",
+    "widgets/*/public"
+  ],
   "extends": "./tsconfig.json"
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -17,7 +17,7 @@ const swcPlugin = swc.vite({
 const config: ViteUserConfig = defineConfig({
   test: {
     coverage: {
-      exclude: ['**/public/**/*.mts', 'settings/**/*.mts'],
+      exclude: ['**/public/**/*.mts', 'scripts/**/*.mts', 'settings/**/*.mts'],
       include: ['**/*.mts'],
       reporter: ['text', 'lcov'],
       thresholds: {


### PR DESCRIPTION
## What

The build scripts become **TypeScript, run natively by Node** — no transpilation, no new tooling:

- `scripts/bundle.mjs` → `scripts/bundle.mts` (and `sync-capability-definitions` in com.melcloud)
- `build:assets` calls the `.mts` directly (`node scripts/bundle.mts`)
- the yaml eslint block gets `files: ["**/*.{yaml,yml}"]` — it used to apply to every file, was the only block reaching `.mjs`, and leaked 28 inert `yml/*` rules onto every `.mts`

## Why TypeScript, not a JS lint block

This PR first shipped a `js.recommended + unicorn` block for `.mjs`. Review asked whether that was the best practice — measured answer: **no**.

| option | measured outcome |
|---|---|
| js/unicorn block (v1 of this PR) | lints, but diverges from the repo's curated rule set (raw `unicorn` without the ledger overrides) and stays untyped |
| `tsConfigs.disableTypeChecked` on `.mjs` | **11 violations, some unsatisfiable in JS** — `explicit-function-return-type` demands annotations `.mjs` cannot write → dead end of disables |
| **`.mts` run natively (this PR)** | full doctrine applies: typed lint, typecheck, strict, zero special-casing |

The stack was already built for it: `engines >= 22.19` (Node runs TS natively since 22.18, type stripping on by default — verified on this machine), and the tsconfig sets **`erasableSyntaxOnly: true`**, the exact flag that guarantees stripping-safe TypeScript.

## What the typed pipeline caught

Converting surfaced real fixes the untyped block missed: `JSON.parse` results typed `unknown` and narrowed instead of flowing as `any`; regexes upgraded to the `v` flag (`require-unicode-regexp`); the `replaceAll` callback — whose rest args cannot carry named groups safely under typed lint — replaced by a cursor-wise rebuild; magic numbers named.

## Wiring, so nothing else moves

- `tsconfig.build.json` excludes `scripts` → **nothing emitted into `.homeybuild`** (verified: no `.homeybuild/scripts`)
- vitest excludes `scripts/**` from coverage, like the other process-level sources
- docs and test comments updated to the `.mts` names

## Functionally verified

Full build + simulated CLI page copy: **byte-identical `?v=` hashes** to the old script, stamps only inside reference contexts, second run idempotent. In com.melcloud, `sync-capability-definitions.mts` re-run produces **zero diff** under `vendor/` and the drift test passes.

Edited together with its two siblings, as the shared-file rule requires.

## Checklist

- [x] `npm run format` / `lint` / `typecheck` pass
- [x] `npm run test:coverage` passes (100%)
- [x] `npm run homey:validate` passes at `publish` level