### PR TITLE
chore: drop the stale-bundle ignore chain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,4 @@
 /coverage/
 /env.json
 node_modules/
-/settings/index.js
-/settings/index.mjs
-/widgets/*/public/index.js
-/widgets/*/public/index.mjs
 /.claude/

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,4 +3,3 @@
 /app.json
 /locales/
 /README.md
-/.claude/

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -50,18 +50,7 @@ const typeLikeSortOptions = {
 }
 
 const config: Config[] = defineConfig([
-  {
-    ignores: [
-      '.homeybuild/',
-      'coverage/',
-      // Pre-`.homeybuild` leftovers in never-rebuilt trees: gitignored,
-      // and ignored here so a stale tree cannot break the lint run.
-      'settings/index.js',
-      'settings/index.mjs',
-      'widgets/*/public/index.js',
-      'widgets/*/public/index.mjs',
-    ],
-  },
+  { ignores: ['.homeybuild/', 'coverage/'] },
   {
     linterOptions: {
       reportUnusedDisableDirectives: 'error',


### PR DESCRIPTION
Two-step dedup, both empirically challenged by Olivier. (1) `.prettierignore` entries duplicating `.gitignore` are inert: prettier 3's default `--ignore-path` is `[.gitignore, .prettierignore]` — proven with a stale, deliberately mis-formatted bundle passing `prettier . --check` without them. (2) One step further: the pre-`.homeybuild` ghost bundles (`settings/index.js|mjs`, `widgets/*/public/index.js|mjs`) exist nowhere any more — the build has emitted into `.homeybuild` since the #1404 fix and CI clones are clean by construction — so their `.gitignore` entries and the eslint ignore block that leaned on them guard phantoms and are dropped too. Entries shielding real committed files (`*.html`, generated `app.json`/`locales/`/`README.md` in `.prettierignore`; `.homeybuild/`, `coverage/` in the eslint ignores) stay. Same sweep lands in com.heatzy (incl. its Sonar exclusions naming the same ghosts) and the extension.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3