### PR TITLE
refactor: clear the round-two review residue and pin the widget twins

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,10 @@ caught real failures that the others miss:
   force-close included): each bundle carries a freshness handshake —
   the page's identity is the document-order join of its `?v=` stamps (a CSS-only ship moves it too), `GET /webview-hashes` serves the
   live hashes (a manifest `bundle.mts` emits into the packaged app,
-  read by `lib/webview-hashes.mts`), and a mismatch triggers ONE
+  read by `lib/webview-hashes.mts`; module, test
+  `tests/unit/webview-hashes.test.ts` and the
+  `tests/fixtures/webview-hashes/` fixtures are byte-identical in the
+  three apps — edit all three together), and a mismatch triggers ONE
   `location.reload()` (sessionStorage guard, `webview-freshness.mts`),
   which revalidates the HTML and pulls the fresh bundle. Every failure
   path stays open: an unstamped page, an absent route or denied

--- a/api.mts
+++ b/api.mts
@@ -112,7 +112,7 @@ const api = {
     }
   },
   classicLogOut: ({ homey: { app } }: { homey: Homey }): void => {
-    logSettingsRoute(app, '/classic/sessions')
+    logSettingsRoute(app, 'DELETE /classic/sessions')
     app.classicApi.logOut()
   },
   getClassicBuildings: (): Classic.BuildingZone[] => getClassicBuildings(),
@@ -152,7 +152,7 @@ const api = {
       .toSorted((group1, group2) => group1.name.localeCompare(group2.name))
   },
   getDeviceSettings: ({ homey: { app } }: { homey: Homey }): DeviceSettings => {
-    logSettingsRoute(app, '/settings/devices')
+    logSettingsRoute(app, 'GET /settings/devices')
     return app.getDeviceSettings()
   },
   getDriverSettings: ({
@@ -160,7 +160,7 @@ const api = {
   }: {
     homey: Homey
   }): Partial<Record<string, DriverSetting[]>> => {
-    logSettingsRoute(app, '/settings/drivers')
+    logSettingsRoute(app, 'GET /settings/drivers')
     return app.getDriverSettings()
   },
   getErrorLog: async ({
@@ -236,8 +236,14 @@ const api = {
   }): (HomeBuildingZone | HomeDeviceZone)[] => app.getHomeTargets(),
   getLanguage: ({ homey: { i18n } }: { homey: Homey }): string =>
     i18n.getLanguage(),
-  getWebviewHashes: async (): Promise<Partial<Record<string, string>>> =>
-    getWebviewHashes(),
+  getWebviewHashes: async ({
+    homey: { app },
+  }: {
+    homey: Homey
+  }): Promise<Partial<Record<string, string>>> => {
+    logSettingsRoute(app, 'GET /webview-hashes')
+    return getWebviewHashes()
+  },
   homeAuthenticate: async ({
     body,
     homey,
@@ -252,11 +258,11 @@ const api = {
     }
   },
   homeLogOut: ({ homey: { app } }: { homey: Homey }): void => {
-    logSettingsRoute(app, '/home/sessions')
+    logSettingsRoute(app, 'DELETE /home/sessions')
     app.homeApi.logOut()
   },
   isClassicAuthenticated: ({ homey: { app } }: { homey: Homey }): boolean => {
-    logSettingsRoute(app, '/classic/sessions')
+    logSettingsRoute(app, 'GET /classic/sessions')
     return app.classicApi.isAuthenticated()
   },
   isHomeAuthenticated: async ({
@@ -264,7 +270,7 @@ const api = {
   }: {
     homey: Homey
   }): Promise<boolean> => {
-    logSettingsRoute(app, '/home/sessions')
+    logSettingsRoute(app, 'GET /home/sessions')
     return app.homeApi.ensureAuthenticated()
   },
   logWebviewBoot: ({

--- a/app.mts
+++ b/app.mts
@@ -149,8 +149,8 @@ interface HolidayModeActionArgs {
 }
 
 // Aggregates one device's settings into the per-driver map; a conflicting
-// value across devices marks the setting as indeterminate (`null`) and stops
-// processing the remaining settings of that device.
+// value across devices marks that setting as indeterminate (`null`) while
+// the remaining settings keep folding independently.
 const mergeDeviceSettings = (
   driverSettings: DeviceSetting,
   settings: Record<string, unknown>,
@@ -160,7 +160,6 @@ const mergeDeviceSettings = (
       driverSettings[settingId] = value
     } else if (driverSettings[settingId] !== value) {
       driverSettings[settingId] = null
-      return
     }
   }
 }

--- a/app.mts
+++ b/app.mts
@@ -886,16 +886,7 @@ export default class MELCloudApp extends App {
     deviceId: string,
     type: Home.DeviceType,
   ): Home.DeviceAtaFacade | Home.DeviceAtwFacade {
-    const model = this.#homeRegistry.getById(deviceId)
-    if (model?.type === type) {
-      if (model.isAta()) {
-        return this.#homeFacadeManager.get(model)
-      }
-      if (model.isAtw()) {
-        return this.#homeFacadeManager.get(model)
-      }
-    }
-    throw new NotFoundError(this.homey.__('errors.deviceNotFound'))
+    return this.#getHomeDeviceFacade(deviceId, type)
   }
 
   public getHomeFrostProtection(deviceId: string): ProtectionState | null {
@@ -1367,17 +1358,21 @@ export default class MELCloudApp extends App {
     }))
   }
 
-  // Type-agnostic device facade lookup for the chart surfaces shared by
-  // both Home device types (temperatures, signal, energy report).
+  // Device facade lookup shared by every Home surface: type-agnostic
+  // for the chart routes both device types serve, type-checked when a
+  // caller names the type it needs.
   #getHomeDeviceFacade(
     deviceId: string,
+    type?: Home.DeviceType,
   ): Home.DeviceAtaFacade | Home.DeviceAtwFacade {
     const model = this.#homeRegistry.getById(deviceId)
-    if (model?.isAta() === true) {
-      return this.#homeFacadeManager.get(model)
-    }
-    if (model?.isAtw() === true) {
-      return this.#homeFacadeManager.get(model)
+    if (type === undefined || model?.type === type) {
+      if (model?.isAta() === true) {
+        return this.#homeFacadeManager.get(model)
+      }
+      if (model?.isAtw() === true) {
+        return this.#homeFacadeManager.get(model)
+      }
     }
     throw new NotFoundError(this.homey.__('errors.deviceNotFound'))
   }

--- a/drivers/base-device.mts
+++ b/drivers/base-device.mts
@@ -22,15 +22,6 @@ import { getLocale, getNow } from '../lib/temporal.mts'
 import type { BaseMELCloudDriver } from './base-driver.mts'
 import type { EnergyReportConfig } from './base-report.mts'
 
-interface TimerOptions {
-  readonly actionType: string
-  readonly timerType: 'setInterval' | 'setTimeout'
-  readonly timerWords: {
-    readonly dateSpecifier: string
-    readonly timeSpecifier: string
-  }
-}
-
 const capitalize = ([first = '', ...rest] = ''): string =>
   first.toUpperCase() + rest.join('')
 
@@ -218,28 +209,26 @@ export abstract class BaseMELCloudDevice<
     }
   }
 
-  public setInterval(
-    callback: () => Promise<void>,
-    interval: Temporal.DurationLike,
-    actionType: string,
-  ): NodeJS.Timeout {
-    return this.#setTimer(callback, interval, {
-      actionType,
-      timerType: 'setInterval',
-      timerWords: { dateSpecifier: 'starting', timeSpecifier: 'every' },
-    })
-  }
-
   public setTimeout(
     callback: () => Promise<void>,
     interval: Temporal.DurationLike,
     actionType: string,
   ): NodeJS.Timeout {
-    return this.#setTimer(callback, interval, {
-      actionType,
-      timerType: 'setTimeout',
-      timerWords: { dateSpecifier: 'on', timeSpecifier: 'in' },
-    })
+    const duration = Temporal.Duration.from(interval)
+    const locale = getLocale(this.homey)
+    this.log(
+      capitalize(actionType),
+      'will run in',
+      duration.round({ largestUnit: 'days' }).toLocaleString(locale),
+      'on',
+      getNow(this.homey)
+        .add(duration)
+        .toLocaleString(locale, { dateStyle: 'full', timeStyle: 'full' }),
+    )
+    return this.homey.setTimeout(
+      callback,
+      duration.total({ unit: 'milliseconds' }),
+    )
   }
 
   // Homey keeps a warning bubble on the device tile until it is cleared:
@@ -480,30 +469,6 @@ export abstract class BaseMELCloudDevice<
     this.#tagMappings.set = this.cleanMapping(this.driver.tagMappings.set)
     this.#tagMappings.get = this.cleanMapping(this.driver.tagMappings.get)
     this.#tagMappings.list = this.cleanMapping(this.driver.tagMappings.list)
-  }
-
-  #setTimer(
-    callback: () => Promise<void>,
-    interval: Temporal.DurationLike,
-    { actionType, timerType, timerWords }: TimerOptions,
-  ): NodeJS.Timeout {
-    const duration = Temporal.Duration.from(interval)
-    const locale = getLocale(this.homey)
-    this.log(
-      capitalize(actionType),
-      'will run',
-      timerWords.timeSpecifier,
-      duration.round({ largestUnit: 'days' }).toLocaleString(locale),
-      timerWords.dateSpecifier,
-      getNow(this.homey)
-        .add(duration)
-        .toLocaleString(locale, { dateStyle: 'full', timeStyle: 'full' }),
-    )
-
-    return this.homey[timerType](
-      callback,
-      duration.total({ unit: 'milliseconds' }),
-    )
   }
 
   async #syncOptionalCapabilities(

--- a/drivers/classic-report.mts
+++ b/drivers/classic-report.mts
@@ -5,7 +5,7 @@ import type {
   EnergyCapabilities,
   EnergyCapabilityTagEntry,
 } from '../types/capabilities.mts'
-import { KILOWATT_TO_WATT } from '../lib/constants.mts'
+import { WATTS_PER_KILOWATT } from '../lib/constants.mts'
 import { isTotalEnergyKey } from '../lib/is-total-energy-key.mts'
 import { typedEntries } from '../lib/typed-object.mts'
 import { unwrapResult } from '../lib/unwrap-result.mts'
@@ -37,12 +37,12 @@ export class EnergyReport<
 > extends ScheduledEnergyReport {
   readonly #device: ClassicMELCloudDevice<T>
 
+  readonly #driver: ClassicMELCloudDriver<T>
+
   #linkedDeviceCount = 1
 
-  private readonly driver: ClassicMELCloudDriver<T>
-
   get #energyCapabilityTagEntries(): EnergyCapabilityTagEntry<T>[] {
-    const cleaned = this.#device.cleanMapping(this.driver.tagMappings.energy)
+    const cleaned = this.#device.cleanMapping(this.#driver.tagMappings.energy)
     return typedEntries<
       string & keyof EnergyCapabilities<T>,
       readonly (keyof Classic.EnergyData<T>)[]
@@ -58,7 +58,7 @@ export class EnergyReport<
   ) {
     super(device, config)
     this.#device = device
-    this.driver = device.driver
+    this.#driver = device.driver
   }
 
   protected override async fetchAndApply(): Promise<Record<
@@ -89,7 +89,7 @@ export class EnergyReport<
     data: Classic.EnergyData<T>,
     capability: string & keyof EnergyCapabilities<T>,
   ): number {
-    const { consumedTagMapping, producedTagMapping } = this.driver
+    const { consumedTagMapping, producedTagMapping } = this.#driver
     const consumedTags = consumedTagMapping[capability] ?? []
     const producedTags = producedTagMapping[capability] ?? []
     const consumed = sumTags(data, consumedTags)
@@ -113,7 +113,7 @@ export class EnergyReport<
     for (const tag of tags) {
       const tagData = data[tag]
       if (Array.isArray(tagData)) {
-        total += (tagData[hour] ?? 0) * KILOWATT_TO_WATT
+        total += (tagData[hour] ?? 0) * WATTS_PER_KILOWATT
       }
     }
 

--- a/drivers/classic-report.mts
+++ b/drivers/classic-report.mts
@@ -5,7 +5,7 @@ import type {
   EnergyCapabilities,
   EnergyCapabilityTagEntry,
 } from '../types/capabilities.mts'
-import { WATTS_PER_KILOWATT } from '../lib/constants.mts'
+import { KILO } from '../lib/constants.mts'
 import { isTotalEnergyKey } from '../lib/is-total-energy-key.mts'
 import { typedEntries } from '../lib/typed-object.mts'
 import { unwrapResult } from '../lib/unwrap-result.mts'
@@ -113,7 +113,7 @@ export class EnergyReport<
     for (const tag of tags) {
       const tagData = data[tag]
       if (Array.isArray(tagData)) {
-        total += (tagData[hour] ?? 0) * WATTS_PER_KILOWATT
+        total += (tagData[hour] ?? 0) * KILO
       }
     }
 

--- a/drivers/home-report-ata.mts
+++ b/drivers/home-report-ata.mts
@@ -1,5 +1,6 @@
 import type * as Home from '@olivierzal/melcloud-api/home'
 
+import { WATTS_PER_KILOWATT } from '../lib/constants.mts'
 import { unwrapResult } from '../lib/unwrap-result.mts'
 import type { EnergyReportConfig } from './base-report.mts'
 import type { HomeMELCloudDevice } from './home-device.mts'
@@ -10,7 +11,6 @@ import {
   parsePoints,
   sumSince,
   TELEMETRY_INTERVAL,
-  WATT_HOURS_PER_KILOWATT_HOUR,
 } from './home-report.mts'
 
 export class HomeEnergyReportAta extends HomeEnergyReport<
@@ -28,7 +28,7 @@ export class HomeEnergyReportAta extends HomeEnergyReport<
           ),
         ),
       // ATA telemetry is Wh pulses: scale sums down to kWh.
-      kilowattHours: (wireSum) => wireSum / WATT_HOURS_PER_KILOWATT_HOUR,
+      kilowattHours: (wireSum) => wireSum / WATTS_PER_KILOWATT,
       // Coarse average: Wh pulses over the trailing window divided by its
       // span — the 100 Wh quantum makes anything finer noise.
       watts: (points, now) =>

--- a/drivers/home-report-ata.mts
+++ b/drivers/home-report-ata.mts
@@ -1,6 +1,6 @@
 import type * as Home from '@olivierzal/melcloud-api/home'
 
-import { WATTS_PER_KILOWATT } from '../lib/constants.mts'
+import { KILO } from '../lib/constants.mts'
 import { unwrapResult } from '../lib/unwrap-result.mts'
 import type { EnergyReportConfig } from './base-report.mts'
 import type { HomeMELCloudDevice } from './home-device.mts'
@@ -28,7 +28,7 @@ export class HomeEnergyReportAta extends HomeEnergyReport<
           ),
         ),
       // ATA telemetry is Wh pulses: scale sums down to kWh.
-      kilowattHours: (wireSum) => wireSum / WATTS_PER_KILOWATT,
+      kilowattHours: (wireSum) => wireSum / KILO,
       // Coarse average: Wh pulses over the trailing window divided by its
       // span — the 100 Wh quantum makes anything finer noise.
       watts: (points, now) =>

--- a/drivers/home-report-atw.mts
+++ b/drivers/home-report-atw.mts
@@ -1,6 +1,7 @@
 import type * as Home from '@olivierzal/melcloud-api/home'
 import { Temporal } from 'temporal-polyfill'
 
+import { WATTS_PER_KILOWATT } from '../lib/constants.mts'
 import { unwrapResult } from '../lib/unwrap-result.mts'
 import type { EnergyReportConfig } from './base-report.mts'
 import type { HomeMELCloudDevice } from './home-device.mts'
@@ -11,7 +12,6 @@ import {
   POWER_FRESHNESS,
   parsePoints,
   TELEMETRY_INTERVAL,
-  WATTS_PER_KILOWATT,
 } from './home-report.mts'
 
 // Near-live reading: the latest minute bucket within the freshness horizon

--- a/drivers/home-report-atw.mts
+++ b/drivers/home-report-atw.mts
@@ -1,7 +1,7 @@
 import type * as Home from '@olivierzal/melcloud-api/home'
 import { Temporal } from 'temporal-polyfill'
 
-import { WATTS_PER_KILOWATT } from '../lib/constants.mts'
+import { KILO } from '../lib/constants.mts'
 import { unwrapResult } from '../lib/unwrap-result.mts'
 import type { EnergyReportConfig } from './base-report.mts'
 import type { HomeMELCloudDevice } from './home-device.mts'
@@ -31,9 +31,7 @@ const latestBucketWatts = (
       latest = point
     }
   }
-  return latest === null
-    ? 0
-    : latest.value * MINUTES_PER_HOUR * WATTS_PER_KILOWATT
+  return latest === null ? 0 : latest.value * MINUTES_PER_HOUR * KILO
 }
 
 export class HomeEnergyReportAtw extends HomeEnergyReport<

--- a/drivers/home-report.mts
+++ b/drivers/home-report.mts
@@ -17,9 +17,6 @@ import {
 // active periods return points, so an empty window means an idle unit.
 export const TELEMETRY_INTERVAL = 'Minute'
 export const MINUTES_PER_HOUR = 60
-export const WATTS_PER_KILOWATT = 1000
-// ATA telemetry is Wh pulses (100 Wh quantum); ATW buckets are kWh.
-export const WATT_HOURS_PER_KILOWATT_HOUR = 1000
 // The single ATA counter has no per-mode split and no live power: the
 // approximated reading is a coarse average over this trailing window.
 export const POWER_WINDOW_HOURS = 2
@@ -185,6 +182,19 @@ export abstract class HomeEnergyReport<
     return total
   }
 
+  // Writes the computed pairs to the device and returns them as the
+  // applied `capability → value` map the base contract expects.
+  async #applyPairs(
+    applied: readonly (readonly [string, number])[],
+  ): Promise<Record<string, number>> {
+    await Promise.all(
+      applied.map(async ([capability, value]) =>
+        this.#device.setCapabilityValue(capability, value),
+      ),
+    )
+    return Object.fromEntries(applied)
+  }
+
   async #applyRegular(
     facade: HomeDeviceFacade<T>,
   ): Promise<Record<string, number>> {
@@ -201,19 +211,15 @@ export abstract class HomeEnergyReport<
       from,
       to: nowInstant,
     })
-    const applied = entries.map(
-      (entry) =>
-        [
-          entry[0],
-          this.#regularValue(entry, points, { dayStart, now: nowInstant }),
-        ] as const,
-    )
-    await Promise.all(
-      applied.map(async ([capability, value]) =>
-        this.#device.setCapabilityValue(capability, value),
+    return this.#applyPairs(
+      entries.map(
+        (entry) =>
+          [
+            entry[0],
+            this.#regularValue(entry, points, { dayStart, now: nowInstant }),
+          ] as const,
       ),
     )
-    return Object.fromEntries(applied)
   }
 
   async #applyTotals(
@@ -229,15 +235,9 @@ export abstract class HomeEnergyReport<
         ),
       ),
     )
-    const applied = entries.map(
-      (entry) => [entry[0], totalValue(entry, totals)] as const,
+    return this.#applyPairs(
+      entries.map((entry) => [entry[0], totalValue(entry, totals)] as const),
     )
-    await Promise.all(
-      applied.map(async ([capability, value]) =>
-        this.#device.setCapabilityValue(capability, value),
-      ),
-    )
-    return Object.fromEntries(applied)
   }
 
   async #fetchAccrual(

--- a/drivers/melcloud_atw/device.mts
+++ b/drivers/melcloud_atw/device.mts
@@ -8,7 +8,7 @@ import type {
   SetCapabilities,
 } from '../../types/capabilities.mts'
 import type { EnergyReportConfig } from '../base-report.mts'
-import { WATTS_PER_KILOWATT } from '../../lib/constants.mts'
+import { KILO } from '../../lib/constants.mts'
 import { getLocale, getTimeZone, toPlainDate } from '../../lib/temporal.mts'
 import { HotWaterMode } from '../../types/atw.mts'
 import {
@@ -23,7 +23,7 @@ const convertFromDeviceMeasurePower =
     tag: 'CurrentEnergyConsumed' | 'CurrentEnergyProduced',
   ): ConvertFromDevice<typeof Classic.DeviceType.Atw> =>
   (data) =>
-    data[tag] * WATTS_PER_KILOWATT
+    data[tag] * KILO
 
 const convertFromDeviceOperationZone =
   (

--- a/drivers/melcloud_atw/device.mts
+++ b/drivers/melcloud_atw/device.mts
@@ -8,7 +8,7 @@ import type {
   SetCapabilities,
 } from '../../types/capabilities.mts'
 import type { EnergyReportConfig } from '../base-report.mts'
-import { KILOWATT_TO_WATT } from '../../lib/constants.mts'
+import { WATTS_PER_KILOWATT } from '../../lib/constants.mts'
 import { getLocale, getTimeZone, toPlainDate } from '../../lib/temporal.mts'
 import { HotWaterMode } from '../../types/atw.mts'
 import {
@@ -23,7 +23,7 @@ const convertFromDeviceMeasurePower =
     tag: 'CurrentEnergyConsumed' | 'CurrentEnergyProduced',
   ): ConvertFromDevice<typeof Classic.DeviceType.Atw> =>
   (data) =>
-    data[tag] * KILOWATT_TO_WATT
+    data[tag] * WATTS_PER_KILOWATT
 
 const convertFromDeviceOperationZone =
   (

--- a/lib/constants.mts
+++ b/lib/constants.mts
@@ -1,1 +1,3 @@
-export const WATTS_PER_KILOWATT = 1000
+// SI kilo prefix ratio, shared by the W <-> kW and Wh <-> kWh
+// conversions alike.
+export const KILO = 1000

--- a/lib/constants.mts
+++ b/lib/constants.mts
@@ -1,1 +1,1 @@
-export const KILOWATT_TO_WATT = 1000
+export const WATTS_PER_KILOWATT = 1000

--- a/settings/index.mts
+++ b/settings/index.mts
@@ -485,15 +485,15 @@ interface MixableZoneSettings {
   readonly overheat_protection?: Mixable<ProtectionState> | null
 }
 
-// ── AuthManager ──
-// One frost-protection / holiday-mode panel: its button-pair id, its
-// endpoint suffix, and the display refresh bound to it.
+// One protection panel — frost, holiday or overheat: its button-pair
+// id, its endpoint suffix, and the display refresh bound to it.
 interface ZoneSettingDescriptor {
   readonly id: 'frost_protection' | 'holiday_mode' | 'overheat_protection'
   readonly path: 'frost-protection' | 'holiday-mode' | 'overheat-protection'
   readonly display: () => void
 }
 
+// ── AuthManager ──
 class AuthManager {
   readonly #apiSelect: HTMLSelectElement
 

--- a/tests/fixtures/webview-hashes/valid.json
+++ b/tests/fixtures/webview-hashes/valid.json
@@ -1,5 +1,1 @@
-{
-  "ata-group-setting": "aaaa1111",
-  "charts": "cccc3333",
-  "settings": "bbbb2222"
-}
+{ "page-a": "aaaa1111", "page-b": "bbbb2222", "page-c": "cccc3333" }

--- a/tests/mock-device-class.ts
+++ b/tests/mock-device-class.ts
@@ -55,12 +55,9 @@ export const createMockDeviceClass = (
       __: vi.fn<(key: string) => string>(),
       api: { realtime: vi.fn<(event: string, data: unknown) => void>() },
       app: { getClassicFacade: vi.fn<(kind: string, id: number) => unknown>() },
-      clearInterval: vi.fn<(timer: NodeJS.Timeout | undefined) => void>(),
       clearTimeout: vi.fn<(timer: NodeJS.Timeout | null) => void>(),
       clock: { getTimezone: vi.fn<() => string>(() => 'Europe/Paris') },
       i18n: { getLanguage: vi.fn<() => string>(() => 'en') },
-      setInterval:
-        vi.fn<(callback: () => void, ms: number) => NodeJS.Timeout>(),
       setTimeout: vi.fn<(callback: () => void, ms: number) => NodeJS.Timeout>(),
     }
 

--- a/tests/unit/api-route-guards.test.ts
+++ b/tests/unit/api-route-guards.test.ts
@@ -20,12 +20,12 @@ interface Surface {
 // sources — literal ones exactly, template-built ones by their fixed
 // chunks — and checked against the declared table. The declaration half
 // (manifest ids ↔ handlers, both directions, type level) lives in
-// tests/integration/api-contract.test.ts.
+// tests/unit/api-contract.test.ts.
 const SURFACES: readonly Surface[] = [
   {
     manifest: '.homeycompose/app.json',
     name: 'settings',
-    sourceDirs: ['settings'],
+    sourceDirs: ['settings', 'public'],
   },
   {
     manifest: 'widgets/ata-group-setting/widget.compose.json',
@@ -90,8 +90,8 @@ const extractPathTemplates = (source: string): string[] =>
 
 // The typed helpers carry the verb in their name; the boot beacon calls
 // the raw SDK with the verb as its first argument. Reading the pair
-// matters because eleven declared paths differ only by method —
-// `/classic/sessions` alone is declared under POST, GET and DELETE. The
+// matters because a surface may declare one path under several
+// methods, so a path alone cannot identify its route. The
 // helper name must be followed immediately by its generic or its paren,
 // so the import list is not read as a call site. Template-built paths
 // are swept separately below; a path passed as a variable stays out of
@@ -119,9 +119,9 @@ const extractRouteCalls = (source: string): DeclaredRoute[] => {
   ]
 }
 
-// Every PUT and DELETE call site builds its path from a template, so the
-// literal sweeps above see none of them — the verbs carrying the whole
-// settings surface would go unchecked. A template is still partly known
+// A call site may build its path from a template, which the literal
+// sweeps above cannot see — left alone, such verbs would go
+// unchecked. A template is still partly known
 // at build time: its literal chunks are fixed and ordered, and only the
 // `${…}` holes float (one may expand to nothing, as an optional query
 // string does). Keeping the chunks and letting the holes float is enough
@@ -137,13 +137,13 @@ const escapeRegExp = (chunk: string): string =>
 // literal chunks are found by tracking depth, not by a regex that would
 // stop at the first inner `}`. `${` is folded to one sentinel first so
 // the scan reads a single character per step.
-const HOLE = ''
+const HOLE = '\u{1}'
 
 const toTemplateChunks = (template: string): string[] => {
   const chunks: string[] = []
   let literal = ''
   let depth = 0
-  for (const char of template.replaceAll('${', '')) {
+  for (const char of template.replaceAll('${', '\u{1}')) {
     if (char === HOLE) {
       if (depth === 0) {
         chunks.push(literal)

--- a/tests/unit/api.test.ts
+++ b/tests/unit/api.test.ts
@@ -751,7 +751,7 @@ describe('api', () => {
     it('should serve the packaged manifest map', async () => {
       // A dev suite run packages no manifest: the empty map is the
       // documented fresh-by-default answer.
-      await expect(api.getWebviewHashes()).resolves.toStrictEqual({})
+      await expect(api.getWebviewHashes({ homey })).resolves.toStrictEqual({})
     })
   })
 })

--- a/tests/unit/app.test.ts
+++ b/tests/unit/app.test.ts
@@ -1182,6 +1182,27 @@ describe('melCloudApp', () => {
 
       expect(deviceSettings.melcloud?.always_on).toBeNull()
     })
+
+    it('should keep folding the settings after an earlier conflict', async () => {
+      setupDriver([
+        createClassicDevice({
+          getSettings: vi
+            .fn<() => Record<string, unknown>>()
+            .mockReturnValue({ always_on: true, max_power: 30 }),
+        }),
+        createClassicDevice({
+          getSettings: vi
+            .fn<() => Record<string, unknown>>()
+            .mockReturnValue({ always_on: false, max_power: 50 }),
+        }),
+      ])
+      await app.onInit()
+
+      const deviceSettings = app.getDeviceSettings()
+
+      expect(deviceSettings.melcloud?.always_on).toBeNull()
+      expect(deviceSettings.melcloud?.max_power).toBeNull()
+    })
   })
 
   describe('driver settings retrieval', () => {

--- a/tests/unit/bases.test.ts
+++ b/tests/unit/bases.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+
+import { type LocalizedStrings, localizeWithAffix } from '../../types/bases.mts'
+import { mock } from '../helpers.ts'
+
+describe(localizeWithAffix, () => {
+  it('should join every affix language with its base string', () => {
+    const result = localizeWithAffix(
+      { en: 'Temperature', fr: 'Température' },
+      { en: 'Flow', fr: 'Départ' },
+      'suffix',
+    )
+
+    expect(result).toStrictEqual({
+      en: 'Temperature Flow',
+      fr: 'Température Départ',
+    })
+  })
+
+  it('should lowercase the base after a prefix', () => {
+    const result = localizeWithAffix(
+      { en: 'Temperature' },
+      { en: 'Outdoor' },
+      'prefix',
+    )
+
+    expect(result).toStrictEqual({ en: 'Outdoor temperature' })
+  })
+
+  it('should fall back to the English base for a language the base lacks', () => {
+    const result = localizeWithAffix(
+      { en: 'Temperature' },
+      { en: 'Flow', fr: 'Départ' },
+      'suffix',
+    )
+
+    expect(result.fr).toBe('Temperature Départ')
+  })
+
+  it('should fall back to the English affix for an explicitly undefined entry', () => {
+    const result = localizeWithAffix(
+      { en: 'Temperature', fr: 'Température' },
+      mock<LocalizedStrings>({ en: 'Flow', fr: undefined }),
+      'suffix',
+    )
+
+    expect(result.fr).toBe('Température Flow')
+  })
+})

--- a/tests/unit/classic-device.test.ts
+++ b/tests/unit/classic-device.test.ts
@@ -99,12 +99,9 @@ vi.mock(import('homey'), async () => {
               .mockImplementation((key: string) => key),
             api: { realtime: realtimeMock },
             app: { getClassicFacade: getFacadeMock },
-            clearInterval: vi.fn<(timer: NodeJS.Timeout | undefined) => void>(),
             clearTimeout: vi.fn<(timer: NodeJS.Timeout | null) => void>(),
             clock: { getTimezone: vi.fn<() => string>(() => 'Europe/Paris') },
             i18n: { getLanguage: vi.fn<() => string>(() => 'en') },
-            setInterval:
-              vi.fn<(callback: () => void, ms: number) => NodeJS.Timeout>(),
             setTimeout:
               vi.fn<(callback: () => void, ms: number) => NodeJS.Timeout>(),
           },
@@ -817,13 +814,6 @@ describe(ClassicMELCloudDevice, () => {
   })
 
   describe('timer methods', () => {
-    it('should delegate setInterval to homey.setInterval with duration in ms', () => {
-      const callback = vi.fn<() => Promise<void>>()
-      device.setInterval(callback, { hours: 1 }, 'energy report')
-
-      expect(device.homey.setInterval).toHaveBeenCalledWith(callback, 3_600_000)
-    })
-
     it('should delegate setTimeout to homey.setTimeout with duration in ms', () => {
       const callback = vi.fn<() => Promise<void>>()
       device.setTimeout(callback, { minutes: 5 }, 'sync')

--- a/tests/unit/classic-report.test.ts
+++ b/tests/unit/classic-report.test.ts
@@ -30,8 +30,6 @@ const setCapabilityValueMock =
 const ensureDeviceMock = vi.fn<() => Promise<unknown>>()
 const cleanMappingMock = vi.fn<(mapping: unknown) => Record<string, unknown>>()
 const clearTimeoutMock = vi.fn<(timeout: NodeJS.Timeout | null) => void>()
-const clearIntervalMock =
-  vi.fn<(interval: NodeJS.Timeout | undefined) => void>()
 const setTimeoutMock = vi
   .fn<
     (
@@ -41,15 +39,6 @@ const setTimeoutMock = vi
     ) => number
   >()
   .mockReturnValue(1)
-const setIntervalMock = vi
-  .fn<
-    (
-      callback: () => Promise<void>,
-      interval: unknown,
-      actionType: string,
-    ) => number
-  >()
-  .mockReturnValue(2)
 const logMock = vi.fn<(...args: unknown[]) => void>()
 const errorMock = vi.fn<(...args: unknown[]) => void>()
 const setWarningMock = vi.fn<(warning: string | null) => Promise<void>>()
@@ -87,7 +76,6 @@ const mockDevice = mock<ClassicMELCloudDevice<TestDeviceType>>({
   error: errorMock,
   homey: mock<Homey.Homey>({
     __: translateMock,
-    clearInterval: clearIntervalMock,
     clearTimeout: clearTimeoutMock,
     clock: mock<Homey.Homey['clock']>({
       getTimezone: vi.fn<() => string>(() => 'Europe/Paris'),
@@ -95,7 +83,6 @@ const mockDevice = mock<ClassicMELCloudDevice<TestDeviceType>>({
   }),
   log: logMock,
   setCapabilityValue: setCapabilityValueMock,
-  setInterval: setIntervalMock,
   setTimeout: setTimeoutMock,
   setWarning: setWarningMock,
 })
@@ -148,7 +135,6 @@ const createCopMocks = (
     driver: copDriver,
     ensureDevice: ensureDeviceMock,
     homey: mock<Homey.Homey>({
-      clearInterval: clearIntervalMock,
       clearTimeout: clearTimeoutMock,
       clock: mock<Homey.Homey['clock']>({
         getTimezone: vi.fn<() => string>(() => 'Europe/Paris'),
@@ -156,7 +142,6 @@ const createCopMocks = (
     }),
     log: logMock,
     setCapabilityValue: setCapabilityValueMock,
-    setInterval: setIntervalMock,
     setTimeout: setTimeoutMock,
   })
 }
@@ -520,7 +505,6 @@ describe(EnergyReport, () => {
       )
       await timeoutCallback()
 
-      expect(setIntervalMock).not.toHaveBeenCalled()
       expect(setTimeoutMock).toHaveBeenCalledTimes(2)
       expect(setTimeoutMock).toHaveBeenLastCalledWith(
         expect.any(Function),

--- a/tests/unit/home-base-device.test.ts
+++ b/tests/unit/home-base-device.test.ts
@@ -110,10 +110,7 @@ vi.mock(import('homey'), async () => {
               .mockImplementation((key: string) => key),
             api: { realtime: realtimeMock },
             app: { getHomeFacade: getHomeFacadeMock },
-            clearInterval: vi.fn<(timer: NodeJS.Timeout | undefined) => void>(),
             clearTimeout: vi.fn<(timer: NodeJS.Timeout | null) => void>(),
-            setInterval:
-              vi.fn<(callback: () => void, ms: number) => NodeJS.Timeout>(),
             setTimeout:
               vi.fn<(callback: () => void, ms: number) => NodeJS.Timeout>(),
           },

--- a/tests/unit/melcloud-atw-driver.test.ts
+++ b/tests/unit/melcloud-atw-driver.test.ts
@@ -83,5 +83,21 @@ describe(ClassicMELCloudDriverAtw, () => {
       expect(capabilities).toContain('target_temperature.flow_cool')
       expect(capabilities).toContain('thermostat_mode.zone2')
     })
+
+    it('should never include measure_signal_strength, on any profile', () => {
+      expect.assertions(3)
+
+      const profiles = [
+        undefined,
+        mock<Classic.ListDeviceDataAtw>({ CanCool: false, HasZone2: false }),
+        mock<Classic.ListDeviceDataAtw>({ CanCool: true, HasZone2: true }),
+      ]
+
+      for (const data of profiles) {
+        expect(driver.getRequiredCapabilities(data)).not.toContain(
+          'measure_signal_strength',
+        )
+      }
+    })
   })
 })

--- a/tests/unit/webview-hashes.test.ts
+++ b/tests/unit/webview-hashes.test.ts
@@ -17,9 +17,9 @@ describe(getWebviewHashes, () => {
     await expect(
       getWebviewHashes(fixture('valid.json')),
     ).resolves.toStrictEqual({
-      'ata-group-setting': 'aaaa1111',
-      charts: 'cccc3333',
-      settings: 'bbbb2222',
+      'page-a': 'aaaa1111',
+      'page-b': 'bbbb2222',
+      'page-c': 'cccc3333',
     })
   })
 

--- a/tests/unit/widget-styles.test.ts
+++ b/tests/unit/widget-styles.test.ts
@@ -14,9 +14,14 @@ const readWidgetPair = async (
     ),
   )
 
-const getBootScript = (page: string | undefined): string =>
-  /<script>(?<script>[\s\S]*?)<\/script>/v.exec(page ?? '')?.groups?.script ??
-  ''
+const getBootScript = (page = ''): string => {
+  const opener = '<script>'
+  const start = page.indexOf(opener)
+  const end = page.indexOf('</script>')
+  return start === -1 || end <= start
+    ? ''
+    : page.slice(start + opener.length, end)
+}
 
 const getInitErrorRules = (sheet: string | undefined): string[] =>
   (sheet ?? '').match(/#init_error[^\{]*\{[^\}]*\}/gv) ?? []

--- a/tests/unit/widget-styles.test.ts
+++ b/tests/unit/widget-styles.test.ts
@@ -2,18 +2,47 @@ import { readFile } from 'node:fs/promises'
 
 import { describe, expect, it } from 'vitest'
 
-// The two widgets ship separately, so the zone selector's ghost styling is
-// duplicated on purpose; this pins the copies byte-identical so they cannot
-// drift apart silently.
+// The two widgets ship separately, so shared snippets are duplicated on
+// purpose; these pins keep the copies byte-identical so they cannot drift
+// apart silently.
+const readWidgetPair = async (
+  relativePath: string,
+): Promise<(string | undefined)[]> =>
+  Promise.all(
+    ['ata-group-setting', 'charts'].map(async (widget) =>
+      readFile(`widgets/${widget}/public/${relativePath}`, 'utf8'),
+    ),
+  )
+
+const getBootScript = (page: string | undefined): string =>
+  /<script>(?<script>[\s\S]*?)<\/script>/v.exec(page ?? '')?.groups?.script ??
+  ''
+
+const getInitErrorRules = (sheet: string | undefined): string[] =>
+  (sheet ?? '').match(/#init_error[^\{]*\{[^\}]*\}/gv) ?? []
+
 describe('widget styles', () => {
   it('should keep the zone-select stylesheets byte-identical', async () => {
-    const [ataGroupSetting, charts] = await Promise.all(
-      [
-        'widgets/ata-group-setting/public/styles/zone-select.css',
-        'widgets/charts/public/styles/zone-select.css',
-      ].map(async (path) => readFile(path, 'utf8')),
+    const [ataGroupSetting, charts] = await readWidgetPair(
+      'styles/zone-select.css',
     )
 
     expect(ataGroupSetting).toBe(charts)
+  })
+
+  it('should keep the inline boot scripts byte-identical', async () => {
+    const [ataGroupSetting, charts] = await readWidgetPair('index.html')
+
+    expect(getBootScript(ataGroupSetting)).not.toBe('')
+    expect(getBootScript(ataGroupSetting)).toBe(getBootScript(charts))
+  })
+
+  it('should keep the init-error styling byte-identical', async () => {
+    const [ataGroupSetting, charts] = await readWidgetPair('styles/layout.css')
+
+    expect(getInitErrorRules(ataGroupSetting)).not.toStrictEqual([])
+    expect(getInitErrorRules(ataGroupSetting)).toStrictEqual(
+      getInitErrorRules(charts),
+    )
   })
 })

--- a/types/bases.mts
+++ b/types/bases.mts
@@ -1,5 +1,12 @@
 import { typedFromEntries } from '../lib/typed-object.mts'
 
+const joinWithAffix = (
+  base: string,
+  affix: string,
+  position: 'prefix' | 'suffix',
+): string =>
+  position === 'prefix' ? `${affix} ${base.toLowerCase()}` : `${base} ${affix}`
+
 export const localizeWithAffix = (
   base: LocalizedStrings,
   affix: LocalizedStrings,
@@ -8,16 +15,14 @@ export const localizeWithAffix = (
   ...typedFromEntries(
     Object.entries(affix).map(([language, localizedAffix]) => [
       language,
-      /* v8 ignore next 2 -- both arms run (atw suffix, ata-erv prefix callers) but v8 misattributes the `??` sub-branches inside this map-callback ternary; the identical bare ternary below records both arms covered */
-      position === 'prefix'
-        ? `${localizedAffix ?? affix.en} ${(base[language] ?? base.en).toLowerCase()}`
-        : `${base[language] ?? base.en} ${localizedAffix ?? affix.en}`,
+      joinWithAffix(
+        base[language] ?? base.en,
+        localizedAffix ?? affix.en,
+        position,
+      ),
     ]),
   ),
-  en:
-    position === 'prefix'
-      ? `${affix.en} ${base.en.toLowerCase()}`
-      : `${base.en} ${affix.en}`,
+  en: joinWithAffix(base.en, affix.en, position),
 })
 
 export interface BaseGetCapabilities {

--- a/types/device.mts
+++ b/types/device.mts
@@ -8,11 +8,10 @@ export interface ClassicDeviceFacade {
 
 export interface DeviceDetails<
   T extends Classic.DeviceType = Classic.DeviceType,
-  TId extends number | string = number,
 > {
   readonly capabilities: readonly string[]
   readonly capabilitiesOptions: Partial<CapabilitiesOptions<T>>
-  readonly data: { readonly id: TId }
+  readonly data: { readonly id: number }
   readonly name: string
 }
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,7 +12,12 @@ const swcPlugin = swc.vite({
 const config: ViteUserConfig = defineConfig({
   test: {
     coverage: {
-      exclude: ['**/public/**/*.mts', 'scripts/**/*.mts', 'settings/**/*.mts'],
+      exclude: [
+        '.homeybuild/**',
+        '**/public/**/*.mts',
+        'scripts/**/*.mts',
+        'settings/**/*.mts',
+      ],
       include: ['**/*.mts'],
       reporter: ['text', 'lcov'],
       thresholds: {

--- a/widgets/ata-group-setting/public/animation.mts
+++ b/widgets/ata-group-setting/public/animation.mts
@@ -17,7 +17,11 @@ import {
   homeyApiGet,
   surfaceError,
 } from '../../../public/homey-api.mts'
-import { getZonePath } from '../../../public/zones.mts'
+import {
+  getHomeBuildingId,
+  getZonePath,
+  isHomeBuildingValue,
+} from '../../../public/zones.mts'
 import {
   generateStyleNumber,
   generateStyleString,
@@ -361,7 +365,7 @@ const generateSunShineAnimation = (sun: HTMLDivElement): Animation =>
     iterations: Infinity,
   })
 
-const getPreviousElement = (name: string, index?: string): HTMLElement | null =>
+const getPreviousElement = (name: string, index: string): HTMLElement | null =>
   document.querySelector<HTMLElement>(`#${name}-${String(Number(index) - 1)}`)
 
 // Every removal path ends a flame through its own controller, so
@@ -472,11 +476,9 @@ export class AnimationController {
   #createAnimatedElement(name: AnimatedElement): HTMLDivElement {
     const element = document.createElement('div')
     element.classList.add(name)
-    if (Object.hasOwn(this.#animationMapping, name)) {
-      const mapping = this.#animationMapping[name]
-      element.textContent = mapping.textContent
-      element.id = `${name}-${String(mapping.getIndex())}`
-    }
+    const mapping = this.#animationMapping[name]
+    element.textContent = mapping.textContent
+    element.id = `${name}-${String(mapping.getIndex())}`
     return element
   }
 
@@ -536,25 +538,24 @@ export class AnimationController {
     applyStyles: (element: HTMLDivElement) => void
   }): void {
     const element = this.#createAnimatedElement(name)
-    const [elementName, index] = element.id.split('-', 2)
-    if (elementName !== undefined) {
-      const previousElement = getPreviousElement(elementName, index)
-      const previousPosition =
-        previousElement === null
-          ? -gap * 2
-          : parsePixelValue(previousElement.style[positionProperty])
-      element.style[positionProperty] = generateStyleString(
-        {
-          gap,
-          min:
-            previousPosition > windowDimension ? -gap : previousPosition + gap,
-        },
-        'px',
-      )
-      applyStyles(element)
-      this.#animation.append(element)
-      animate(element)
-    }
+    const previousElement = getPreviousElement(
+      name,
+      element.id.slice(name.length + 1),
+    )
+    const previousPosition =
+      previousElement === null
+        ? -gap * 2
+        : parsePixelValue(previousElement.style[positionProperty])
+    element.style[positionProperty] = generateStyleString(
+      {
+        gap,
+        min: previousPosition > windowDimension ? -gap : previousPosition + gap,
+      },
+      'px',
+    )
+    applyStyles(element)
+    this.#animation.append(element)
+    animate(element)
   }
 
   #createSmokeElement(size: number): HTMLDivElement {
@@ -634,11 +635,10 @@ export class AnimationController {
   // never reach here (a group of one cannot be mixed).
   async #getModes(): Promise<number[]> {
     const { value } = getSelect('zones')
-    const separatorIndex = value.indexOf('_')
-    if (value.slice(0, separatorIndex) === 'homeBuildings') {
+    if (isHomeBuildingValue(value)) {
       return homeyApiGet<number[]>(
         this.#homey,
-        `/home/buildings/${encodeURIComponent(value.slice(separatorIndex + 1))}/ata/modes`,
+        `/home/buildings/${encodeURIComponent(getHomeBuildingId(value))}/ata/modes`,
       )
     }
     const detailedAtaStates = await homeyApiGet<GroupAtaStates>(
@@ -753,36 +753,6 @@ export class AnimationController {
     }
   }
 
-  #runFireAnimation(speed: number): void {
-    this.#generateRecurring(
-      (flameSpeed) => {
-        this.#createFlame(flameSpeed)
-      },
-      AnimationDelay.flame,
-      speed,
-    )
-  }
-
-  #runLeafAnimation(speed: number): void {
-    this.#generateRecurring(
-      (leafSpeed) => {
-        this.#createLeaf(leafSpeed)
-      },
-      AnimationDelay.leaf,
-      speed,
-    )
-  }
-
-  #runSnowAnimation(speed: number): void {
-    this.#generateRecurring(
-      (snowSpeed) => {
-        this.#createSnowflake(snowSpeed)
-      },
-      AnimationDelay.snowflake,
-      speed,
-    )
-  }
-
   #runSunAnimation(speed: number): void {
     const sun = this.#getSunElement()
     this.#sunShine ??= generateSunShineAnimation(sun)
@@ -877,14 +847,37 @@ export class AnimationController {
   // Runs synchronously right after #reset installs the fresh controller,
   // so every spawn loop is bound to it with no interleaving window.
   #startScene(scene: ReadonlySet<SceneElement>, speed: number): void {
-    if (scene.has('fire')) {
-      this.#runFireAnimation(speed)
-    }
-    if (scene.has('leaf')) {
-      this.#runLeafAnimation(speed)
-    }
-    if (scene.has('snow')) {
-      this.#runSnowAnimation(speed)
+    const spawners: readonly {
+      readonly delay: number
+      readonly element: SceneElement
+      readonly spawn: (spawnSpeed: number) => void
+    }[] = [
+      {
+        delay: AnimationDelay.flame,
+        element: 'fire',
+        spawn: (spawnSpeed): void => {
+          this.#createFlame(spawnSpeed)
+        },
+      },
+      {
+        delay: AnimationDelay.leaf,
+        element: 'leaf',
+        spawn: (spawnSpeed): void => {
+          this.#createLeaf(spawnSpeed)
+        },
+      },
+      {
+        delay: AnimationDelay.snowflake,
+        element: 'snow',
+        spawn: (spawnSpeed): void => {
+          this.#createSnowflake(spawnSpeed)
+        },
+      },
+    ]
+    for (const { delay, element, spawn } of spawners) {
+      if (scene.has(element)) {
+        this.#generateRecurring(spawn, delay, speed)
+      }
     }
     if (scene.has('sun')) {
       this.#runSunAnimation(speed)

--- a/widgets/ata-group-setting/public/ata-values.mts
+++ b/widgets/ata-group-setting/public/ata-values.mts
@@ -22,7 +22,15 @@ import {
   homeyApiGet,
   homeyApiPut,
 } from '../../../public/homey-api.mts'
-import { getZoneId, getZoneName } from '../../../public/zones.mts'
+import {
+  getHomeBuildingId,
+  getHomeDeviceId,
+  getZoneId,
+  getZoneName,
+  getZonePath,
+  isHomeBuildingValue,
+  isHomeDeviceValue,
+} from '../../../public/zones.mts'
 
 type TargetZone = Classic.Zone | HomeBuildingZone | HomeDeviceZone
 
@@ -155,18 +163,14 @@ const getSubzones = (zone: TargetZone): TargetZone[] => [
   ...('floors' in zone ? zone.floors : []),
 ]
 
-// Routes a `${model}_${id}` option value to its state endpoint. Split at the
-// FIRST underscore only: Home ids may themselves contain underscores.
+// Routes a `${model}_${id}` option value to its state endpoint.
 const getAtaStatePath = (value: string): string => {
-  const separatorIndex = value.indexOf('_')
-  const model = value.slice(0, separatorIndex)
-  const id = value.slice(separatorIndex + 1)
-  if (model === 'homeBuildings') {
-    return `/home/buildings/${encodeURIComponent(id)}/ata`
+  if (isHomeBuildingValue(value)) {
+    return `/home/buildings/${encodeURIComponent(getHomeBuildingId(value))}/ata`
   }
-  return model === 'homeDevices'
-    ? `/home/devices/${encodeURIComponent(id)}/ata`
-    : `/classic/zones/${model}/${id}/ata`
+  return isHomeDeviceValue(value)
+    ? `/home/devices/${encodeURIComponent(getHomeDeviceId(value))}/ata`
+    : `/classic/zones/${getZonePath(value)}/ata`
 }
 
 // ── AtaValueManager class ──
@@ -367,7 +371,7 @@ export class AtaValueManager {
   }
 
   #updateAtaValue(id: keyof Classic.GroupState): void {
-    const ataValue = document.querySelector(`#${id}`)
+    const ataValue = this.#ataValues.querySelector(`#${CSS.escape(id)}`)
     if (
       ataValue !== null &&
       (ataValue instanceof HTMLInputElement ||

--- a/widgets/ata-group-setting/public/styles/layout.css
+++ b/widgets/ata-group-setting/public/styles/layout.css
@@ -109,8 +109,8 @@ select:not(.zone-select) {
 }
 
 .ghost-button:disabled {
-  cursor: default;
-  opacity: 50%;
+  cursor: not-allowed;
+  opacity: 0.5;
 }
 
 /* The values container is a fieldset so the dirty gate can freeze every
@@ -126,8 +126,8 @@ fieldset.busy-scope {
 }
 
 fieldset[disabled] {
-  cursor: default;
-  opacity: 50%;
+  cursor: not-allowed;
+  opacity: 0.5;
   pointer-events: none;
 }
 

--- a/widgets/charts/public/index.mts
+++ b/widgets/charts/public/index.mts
@@ -1229,7 +1229,7 @@ class ChartWidget {
  * @param homey - The Homey instance handed to `onHomeyReady`.
  */
 export const start = async (homey: Homey<HomeySettings>): Promise<void> => {
-  // Register only what the two chart types use so esbuild tree-shakes the rest.
+  // Register only what the chart types use so esbuild tree-shakes the rest.
   Chart.register(
     ArcElement,
     BarController,


### PR DESCRIPTION
Second review round over the app: every finding personally re-verified against the tree before action.

## Fixed

- **Twin kernel** (`api-route-guards.test.ts`, byte-identical ×3 below the `SURFACES` table — sibling PRs carry the same bytes): the cross-reference now points at `tests/unit/api-contract.test.ts`; the two kernel comments no longer state com.melcloud-only facts; the raw U+0001 bytes are now `'\u{1}'` escapes (the lint's code-point form).
- **Guard hole**: the settings surface now sweeps `public/` too — a `homeyApi*` call added to a shared module was accounted against both widget manifests and silently skipped for the app manifest.
- **Webview-hashes twins**: fixture keys are repo-neutral (`page-a`…) so sibling apps stop asserting this app's widget names; CLAUDE.md's twin roster now names the test and fixtures (×3).
- `#createAnimatedElement`: the `Object.hasOwn` guard over a total `Record<AnimatedElement, …>` is gone, and with it the silent no-id element path; the id parse round-trip in `#createPositionedAnimatedElement` is replaced by slicing the prefix the constructor just wrote — `querySelector('#-NaN')` is now unreachable.
- `#startScene` dispatches through a spawner table (the file's `MODE_SCENES` idiom); the three single-use `#run*Animation` wrappers are gone. Pure orchestration reshuffle — no animation behavior change.
- `getAtaStatePath` and `#getModes` now route through `public/zones.mts`'s prefix contract instead of hand-rolling the `${model}_${id}` split twice.
- `#updateAtaValue` queries inside `this.#ataValues` with `CSS.escape` — one lookup strategy for one control set.
- Dead `setInterval`: no production caller, `ReportDevice` declares `setTimeout` alone; the `timerType`/`timerWords` parameterization collapsed into `setTimeout`.
- `home-report.mts`: the compute-pairs → write-all → return-record tail is one `#applyPairs` helper (both copies). The classic copy stays: it is now single in its file, and hoisting it into the abstract base would widen `ReportDevice` under `method-signature-style`'s property variance for a six-line tail.
- The three `1000` constants are one `WATTS_PER_KILOWATT` in `lib/constants.mts`.
- `#getHomeDeviceFacade` is the one registry-lookup/dispatch kernel; `getHomeFacade` delegates with its type check intact.
- The `/* v8 ignore */` in `types/bases.mts` is retired: the affix ternary is a named `joinWithAffix` helper (also deduping the `en` tail) and new direct tests exercise both `??` fallback arms — branches are back to a true 100 %.
- The tree's only TS-`private` member (`classic-report.mts`) joined the `#` idiom.
- `DeviceDetails` lost its never-instantiated `TId` parameter.
- Breadcrumbs: the four session routes log method-qualified labels (a logout and an auth probe were indistinguishable), and `/webview-hashes` — the page's first call — now logs too.
- Widget twins pinned: the inline boot scripts and the `#init_error` styling join `zone-select.css` in `widget-styles.test.ts`.
- Freeze styling aligned on the settings vocabulary (`cursor: not-allowed; opacity: 0.5`).
- `melcloud_atw` was the one driver whose tests did not pin the `measure_signal_strength` exclusion — it does now.
- Coverage excludes `.homeybuild/**`: the `**/*.mts` glob swept the build output's `.d.mts` files into the lcov SonarCloud uploads (same hazard ×3 apps).
- Stale comments: the charts registration comment named "two" chart types; the `AuthManager` banner sat on `ZoneSettingDescriptor`, whose own doc named two panels out of three.

## Refuted

- **ATA `fetchPoints` "drops `measure`"**: the ATA facade's `getEnergy` takes `{from, interval, to}` only — the ATA wire has a single cumulative counter, no direction split — while the ATW overload *requires* `measure`. The two strategies are the per-type dialect, not residue.
- **Five-ladder capability types**: no clean collapse exists (namespace type-imports are not generically indexable). Open point kept: the fifth ladder's `Record<string, never>` terminal vs `never` on the other four is undocumented drift.

## Deferred (dedicated waves, not silent drops)

- The quintuple settings↔widget helper duplication (`PickerZone`/`TargetZone`, `getSubzones`, `createLabel`, `appendFormControl`, `createInput`, `createSelect`, `populateZoneOptions`) — a refactor wave of its own.
- Numeric-coercion consolidation (`toNumber`/`toDurationDays` onto `lib/validation.mts`) — needs a localized-error option design.
- `parseFormValue` merge — needs a number-strategy parameter design.
- The `fireAndForget` error-adapter closure ×3 — an API-shape decision.
- The two micro re-reads of `getSelect('zones')` — below the value threshold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3