### PR TITLE
docs: fix the store link and list Home ATW in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,11 @@ This app integrates [MELCloud](https://app.melcloud.com/) and [MELCloud Home](ht
 ### MELCloud Home
 
 - **Air-to-air heat pumps** (ATA) — cooling, heating, fan speed, vane position
+- **Air-to-water heat pumps** (ATW) — zones, hot water, energy reporting
 
 ## Installation
 
-1. Install the [MELCloud app](https://homey.app/a/com.mecloud) from the Homey App Store.
+1. Install the [MELCloud app](https://homey.app/a/com.melcloud) from the Homey App Store.
 2. Open the app settings and log in with your MELCloud credentials.
 3. Add your devices via the pairing wizard.
 


### PR DESCRIPTION
Two README staleness fixes, both verified against the tree: the App Store link dropped an "l" (`com.mecloud`), and the MELCloud Home section still listed ATA only while the `home-melcloud_atw` driver ships zones, hot water and energy reporting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3
