### PR TITLE
docs: align the README with its family and pin docs currency in doctrine

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -337,6 +337,13 @@ coverage.
 
 ## Repo process
 
+- Companion docs are part of a change's definition of done: a PR that
+  changes behavior, surface, requirements or process updates the
+  affected companion files (README.md, CONTRIBUTING.md, SECURITY.md,
+  CLAUDE.md) in the same PR, never in a later sweep — the 2026-08
+  README audit caught exactly the drift this prevents (a shipped Home
+  ATW driver absent from its README, a stale `Result` kind list).
+
 - `@olivierzal/melcloud-api` is pinned EXACTLY, never with a caret: the
   library's breaking changes are self-published, adoption is an explicit
   reviewed PR per release, and a caret is what silently held heatzy-api's

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ npm run homey:start  # run the app on your Homey (remote)
 
 Architecture notes:
 
+- The API layer lives in [@olivierzal/melcloud-api](https://github.com/OlivierZal/melcloud-api), a sibling repository with its own tooling; API bugs are fixed there, not worked around here.
 - Browser code (both widgets' `public/` and the `settings/` page) is bundled by `scripts/bundle.mts` into a compat pair per entry — `index.js` (IIFE, what the shipped HTML loads) and `index.mjs` (for HTMLs cached by phones from earlier app versions) — emitted into `.homeybuild`, the packaged app, never into the source tree. `npm run build` produces them, and the Homey CLI runs it automatically on validate/publish. Shared helpers live in `public/` and are imported directly by widgets and settings.
 - Both the build and `npm run typecheck` use the native TypeScript 7 compiler (`typescript@7` aliased as `@typescript/native`) for speed; `typescript@6` remains alongside it for tools that need the JS API (typescript-eslint) until TypeScript 7.1 ships its stable programmatic API.
 - Test coverage is enforced at 100% for backend code; browser glue (`public/`, `settings/`, widget `public/`) is excluded from coverage, so the badge covers drivers, app and API layers only.


### PR DESCRIPTION
Family-alignment audit of the five READMEs, by repo nature (API lib vs Homey app), plus the docs-currency doctrine rule. Per repo: melcloud-api gains the `Validated boundaries` feature bullet its heatzy-api twin already had (zod guards its payloads too — `src/validation/schemas.ts`) and the docs badge loses its stale `?v=2`; com.melcloud gains the API-layer architecture bullet com.heatzy already had; the extension gains its nature's equivalent (wire-level dependency, app id `com.mecloud`); and all five doctrines now state that companion docs (README, CONTRIBUTING, SECURITY, CLAUDE.md) are updated in the same PR as the change they describe — the 2026-08 README audit caught exactly the drift this prevents. Remaining cross-family differences are deliberate and code-backed (Error handling and Imports sections only where `Result` and subpath exports exist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3
