### PR TITLE
docs: reattach the vocabulary opt-out comment to its rule

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -781,9 +781,9 @@ const config: Config[] = defineConfig([
       'unicorn/filename-case': 'off',
       // Owned by `@typescript-eslint/naming-convention`.
       'unicorn/id-match': 'off',
+      'unicorn/iteration-fallback-style': 'error',
       // Vocabulary opt-out: the abbreviation renames it forces
       // (`args` -> `arguments_`, ...) fight the domain naming.
-      'unicorn/iteration-fallback-style': 'error',
       'unicorn/name-replacements': 'off',
       // Owned by `import-x/no-anonymous-default-export`.
       'unicorn/no-anonymous-default-export': 'off',


### PR DESCRIPTION
Follow-up to #1517, addressing the Copilot remark raised on the sibling PRs (com.heatzy#1064, com.melcloud.extension#1244): the perfectionist insertion of `unicorn/iteration-fallback-style` landed between the "Vocabulary opt-out" comment and `unicorn/name-replacements`, the rule it documents. The new rule moves above the comment; alphabetical order is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3
