### PR TITLE
fix: repair the frost auto-enable cascade and clear review residue

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,6 +3,4 @@
 /app.json
 /locales/
 /README.md
-/settings/index.mjs
-/widgets/*/public/index.mjs
 /.claude/

--- a/app.mts
+++ b/app.mts
@@ -1146,8 +1146,6 @@ export default class MELCloudApp extends App {
     }
   }
 
-  // Type-agnostic device facade lookup for the chart surfaces shared by
-  // both Home device types (temperatures, signal, energy report).
   // The day-chart query every dialect's report reads. Derived once: the
   // window anchor and the timezone source must not drift between the six
   // call sites, which the facades' shared `(query?: ReportQuery)` contract
@@ -1369,6 +1367,8 @@ export default class MELCloudApp extends App {
     }))
   }
 
+  // Type-agnostic device facade lookup for the chart surfaces shared by
+  // both Home device types (temperatures, signal, energy report).
   #getHomeDeviceFacade(
     deviceId: string,
   ): Home.DeviceAtaFacade | Home.DeviceAtwFacade {

--- a/drivers/base-device.mts
+++ b/drivers/base-device.mts
@@ -114,10 +114,6 @@ export abstract class BaseMELCloudDevice<
   } = { get: {}, list: {}, set: {} }
 
   public override async onInit(): Promise<void> {
-    // Start available and let the first sync re-assert from the facades'
-    // `isAvailable` contract; this also heals the stuck unavailable state
-    // builds up to #1481 may have left.
-    await this.setAvailable()
     await this.setWarning(null)
     this.#registerCapabilityListeners()
     await this.ensureDevice()
@@ -258,12 +254,8 @@ export abstract class BaseMELCloudDevice<
   }
 
   // One skeleton for both dialects, which the facades' neutral
-  // `isAvailable` contract makes possible: before it, Classic read a raw
-  // `Offline` flag and Home a disconnection streak, so each intermediate
-  // class carried its own copy of this method — identical but for the
-  // warning key and the payload read, and each commented "mirrors the
-  // other contract". The contract is pinned in melcloud-api's
-  // tests/contracts/is-available.test.ts.
+  // `isAvailable` contract makes possible — the contract is pinned in
+  // melcloud-api's tests/contracts/is-available.test.ts.
   public async syncFromDevice(): Promise<void> {
     const device = await this.ensureDevice()
     if (device === null) {

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -54,7 +54,12 @@ const config: Config[] = defineConfig([
     ignores: [
       '.homeybuild/',
       'coverage/',
-      // Stale pre-`.homeybuild` esbuild outputs, also gitignored
+      // Pre-`.homeybuild` leftovers in never-rebuilt trees: gitignored,
+      // and ignored here so a stale tree cannot break the lint run.
+      'settings/index.js',
+      'settings/index.mjs',
+      'widgets/*/public/index.js',
+      'widgets/*/public/index.mjs',
     ],
   },
   {

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -55,8 +55,6 @@ const config: Config[] = defineConfig([
       '.homeybuild/',
       'coverage/',
       // Stale pre-`.homeybuild` esbuild outputs, also gitignored
-      'settings/index.mjs',
-      'widgets/*/public/index.mjs',
     ],
   },
   {

--- a/lib/classic-facade-manager.mts
+++ b/lib/classic-facade-manager.mts
@@ -18,8 +18,3 @@ export const getClassicBuildings = ({
   type,
 }: { type?: Classic.DeviceType | undefined } = {}): Classic.BuildingZone[] =>
   getClassicFacadeManager().getBuildings(type === undefined ? {} : { type })
-
-export const getClassicZones = ({
-  type,
-}: { type?: Classic.DeviceType | undefined } = {}): Classic.Zone[] =>
-  getClassicFacadeManager().getZones(type === undefined ? {} : { type })

--- a/public/webview-freshness.mts
+++ b/public/webview-freshness.mts
@@ -2,8 +2,8 @@
 // cached across app versions — the HTML itself included (proven in the
 // wild), so a booted page may run stale UI code indefinitely: the
 // cached HTML's `?v=` stamps keep serving the matching cached assets.
-// The page's identity is the SORTED JOIN of every `?v=` stamp it
-// carries (so a CSS-only or markup-only ship moves it too); the app
+// The page's identity is the DOCUMENT-ORDER join of every `?v=` stamp
+// it carries (so a CSS-only or markup-only ship moves it too); the app
 // serves the live identities (`GET /webview-hashes`, emitted at
 // package time), fetched through the app bridge so no HTTP cache can
 // stale them. On mismatch the page reloads ONCE — the reload

--- a/scripts/bundle.mts
+++ b/scripts/bundle.mts
@@ -7,7 +7,7 @@
 // HTMLs — and npm dependencies (Chart.js) are inlined so widgets work
 // offline with versions pinned by the lockfile.
 import { createHash } from 'node:crypto'
-import { readFile, rm, writeFile } from 'node:fs/promises'
+import { readFile, writeFile } from 'node:fs/promises'
 import path from 'node:path'
 
 import { type BuildOptions, build } from 'esbuild'
@@ -41,9 +41,7 @@ const pages = [
 ]
 
 // A local asset reference — an href/src attribute value, with an
-// optional existing stamp. (A dynamic-import alternative once lived
-// here: dead since the classic-defer fix, no shipped HTML uses
-// `import()` any more.)
+// optional existing stamp.
 const REFERENCE =
   /(?<prefix>href="|src=")(?<file>[^"':?\/][^"':?]*)(?:\?v=[0-9a-f]+)?(?<suffix>")/gv
 
@@ -74,18 +72,6 @@ await Promise.all(
       }),
     ]
   }),
-)
-
-// Remove stale source-tree bundles left by pre-`.homeybuild` builds.
-await Promise.all(
-  entryPoints.flatMap((entryPoint) =>
-    ['.js', '.mjs'].map(async (extension) =>
-      rm(
-        entryPoint.replace(/\.mts$/v, () => extension),
-        { force: true },
-      ),
-    ),
-  ),
 )
 
 // Cache-bust the PACKAGED pages: phone webviews cache assets across app

--- a/settings/index.mts
+++ b/settings/index.mts
@@ -158,14 +158,6 @@ const disableButton = (id: string, isDisabled = true): void => {
   getButton(id).disabled = isDisabled
 }
 
-// The error log aggregates both accounts, so it is not disabled here.
-const disableClassicZoneButtons = (): void => {
-  for (const id of ['frost_protection', 'holiday_mode']) {
-    disableButton(`apply_${id}`)
-    disableButton(`refresh_${id}`)
-  }
-}
-
 const withDisablingButton = async (
   id: string,
   action: () => Promise<void>,
@@ -1607,8 +1599,11 @@ class ZoneSettingsManager {
       this.#frostProtectionMaxTemperature,
     ]) {
       element.addEventListener('change', () => {
-        if (element.value === 'false') {
-          element.value = 'true'
+        if (
+          element.value !== '' &&
+          this.#frostProtectionEnabled.value === 'false'
+        ) {
+          this.#frostProtectionEnabled.value = 'true'
         }
       })
     }
@@ -1822,9 +1817,6 @@ class ZoneSettingsManager {
     }
   }
 
-  // A blank enabled select means a Home building's devices disagree
-  // ("mixed") and the user has not chosen: applying would silently write a
-  // single value (off) to them all, so require an explicit choice first.
   #refreshOverheatVisibility(): void {
     const { value } = this.#zone
     const isCapable = this.#overheatCapableValues.has(value)
@@ -1846,6 +1838,9 @@ class ZoneSettingsManager {
     this.#refreshOverheatVisibility()
   }
 
+  // A blank enabled select means a Home building's devices disagree
+  // ("mixed") and the user has not chosen: applying would silently write a
+  // single value (off) to them all, so require an explicit choice first.
   #requireEnabledChosen(select: HTMLSelectElement): boolean {
     if (select.value !== '') {
       return true
@@ -1950,22 +1945,6 @@ class SettingsApp {
     })
   }
 
-  #disableCommonButtonsIfNoDevices(): void {
-    if (Object.keys(this.#deviceSettingsManager.deviceSettings).length > 0) {
-      return
-    }
-
-    disableButton('apply_settings_common')
-    disableButton('refresh_settings_common')
-  }
-
-  #disableForError(error: NoDeviceError): void {
-    if (error instanceof NoClassicDeviceError) {
-      disableClassicZoneButtons()
-    }
-    this.#disableCommonButtonsIfNoDevices()
-  }
-
   async #ensureDevicesForApi(api: Api): Promise<void> {
     if (api === 'classic') {
       await this.#fetchClassicBuildings()
@@ -2057,9 +2036,6 @@ class SettingsApp {
       try {
         await this.#ensureDevicesForApi(api)
       } catch (error) {
-        if (error instanceof NoDeviceError) {
-          this.#disableForError(error)
-        }
         await this.#homey.alert(
           error instanceof NoDeviceError
             ? error.message
@@ -2130,9 +2106,10 @@ class SettingsApp {
     try {
       await this.#fetchClassicBuildings()
     } catch (error) {
-      if (error instanceof NoClassicDeviceError) {
-        this.#disableForError(error)
-      } else {
+      // No paired Classic device is not an auth failure: the session
+      // stays valid, only the device-scoped surfaces have nothing to
+      // show (their gates stay pristine on empty data).
+      if (!(error instanceof NoClassicDeviceError)) {
         this.#authState.classic = false
       }
     }
@@ -2141,8 +2118,6 @@ class SettingsApp {
   async #validateInitialHomeAuth(): Promise<void> {
     if (this.#hasHomeDevices()) {
       await this.#fetchHomeTargets()
-    } else {
-      this.#disableForError(new NoDeviceError(this.#homey))
     }
   }
 }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,6 +2,6 @@ sonar.projectKey=OlivierZal_com.melcloud
 sonar.organization=olivierzal
 sonar.sourceEncoding=UTF-8
 sonar.javascript.lcov.reportPaths=./coverage/lcov.info
-sonar.exclusions=**/*.jpg,**/*.png,coverage/**,settings/index.mjs,widgets/*/public/index.mjs
+sonar.exclusions=**/*.jpg,**/*.png,coverage/**
 sonar.coverage.exclusions=tests/**,**/*.config.*,**/public/**,settings/**,scripts/**
 sonar.cpd.exclusions=**/*.config.*,settings/index.html,widgets/*/public/index.html

--- a/tests/unit/classic-facade-manager.test.ts
+++ b/tests/unit/classic-facade-manager.test.ts
@@ -3,7 +3,6 @@ import * as Classic from '@olivierzal/melcloud-api/classic'
 
 import {
   getClassicBuildings,
-  getClassicZones,
   setClassicFacadeManager,
 } from '../../lib/classic-facade-manager.mts'
 import { mock } from '../helpers.ts'
@@ -75,23 +74,6 @@ describe('classic-facade-manager', () => {
 
         expect(mockFacadeManager.getBuildings).toHaveBeenCalledWith({
           type: Classic.DeviceType.Ata,
-        })
-      })
-    })
-
-    describe(getClassicZones, () => {
-      it('should delegate to facadeManager.getZones', () => {
-        const result = getClassicZones()
-
-        expect(result).toBe(mockZones)
-        expect(mockFacadeManager.getZones).toHaveBeenCalledWith({})
-      })
-
-      it('should pass type filter', () => {
-        getClassicZones({ type: Classic.DeviceType.Atw })
-
-        expect(mockFacadeManager.getZones).toHaveBeenCalledWith({
-          type: Classic.DeviceType.Atw,
         })
       })
     })

--- a/widgets/ata-group-setting/public/ata-values.mts
+++ b/widgets/ata-group-setting/public/ata-values.mts
@@ -287,20 +287,20 @@ export class AtaValueManager {
   }
 
   public async setValues(): Promise<void> {
+    // The gate's `isActionable` arms Update only on a non-empty body —
+    // never re-derive that invariant here.
     await this.#dirtyGate.runBusy(async () => {
       const body = this.#buildAtaValuesBody()
-      if (Object.keys(body).length > 0) {
-        await homeyApiPut(
-          this.#homey,
-          getAtaStatePath(this.#zone.value),
-          body satisfies Classic.GroupState,
-        )
-        // The zone's known state absorbs the accepted write immediately:
-        // the debounced `deviceupdate` refetch confirms it later, but
-        // until then the body filter (and so `isActionable`) must judge
-        // against what the server now holds, not the pre-write state.
-        this.#updateZoneMapping(body)
-      }
+      await homeyApiPut(
+        this.#homey,
+        getAtaStatePath(this.#zone.value),
+        body satisfies Classic.GroupState,
+      )
+      // The zone's known state absorbs the accepted write immediately:
+      // the debounced `deviceupdate` refetch confirms it later, but
+      // until then the body filter (and so `isActionable`) must judge
+      // against what the server now holds, not the pre-write state.
+      this.#updateZoneMapping(body)
       // New pristine baseline is the just-applied form. A rejected PUT
       // throws before this, so the edit stays dirty for a retry.
       this.#dirtyGate.markSaved()


### PR DESCRIPTION
Wave 2 of the five-repo residue review (every finding re-verified before acting; two agent findings were refuted on evidence — the charts zone-value split is a different, slashed scheme post-`getZonePath`, deferred with that nuance, and one extension indirection turned out metric-forced). Headline repair: the frost panel's temperature-change listener was a mangled copy of the holiday date cascade — it compared a NUMBER input's value to `'false'` (unreachable) instead of flipping the panel's enabled select; editing a frost temperature now auto-enables the panel exactly like editing a holiday date does. Also: the manual button disables (and the `#disableForError` chain) were dead letters the dirty gate rewrites on every recompute; the startup `setAvailable` heal is subsumed by `syncAvailability`; the widget's inner empty-body guard re-derived the gate's `isActionable` invariant; `getClassicZones` was export-dead; two alphabetical-sort-displaced doc comments are re-attached; history comments and the source-tree bundle crutch are gone; the freshness twin's header says document-order join like its implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3
