### PR TITLE
docs: restore the load-bearing store-link typo and pin it in doctrine

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,15 @@ coverage.
 
 ## Homey platform gotchas
 
+- The published app id is `com.mecloud` — the original submission's
+  typo, now LOAD-BEARING: the id is the app's platform identity
+  (pairing, install base, inter-app API), so publishing under the
+  corrected spelling would be a new app and would orphan every paired
+  device. Everything derived keeps the typo: the store URL
+  (`https://homey.app/a/com.mecloud`) and the id the extension uses to
+  address this app. Never "fix" the missing `l` anywhere — manifest,
+  code or docs links (a README "fix" once turned the working store
+  link into a 404; reverted, 2026-08).
 - `.homeycompose/` is the SOURCE for `app.json` and `locales/*.json`; the
   Homey CLI regenerates those outputs on every preprocess and writes them
   WITHOUT a trailing newline. Commit the CLI-generated form verbatim — do

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This app integrates [MELCloud](https://app.melcloud.com/) and [MELCloud Home](ht
 
 ## Installation
 
-1. Install the [MELCloud app](https://homey.app/a/com.melcloud) from the Homey App Store.
+1. Install the [MELCloud app](https://homey.app/a/com.mecloud) from the Homey App Store.
 2. Open the app settings and log in with your MELCloud credentials.
 3. Add your devices via the pairing wizard.
 


### PR DESCRIPTION
The App Store links spell `com.mecloud` because that **is** the published app id — the original submission's typo, now load-bearing: a platform id cannot change without orphaning every install, and everything derives from it (store URL, `MELCLOUD_APP_ID` in the extension). The previous README pass "corrected" the links into 404s.

Verified before restoring: `.homeycompose/app.json` declares `com.mecloud` / `com.mecloud.extension`, `https://homey.app/a/com.mecloud` answers 200 while `.../com.melcloud` answers 404. The trap is now pinned in CLAUDE.md (both repos) so it cannot be "fixed" again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3
