### PR TITLE
chore: adopt eslint-plugin-unicorn 73

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -783,6 +783,7 @@ const config: Config[] = defineConfig([
       'unicorn/id-match': 'off',
       // Vocabulary opt-out: the abbreviation renames it forces
       // (`args` -> `arguments_`, ...) fight the domain naming.
+      'unicorn/iteration-fallback-style': 'error',
       'unicorn/name-replacements': 'off',
       // Owned by `import-x/no-anonymous-default-export`.
       'unicorn/no-anonymous-default-export': 'off',

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "eslint-plugin-jsdoc": "^63.3.3",
         "eslint-plugin-package-json": "^1.6.1",
         "eslint-plugin-perfectionist": "^5.10.0",
-        "eslint-plugin-unicorn": "^72.0.0",
+        "eslint-plugin-unicorn": "^73.0.0",
         "eslint-plugin-yml": "^3.6.0",
         "homey-apps-sdk-v3-types": "^0.3.12",
         "homey-lib": "^2.51.4",
@@ -3885,9 +3885,9 @@
       }
     },
     "node_modules/eslint-plugin-unicorn": {
-      "version": "72.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-72.0.0.tgz",
-      "integrity": "sha512-hqO6ksoOHO+ZhdseTuKRVQbx9U7PRO/cv8qAR1mctwzdVO2hYud8uS9luAhp43RJgziYgHAph8eHyipT8GL0ng==",
+      "version": "73.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-73.0.0.tgz",
+      "integrity": "sha512-V0YatLe9nkGhXEXKe2Qljb1EY0sJHwDV0HUF1NKFwtsHh/fU7qGHDgv+6fchzZcgU2/7noHo2gdjnmo0P2uDPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "eslint-plugin-jsdoc": "^63.3.3",
     "eslint-plugin-package-json": "^1.6.1",
     "eslint-plugin-perfectionist": "^5.10.0",
-    "eslint-plugin-unicorn": "^72.0.0",
+    "eslint-plugin-unicorn": "^73.0.0",
     "eslint-plugin-yml": "^3.6.0",
     "homey-apps-sdk-v3-types": "^0.3.12",
     "homey-lib": "^2.51.4",

--- a/settings/index.mts
+++ b/settings/index.mts
@@ -589,7 +589,9 @@ class AuthManager {
     return API_VALUES.filter((api) => !this.#hasCompleteCredentials(api))
   }
 
-  /** @alerts Displays authentication errors to the user. */
+  /**
+   * @alerts Displays authentication errors to the user.
+   */
   public async login(): Promise<void> {
     const api = this.#currentApi
     // Trimmed: mobile keyboards append a space after autocompleted
@@ -618,7 +620,9 @@ class AuthManager {
     })
   }
 
-  /** @alerts Displays reset failures to the user. */
+  /**
+   * @alerts Displays reset failures to the user.
+   */
   public async resetCredentials(): Promise<void> {
     if (
       !(await homeyConfirm(
@@ -729,7 +733,9 @@ class DeviceSettingsManager {
     this.#settingsCommon = getDiv('settings_common')
   }
 
-  /** @alerts Displays fetch errors to the user. */
+  /**
+   * @alerts Displays fetch errors to the user.
+   */
   public async fetchDeviceSettings(): Promise<void> {
     try {
       this.#deviceSettings = await homeyApiGet<DeviceSettings>(
@@ -741,7 +747,9 @@ class DeviceSettingsManager {
     }
   }
 
-  /** @alerts Displays fetch errors to the user. Returns empty fallback on error. */
+  /**
+   * @alerts Displays fetch errors to the user. Returns empty fallback on error.
+   */
   public async fetchDriverSettings(): Promise<
     Partial<Record<string, DriverSetting[]>>
   > {
@@ -1184,7 +1192,9 @@ class ErrorLogManager {
     })
   }
 
-  /** @alerts Displays fetch errors to the user. */
+  /**
+   * @alerts Displays fetch errors to the user.
+   */
   public async fetchErrorLog(): Promise<void> {
     await withDisablingButton(this.#seeButton.id, async () => {
       try {
@@ -1363,7 +1373,9 @@ class ZoneSettingsManager {
     this.#overheatProtectionDirtyGate.markSaved()
   }
 
-  /** @silent Falls back to default values on error. */
+  /**
+   * @silent Falls back to default values on error.
+   */
   public displayFrostProtectionData(): void {
     const data = this.#zoneMapping[this.#zone.value]
     if (data !== undefined) {
@@ -1413,7 +1425,9 @@ class ZoneSettingsManager {
     this.#overheatProtectionDirtyGate.markSaved()
   }
 
-  /** @silent Falls back to default values on error. */
+  /**
+   * @silent Falls back to default values on error.
+   */
   public async fetchFrostProtectionData(): Promise<void> {
     await this.#fetchZoneSetting({
       id: 'frost_protection',
@@ -1424,7 +1438,9 @@ class ZoneSettingsManager {
     })
   }
 
-  /** @silent Falls back to default values on error. */
+  /**
+   * @silent Falls back to default values on error.
+   */
   public async fetchHolidayModeData(): Promise<void> {
     await this.#fetchZoneSetting({
       id: 'holiday_mode',
@@ -1435,7 +1451,9 @@ class ZoneSettingsManager {
     })
   }
 
-  /** @silent Falls back to default values on error. */
+  /**
+   * @silent Falls back to default values on error.
+   */
   public async fetchOverheatProtectionData(): Promise<void> {
     await this.#fetchZoneSetting({
       id: 'overheat_protection',
@@ -1468,7 +1486,9 @@ class ZoneSettingsManager {
     }
   }
 
-  /** @alerts Displays save errors to the user. */
+  /**
+   * @alerts Displays save errors to the user.
+   */
   public async setFrostProtectionData({
     isEnabled,
     max,
@@ -1487,7 +1507,9 @@ class ZoneSettingsManager {
     )
   }
 
-  /** @alerts Displays save errors to the user. */
+  /**
+   * @alerts Displays save errors to the user.
+   */
   public async setHolidayModeData(update: HolidayModeUpdate): Promise<void> {
     const { endDate, isEnabled, startDate } = update
     await this.#putZoneSetting(
@@ -1509,7 +1531,9 @@ class ZoneSettingsManager {
     )
   }
 
-  /** @alerts Displays save errors to the user. */
+  /**
+   * @alerts Displays save errors to the user.
+   */
   public async setOverheatProtectionData({
     isEnabled,
     max,
@@ -1864,7 +1888,9 @@ class SettingsApp {
     )
   }
 
-  /** @alerts Falls back to an empty settings object on error. */
+  /**
+   * @alerts Falls back to an empty settings object on error.
+   */
   static async #fetchHomeySettings(homey: Homey): Promise<HomeySettings> {
     try {
       return await homeyCallback((callback) => {
@@ -2006,7 +2032,9 @@ class SettingsApp {
     })
   }
 
-  /** @alerts Displays post-login errors to the user. */
+  /**
+   * @alerts Displays post-login errors to the user.
+   */
   async #onLogin(api: Api): Promise<void> {
     // Reflect the server truth instead of assuming success: the login
     // POST resolves even when the post-login device sync fails.

--- a/types/api.mts
+++ b/types/api.mts
@@ -1,9 +1,13 @@
 import type { LoginCredentials } from '@olivierzal/melcloud-api'
 
-/** Identifier for one of the two MELCloud APIs. */
+/**
+ * Identifier for one of the two MELCloud APIs.
+ */
 export type Api = 'classic' | 'home'
 
-/** Minimal API-client surface used by drivers during pairing/repair. */
+/**
+ * Minimal API-client surface used by drivers during pairing/repair.
+ */
 export interface AuthenticationAPI {
   readonly authenticate: (credentials: LoginCredentials) => Promise<void>
   readonly isAuthenticated: () => boolean

--- a/types/capabilities.mts
+++ b/types/capabilities.mts
@@ -41,7 +41,9 @@ export interface CapabilitiesOptionsAtaErv {
   readonly fan_speed: RangeOptions
 }
 
-/** Base write-converter type for capability-to-device transforms. */
+/**
+ * Base write-converter type for capability-to-device transforms.
+ */
 export type CapabilityConverter = {
   // eslint-disable-next-line @typescript-eslint/method-signature-style -- method syntax is bivariant, letting concrete converters narrow `value` to their capability's type
   bivariant(value: unknown): unknown

--- a/types/device.mts
+++ b/types/device.mts
@@ -23,5 +23,7 @@ export interface EnergyReportOperation {
   readonly unschedule: () => void
 }
 
-/** Telemetry direction a Home energy capability reads. */
+/**
+ * Telemetry direction a Home energy capability reads.
+ */
 export type HomeEnergyMeasureName = 'consumed' | 'produced'


### PR DESCRIPTION
## What

`eslint-plugin-unicorn` `^72` → `^73`, with every new rule settled on **measured evidence** (v73 probed against the real sources before any verdict) — one PR per repo, same title.

| rule | preset | violations (family) | verdict |
|---|---|---|---|
| `single-line-block-comment-style` | auto-on | 326 | **adopted** — single-line JSDoc → canonical 3-line form |
| `no-unsafe-sqlite-interpolation` | auto-on | 0 | inert (no sqlite), free protection |
| `iteration-fallback-style` | opt-in | 0 | **adopted at error** — free guard, mutation-verified |
| `consistent-arrow-return-style` | opt-in | ~496 | **refused** — multiline implicit return is the house idiom |
| `no-barrel-files` | opt-in | 28 | **refused** — the barrels ARE the public API (`exports` map, publint-validated); the anti-barrel cost model targets bundled apps with deep transitive graphs, not a small Node-loaded library. Revisit if the library is ever bundled. |

## The autofix incident, and why the diff is script-made

`eslint --fix` for the comment rule **interacting with `multiline-comment-style: separate-lines`** produced two damage shapes instead of the approved preview: doc comments degraded to bare `//` triples (JSDoc semantics lost — typedoc, IDE hover), and expansions without the `*` prefix. Both were caught, reverted, and the expansion re-done by a **deterministic script**: `/** X */` → the canonical 3-line form.

**Purity proven**: the JSDoc diff touches **zero non-comment lines** (measured), and `npm run docs` (typedoc) passes on the rebuilt comments.

## Ledger movement (libraries)

- `no-this-outside-of-class` off **lifted**: v73 allows explicit TypeScript `this` parameters — exactly the decorator-protocol reason the entry documented. Zero violations with the rule live; a genuine violation (undeclared `this`) fires. One documented disable less.
- `no-nonstandard-builtin-properties` off **stays**: still flags `Symbol.dispose` (17+13 sites), the documented reason remains true.

## Checklist

- [x] `npm run format` / `lint` / `typecheck` pass
- [x] `npm run test:coverage` passes (100%)
- [x] apps: `homey:validate` at publish level · libs: `lint:package` + `docs` pass
