### PR TITLE
chore: format the README and follow the tsdk setting rename

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,4 +2,3 @@
 /.homeycompose/app.json
 /app.json
 /locales/
-/README.md

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
+  "js/ts.tsdk.path": "node_modules/@typescript/native",
   "sonarlint.connectedMode.project": {
     "connectionId": "olivierzal",
     "projectKey": "OlivierZal_com.melcloud"
-  },
-  "typescript.native-preview.tsdk": "node_modules/@typescript/native"
+  }
 }


### PR DESCRIPTION
Config-ghost sweep follow-ups. `/README.md` leaves `.prettierignore`: the file is already prettier-clean (zero diff, verified across all five repos), formatting markdown is the modern norm (`proseWrap: preserve` never rewraps prose), so the entry only hid future drift. `.vscode/settings.json` follows the extension's announced rename `typescript.native-preview.tsdk` → `js/ts.tsdk.path` (same value, key re-sorted per json/sort-keys). Audited and kept: `/env.json` (Homey CLI input file — a secrets guard for a file class that can legitimately appear), `scripts/**` Sonar exclusions (directory exists), `**/*.jpg` (store images are jpg here, unlike com.heatzy where the pattern was a ghost). Same sweep lands in the four siblings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3