### PR TITLE
fix: make the freeze dim and hidden panels win the injected cascade

### DIFF
--- a/settings/index.css
+++ b/settings/index.css
@@ -65,10 +65,12 @@ input[type='datetime-local']:focus {
 }
 
 /* Ensure `hidden` works on fieldsets: the UA `[hidden] { display: none }`
-   rule ties in specificity (0,1,0) with `.homey-form-fieldset`'s explicit
-   `display`, and the latter wins by source order. Bump specificity to
-   (0,1,1) with a tag selector so the `hidden` attribute is authoritative. */
-fieldset[hidden] {
+   rule ties with the injected sheet's explicit `display` rules and with
+   `fieldset.busy-scope` below, and a tie falls to source order. The
+   `body` ancestor lifts this to (0,1,2) so the `hidden` attribute is
+   authoritative whatever the stylesheet order — the same device as the
+   checkbox-set restack. */
+body fieldset[hidden] {
   display: none;
 }
 
@@ -151,10 +153,16 @@ input.homey-form-checkbox-input:indeterminate
    because WebKit renders inline fieldsets atomically. */
 fieldset.busy-scope {
   border: 0;
-  display: block;
   margin: 0;
   min-inline-size: 0;
   padding: 0;
+}
+
+/* `display` split off and gated on `:not([hidden])`: the block display
+   ties (0,1,1) with the hidden rule's old form and won by source order,
+   which kept a hidden panel visible (the overheat panel regression). */
+fieldset.busy-scope:not([hidden]) {
+  display: block;
 }
 
 /* A dirty-gate freeze sets `disabled` on the gated fieldset while its
@@ -162,7 +170,11 @@ fieldset.busy-scope {
    `:disabled`) so nested fieldsets inside a frozen section do not
    compound the opacity; `pointer-events` because `disabled` only
    reaches form controls, not arbitrary interactive descendants. */
-fieldset[disabled] {
+/* The `body` ancestor outweighs the injected sheet's `all: unset` on
+   checkbox-set fieldsets whatever the order: without it the section dim
+   lost the cascade on-device and the button neutralizer below left
+   in-flight Apply/Refresh fully opaque. */
+body fieldset[disabled] {
   cursor: not-allowed;
   opacity: 0.5;
   pointer-events: none;


### PR DESCRIPTION
Fixes the two reported settings regressions, both provable cascade ties introduced by the freeze wave (#1523):

1. **Overheat panel visible for every zone** — the panel is `<fieldset class="busy-scope" hidden>`, and `fieldset.busy-scope { display: block }` tied (0,1,1) with `fieldset[hidden] { display: none }` but sat later in the sheet, so source order kept the panel displayed. The JS gating was intact. `busy-scope`'s display is now gated on `:not([hidden])` and the hidden rule carries a `body` ancestor.
2. **Apply/Refresh not greyed during an in-flight checkbox-section call** — the sections ARE `fieldset.homey-form-checkbox-set` (button row appended inside), the injected sheet's `all: unset` ties (0,1,1) with the `fieldset[disabled]` dim, and when injection order wins, the neutralizer (`opacity: 1` on buttons inside a frozen fieldset) leaves the buttons fully opaque — while the checkboxes stay unclickable through NATIVE `disabled` semantics, exactly as observed. The dim now carries the `body` ancestor the checkbox-set restack already documents: (0,1,2) outweighs the injected (0,1,1) whatever the stylesheet order.

Same dim hardening lands in com.heatzy and the extension (same freeze rules, latent there); neither sibling toggles `hidden` on fieldsets, so the busy-scope split is com.melcloud-only. **Worth an on-device cold-open check** per the injected-sheet doctrine: one open of the settings page should show the overheat panel only for Home ATA targets and grey both buttons during a checkbox-section apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3