### PR TITLE
docs: sharpen the docs-currency sentence

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -338,9 +338,9 @@ coverage.
 ## Repo process
 
 - Companion docs are part of a change's definition of done: a PR that
-  changes behavior, surface, requirements or process updates the
-  affected companion files (README.md, CONTRIBUTING.md, SECURITY.md,
-  CLAUDE.md) in the same PR, never in a later sweep — the 2026-08
+  changes behavior, API surface, requirements or process must update
+  the affected companion files (README.md, CONTRIBUTING.md,
+  SECURITY.md, CLAUDE.md) in the same PR, never in a later sweep — the 2026-08
   README audit caught exactly the drift this prevents (a shipped Home
   ATW driver absent from its README, a stale `Result` kind list).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -337,12 +337,12 @@ coverage.
 
 ## Repo process
 
-- Companion docs are part of a change's definition of done: a PR that
-  changes behavior, API surface, requirements or process must update
-  the affected companion files (README.md, CONTRIBUTING.md,
-  SECURITY.md, CLAUDE.md) in the same PR, never in a later sweep — the 2026-08
-  README audit caught exactly the drift this prevents (a shipped Home
-  ATW driver absent from its README, a stale `Result` kind list).
+- Companion docs are part of a change's definition of done: whenever a
+  PR changes behavior, API surface, requirements or process, the same
+  PR updates the affected companion files (README.md, CONTRIBUTING.md,
+  SECURITY.md, CLAUDE.md) — never a later sweep; the 2026-08 README
+  audit caught exactly the drift this prevents (a shipped Home ATW
+  driver absent from its README, a stale `Result` kind list).
 
 - `@olivierzal/melcloud-api` is pinned EXACTLY, never with a caret: the
   library's breaking changes are self-published, adoption is an explicit


### PR DESCRIPTION
Follow-up to the family-alignment wave: the docs-currency sentence read "…or process updates the affected companion files", where "process updates" parses as a noun phrase (raised by Copilot on OlivierZal/heatzy-api#1175). Reworded to "must update" with "API surface" spelled out — the same fix lands on the two still-open sibling PRs, keeping the five doctrines aligned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3
