### PR TITLE
fix: refetch a stale webview through a never-cached address

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,8 +46,12 @@ caught real failures that the others miss:
   `tests/unit/webview-hashes.test.ts` and the
   `tests/fixtures/webview-hashes/` fixtures are byte-identical in the
   three apps — edit all three together), and a mismatch triggers ONE
-  `location.reload()` (sessionStorage guard, `webview-freshness.mts`),
-  which revalidates the HTML and pulls the fresh bundle. Every failure
+  refetch of the document through a never-cached address
+  (`?fresh=<identity>` — a bare reload can be re-served the same stale
+  document from the HTTP cache; sessionStorage guard,
+  `webview-freshness.mts`), whose fresh stamps pull the fresh assets;
+  a mismatch that survives its refetch is reported to
+  `POST /boot-error`. Every failure
   path stays open: an unstamped page, an absent route or denied
   storage must never take a working webview down.
 - `npm run homey:validate` — Homey validation at publish level; may

--- a/public/homey-api.mts
+++ b/public/homey-api.mts
@@ -107,6 +107,14 @@ export const homeyApiGet = async <T,>(
   // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- Homey widget API returns unknown
   (await homey.api('GET', path)) as T
 
+export const homeyApiPost = async (
+  homey: HomeyWidget,
+  path: string,
+  body: object,
+): Promise<void> => {
+  await homey.api('POST', path, body)
+}
+
 export const homeyApiPut = async (
   homey: HomeyWidget,
   path: string,

--- a/public/webview-freshness-boot.mts
+++ b/public/webview-freshness-boot.mts
@@ -1,0 +1,31 @@
+// Widget-side freshness bootstrap: one shared decision for every widget
+// entry. The twin primitive stays transport-free; this wrapper feeds it
+// the promise-native widget transport and the boot-error breadcrumb
+// channel.
+import type HomeyWidget from 'homey/lib/HomeyWidget'
+
+import { fireAndForget, homeyApiGet, homeyApiPost } from './homey-api.mts'
+import { ensureFreshWebview } from './webview-freshness.mts'
+
+// A stale cached page refetches itself once (never-cached address)
+// instead of booting: when this resolves `true` the caller must skip its
+// init — the document is about to be replaced.
+export const ensureFreshWidget = async (
+  homey: HomeyWidget,
+  entry: string,
+): Promise<boolean> =>
+  ensureFreshWebview(
+    entry,
+    async () => homeyApiGet(homey, '/webview-hashes'),
+    (message) => {
+      fireAndForget(
+        homeyApiPost(homey, '/boot-error', {
+          message,
+          name: 'WebviewFreshness',
+        }),
+        () => {
+          // A missed freshness breadcrumb is acceptable.
+        },
+      )
+    },
+  )

--- a/public/webview-freshness.mts
+++ b/public/webview-freshness.mts
@@ -6,14 +6,17 @@
 // it carries (so a CSS-only or markup-only ship moves it too); the app
 // serves the live identities (`GET /webview-hashes`, emitted at
 // package time), fetched through the app bridge so no HTTP cache can
-// stale them. On mismatch the page reloads ONCE — the reload
-// revalidates the HTML, whose fresh stamps pull the fresh assets.
-// Every failure path stays open (unstamped page, unreachable route,
-// unknown entry, denied storage): a wrong guess must never take a
-// working webview down. Byte-identical copies live in the sibling
-// Homey apps — edit all three together.
+// stale them. On mismatch the page refetches itself ONCE, through an
+// address the HTTP cache has never seen: a bare reload can be served
+// the same stale document again (proven on-device by a page mixing
+// asset generations), burning the one-shot guard on a no-op. A
+// mismatch that survives its refetch is reported through the optional
+// `report` channel instead of retried. Every failure path stays open
+// (unstamped page, unreachable route, unknown entry, denied storage):
+// a wrong guess must never take a working webview down. Byte-identical
+// copies live in the sibling Homey apps — edit all three together.
 
-const RELOAD_GUARD_KEY = 'webview_reloaded_for'
+const REFETCH_GUARD_KEY = 'webview_refetched_for'
 
 const STAMP = /\?v=(?<hash>[0-9a-f]+)$/u
 
@@ -55,44 +58,69 @@ const getPageIdentity = (): string | null => {
   return stamps.length > 0 ? stamps.join('.') : null
 }
 
-// Denied storage reads as "already reloaded": without the guard a
-// persistent mismatch would reload forever, and never reloading is the
-// safe side of that trade.
-const hasReloadedFor = (hash: string): boolean => {
+// Denied storage reads as "already refetched": without the guard a
+// persistent mismatch would refetch forever, and never refetching is
+// the safe side of that trade.
+const hasRefetchedFor = (hash: string): boolean => {
   try {
-    return sessionStorage.getItem(RELOAD_GUARD_KEY) === hash
+    return sessionStorage.getItem(REFETCH_GUARD_KEY) === hash
   } catch {
     return true
   }
 }
 
-const markReloadedFor = (hash: string): void => {
+const markRefetchedFor = (hash: string): void => {
   try {
-    sessionStorage.setItem(RELOAD_GUARD_KEY, hash)
+    sessionStorage.setItem(REFETCH_GUARD_KEY, hash)
   } catch {
-    // Denied storage already reads as "reloaded" (`hasReloadedFor`).
+    // Denied storage already reads as "refetched" (`hasRefetchedFor`).
   }
 }
 
-// Returns whether a reload was issued — the caller must then skip its
+// The `fresh` key makes the address one the HTTP cache has never seen,
+// forcing a network fetch of the document; it is overwritten, never
+// accumulated, and carries the stale identity — not a clock or random
+// read, which would mint a new address on every boot and sidestep the
+// per-identity guard.
+const refetchDocument = (identity: string): void => {
+  const url = new URL(location.href)
+  url.searchParams.set('fresh', identity)
+  location.replace(url.href)
+}
+
+// One-shot refetch decision for a confirmed mismatch: refetches unless
+// this identity already spent its attempt, reporting either way.
+const refetchOnce = (
+  identity: string,
+  expected: string,
+  report?: (message: string) => void,
+): boolean => {
+  if (hasRefetchedFor(identity)) {
+    report?.(
+      `Stale webview persists after its refetch: page ${identity}, live ${expected}`,
+    )
+    return false
+  }
+  report?.(`Stale webview: page ${identity}, live ${expected} — refetching`)
+  markRefetchedFor(identity)
+  refetchDocument(identity)
+  return true
+}
+
+// Returns whether a refetch was issued — the caller must then skip its
 // own init: the document is about to be replaced.
 export const ensureFreshWebview = async (
   entry: string,
   fetchHashes: () => Promise<Partial<Record<string, string>>>,
+  report?: (message: string) => void,
 ): Promise<boolean> => {
   const identity = getPageIdentity()
   if (identity === null) {
     return false
   }
   const expected = await fetchExpected(entry, fetchHashes)
-  if (
-    expected === undefined ||
-    expected === identity ||
-    hasReloadedFor(identity)
-  ) {
+  if (expected === undefined || expected === identity) {
     return false
   }
-  markReloadedFor(identity)
-  location.reload()
-  return true
+  return refetchOnce(identity, expected, report)
 }

--- a/public/webview-freshness.mts
+++ b/public/webview-freshness.mts
@@ -58,22 +58,36 @@ const getPageIdentity = (): string | null => {
   return stamps.length > 0 ? stamps.join('.') : null
 }
 
-// Denied storage reads as "already refetched": without the guard a
-// persistent mismatch would refetch forever, and never refetching is
-// the safe side of that trade.
-const hasRefetchedFor = (hash: string): boolean => {
+// Denied storage cannot arm the loop guard, so it must not refetch:
+// the address is deterministic per identity, and an unguarded attempt
+// re-served from the cache would boot-navigate forever. Skipping (and
+// saying so) is the safe side of that trade.
+const DENIED = Symbol('denied')
+
+const readStoredGuard = (): string | symbol | null => {
   try {
-    return sessionStorage.getItem(REFETCH_GUARD_KEY) === hash
+    return sessionStorage.getItem(REFETCH_GUARD_KEY)
   } catch {
-    return true
+    return DENIED
   }
 }
 
-const markRefetchedFor = (hash: string): void => {
+const readRefetchGuard = (hash: string): 'armed' | 'denied' | 'spent' => {
+  const stored = readStoredGuard()
+  if (stored === DENIED) {
+    return 'denied'
+  }
+  return stored === hash ? 'spent' : 'armed'
+}
+
+// Returns whether the guard was persisted — navigating without it risks
+// the same livelock as a denied read, so a failed write also skips.
+const markRefetchedFor = (hash: string): boolean => {
   try {
     sessionStorage.setItem(REFETCH_GUARD_KEY, hash)
+    return true
   } catch {
-    // Denied storage already reads as "refetched" (`hasRefetchedFor`).
+    return false
   }
 }
 
@@ -81,30 +95,70 @@ const markRefetchedFor = (hash: string): void => {
 // forcing a network fetch of the document; it is overwritten, never
 // accumulated, and carries the stale identity — not a clock or random
 // read, which would mint a new address on every boot and sidestep the
-// per-identity guard.
-const refetchDocument = (identity: string): void => {
-  const url = new URL(location.href)
-  url.searchParams.set('fresh', identity)
-  location.replace(url.href)
+// per-identity guard. A navigation failure is reported and swallowed:
+// the stale page must keep booting.
+const refetchDocument = (
+  identity: string,
+  report?: (message: string) => void,
+): boolean => {
+  try {
+    const url = new URL(location.href)
+    url.searchParams.set('fresh', identity)
+    location.replace(url.href)
+    return true
+  } catch {
+    report?.(`Stale webview refetch could not navigate: page ${identity}`)
+    return false
+  }
+}
+
+// Reports the guard outcome that stops a refetch, if any.
+const reportStopped = ({
+  expected,
+  guard,
+  identity,
+  report,
+}: {
+  expected: string
+  guard: 'armed' | 'denied' | 'spent'
+  identity: string
+  report?: ((message: string) => void) | undefined
+}): boolean => {
+  if (guard === 'denied') {
+    report?.(
+      `Stale webview: page ${identity}, live ${expected} — storage denied, refetch skipped`,
+    )
+    return true
+  }
+  if (guard === 'spent') {
+    report?.(
+      `Stale webview persists after its refetch: page ${identity}, live ${expected}`,
+    )
+    return true
+  }
+  return false
 }
 
 // One-shot refetch decision for a confirmed mismatch: refetches unless
-// this identity already spent its attempt, reporting either way.
+// this identity already spent its attempt or the guard cannot hold one,
+// reporting each outcome distinctly.
 const refetchOnce = (
   identity: string,
   expected: string,
   report?: (message: string) => void,
 ): boolean => {
-  if (hasRefetchedFor(identity)) {
+  const guard = readRefetchGuard(identity)
+  if (reportStopped({ expected, guard, identity, report })) {
+    return false
+  }
+  if (!markRefetchedFor(identity)) {
     report?.(
-      `Stale webview persists after its refetch: page ${identity}, live ${expected}`,
+      `Stale webview: page ${identity}, live ${expected} — guard unwritable, refetch skipped`,
     )
     return false
   }
   report?.(`Stale webview: page ${identity}, live ${expected} — refetching`)
-  markRefetchedFor(identity)
-  refetchDocument(identity)
-  return true
+  return refetchDocument(identity, report)
 }
 
 // Returns whether a refetch was issued — the caller must then skip its

--- a/settings/index.mts
+++ b/settings/index.mts
@@ -1919,8 +1919,19 @@ class SettingsApp {
     // A stale cached page reloads itself once instead of booting: skip
     // the init — the document is about to be replaced.
     if (
-      await ensureFreshWebview('settings', async () =>
-        homeyApiGet(this.#homey, '/webview-hashes'),
+      await ensureFreshWebview(
+        'settings',
+        async () => homeyApiGet(this.#homey, '/webview-hashes'),
+        (message) => {
+          this.#homey.api(
+            'POST',
+            '/boot-error',
+            { message, name: 'WebviewFreshness' },
+            () => {
+              // A missed freshness breadcrumb is acceptable.
+            },
+          )
+        },
       )
     ) {
       return

--- a/settings/index.mts
+++ b/settings/index.mts
@@ -1916,7 +1916,8 @@ class SettingsApp {
   // `ready()` always fires — an unbounded await here would hold Homey's
   // loading overlay open forever on a single hung or failed call.
   public async init(): Promise<void> {
-    // A stale cached page reloads itself once instead of booting: skip
+    // A stale cached page refetches itself once (never-cached address)
+    // instead of booting: skip
     // the init — the document is about to be replaced.
     if (
       await ensureFreshWebview(

--- a/tests/unit/webview-freshness.test.ts
+++ b/tests/unit/webview-freshness.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { type Mock, afterEach, describe, expect, it, vi } from 'vitest'
 
 import { ensureFreshWebview } from '../../public/webview-freshness.mts'
 
@@ -40,7 +40,7 @@ const install = ({
   isStorageDenied?: boolean
   isWriteDenied?: boolean
   stored?: string | null
-}): { store: Map<string, string>; replace: (url: string) => void } => {
+}): { replace: Mock<(url: string) => void>; store: Map<string, string> } => {
   const replace = vi.fn<(url: string) => void>()
   const store = new Map<string, string>()
   if (stored !== null) {
@@ -214,26 +214,55 @@ describe(ensureFreshWebview, () => {
     expect(replace).not.toHaveBeenCalled()
   })
 
-  it('should refetch even when the guard cannot be written', async () => {
+  it('should skip the refetch when the guard cannot be written', async () => {
+    const report = vi.fn<(message: string) => void>()
     const { replace } = install({ isWriteDenied: true, references: STALE_PAGE })
 
     await expect(
-      ensureFreshWebview('ata-group-setting', serveHashes),
-    ).resolves.toBe(true)
+      ensureFreshWebview('ata-group-setting', serveHashes, report),
+    ).resolves.toBe(false)
 
-    expect(replace).toHaveBeenCalledTimes(1)
+    // Navigating without a persisted guard risks a boot-navigation
+    // livelock: the address is deterministic per identity, so a cached
+    // response to it would be re-attempted on every boot.
+    expect(replace).not.toHaveBeenCalled()
+    expect(report).toHaveBeenCalledWith(
+      'Stale webview: page cccc0000.00000000, live cccc0000.aaaa1111 — guard unwritable, refetch skipped',
+    )
   })
 
-  it('should read denied storage as already refetched', async () => {
+  it('should skip the refetch and say so when storage is denied', async () => {
+    const report = vi.fn<(message: string) => void>()
     const { replace } = install({
       isStorageDenied: true,
       references: STALE_PAGE,
     })
 
     await expect(
-      ensureFreshWebview('ata-group-setting', serveHashes),
+      ensureFreshWebview('ata-group-setting', serveHashes, report),
     ).resolves.toBe(false)
 
     expect(replace).not.toHaveBeenCalled()
+    // Denied storage is its own outcome — reporting it as a spent
+    // refetch would claim an attempt that never happened.
+    expect(report).toHaveBeenCalledWith(
+      'Stale webview: page cccc0000.00000000, live cccc0000.aaaa1111 — storage denied, refetch skipped',
+    )
+  })
+
+  it('should keep the page booting when the navigation fails', async () => {
+    const report = vi.fn<(message: string) => void>()
+    const { replace } = install({ references: STALE_PAGE })
+    replace.mockImplementation(() => {
+      throw new Error('blocked')
+    })
+
+    await expect(
+      ensureFreshWebview('ata-group-setting', serveHashes, report),
+    ).resolves.toBe(false)
+
+    expect(report).toHaveBeenCalledWith(
+      'Stale webview refetch could not navigate: page cccc0000.00000000',
+    )
   })
 })

--- a/tests/unit/webview-freshness.test.ts
+++ b/tests/unit/webview-freshness.test.ts
@@ -3,8 +3,8 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { ensureFreshWebview } from '../../public/webview-freshness.mts'
 
 // The helper reads narrow slices of the page (its stamped references,
-// sessionStorage, location.reload), so plain doubles installed on
-// globalThis are enough — no DOM environment.
+// sessionStorage, location), so plain doubles installed on globalThis
+// are enough — no DOM environment.
 class FakeReference {
   readonly #reference: string
 
@@ -26,26 +26,30 @@ const globals = globalThis as {
   sessionStorage?: unknown
 }
 
+const PAGE_URL = 'https://webview.invalid/page'
+
 const install = ({
+  href = PAGE_URL,
   isStorageDenied = false,
   isWriteDenied = false,
   references,
   stored = null,
 }: {
   references: readonly FakeReference[]
+  href?: string
   isStorageDenied?: boolean
   isWriteDenied?: boolean
   stored?: string | null
-}): { store: Map<string, string>; reload: () => void } => {
-  const reload = vi.fn<() => void>()
+}): { store: Map<string, string>; replace: (url: string) => void } => {
+  const replace = vi.fn<(url: string) => void>()
   const store = new Map<string, string>()
   if (stored !== null) {
-    store.set('webview_reloaded_for', stored)
+    store.set('webview_refetched_for', stored)
   }
   globals.document = {
     querySelectorAll: (): readonly FakeReference[] => references,
   }
-  globals.location = { reload }
+  globals.location = { href, replace }
   globals.sessionStorage = {
     getItem: (key: string): string | null => {
       if (isStorageDenied) {
@@ -60,7 +64,7 @@ const install = ({
       store.set(key, value)
     },
   }
-  return { reload, store }
+  return { replace, store }
 }
 
 // The live identity is the DOCUMENT-ORDER join of the page's stamps.
@@ -87,29 +91,56 @@ describe(ensureFreshWebview, () => {
     delete globals.sessionStorage
   })
 
-  it('should reload once on a stale identity and record the guard', async () => {
-    const { reload, store } = install({ references: STALE_PAGE })
+  it('should refetch a stale page through a never-cached address', async () => {
+    const { replace, store } = install({ references: STALE_PAGE })
 
     await expect(
       ensureFreshWebview('ata-group-setting', serveHashes),
     ).resolves.toBe(true)
 
-    expect(reload).toHaveBeenCalledTimes(1)
-    expect(store.get('webview_reloaded_for')).toBe('cccc0000.00000000')
+    // A fresh query key forces a network fetch — a bare reload can be
+    // served the same stale document from the HTTP cache.
+    expect(replace).toHaveBeenCalledTimes(1)
+    expect(replace).toHaveBeenCalledWith(`${PAGE_URL}?fresh=cccc0000.00000000`)
+    expect(store.get('webview_refetched_for')).toBe('cccc0000.00000000')
   })
 
-  it('should not reload when the page identity is live', async () => {
-    const { reload } = install({ references: FRESH_PAGE })
+  it('should overwrite a previous fresh key instead of accumulating', async () => {
+    const { replace } = install({
+      href: `${PAGE_URL}?fresh=deadbeef`,
+      references: STALE_PAGE,
+    })
+
+    await expect(
+      ensureFreshWebview('ata-group-setting', serveHashes),
+    ).resolves.toBe(true)
+
+    expect(replace).toHaveBeenCalledWith(`${PAGE_URL}?fresh=cccc0000.00000000`)
+  })
+
+  it('should report the identities alongside the refetch', async () => {
+    const report = vi.fn<(message: string) => void>()
+    install({ references: STALE_PAGE })
+
+    await ensureFreshWebview('ata-group-setting', serveHashes, report)
+
+    expect(report).toHaveBeenCalledWith(
+      'Stale webview: page cccc0000.00000000, live cccc0000.aaaa1111 — refetching',
+    )
+  })
+
+  it('should not refetch when the page identity is live', async () => {
+    const { replace } = install({ references: FRESH_PAGE })
 
     await expect(
       ensureFreshWebview('ata-group-setting', serveHashes),
     ).resolves.toBe(false)
 
-    expect(reload).not.toHaveBeenCalled()
+    expect(replace).not.toHaveBeenCalled()
   })
 
-  it('should not reload twice for the same stale identity', async () => {
-    const { reload } = install({
+  it('should not refetch twice for the same stale identity', async () => {
+    const { replace } = install({
       references: STALE_PAGE,
       stored: 'cccc0000.00000000',
     })
@@ -118,21 +149,38 @@ describe(ensureFreshWebview, () => {
       ensureFreshWebview('ata-group-setting', serveHashes),
     ).resolves.toBe(false)
 
-    expect(reload).not.toHaveBeenCalled()
+    expect(replace).not.toHaveBeenCalled()
+  })
+
+  it('should report a mismatch that survived its refetch', async () => {
+    const report = vi.fn<(message: string) => void>()
+    const { replace } = install({
+      references: STALE_PAGE,
+      stored: 'cccc0000.00000000',
+    })
+
+    await expect(
+      ensureFreshWebview('ata-group-setting', serveHashes, report),
+    ).resolves.toBe(false)
+
+    expect(replace).not.toHaveBeenCalled()
+    expect(report).toHaveBeenCalledWith(
+      'Stale webview persists after its refetch: page cccc0000.00000000, live cccc0000.aaaa1111',
+    )
   })
 
   it('should stay put on an unstamped page', async () => {
-    const { reload } = install({ references: [] })
+    const { replace } = install({ references: [] })
 
     await expect(
       ensureFreshWebview('ata-group-setting', serveHashes),
     ).resolves.toBe(false)
 
-    expect(reload).not.toHaveBeenCalled()
+    expect(replace).not.toHaveBeenCalled()
   })
 
   it('should ignore references whose stamp is off-shape', async () => {
-    const { reload } = install({
+    const { replace } = install({
       references: [new FakeReference('src', 'index.js?v=NOT-A-HASH')],
     })
 
@@ -140,19 +188,19 @@ describe(ensureFreshWebview, () => {
       ensureFreshWebview('ata-group-setting', serveHashes),
     ).resolves.toBe(false)
 
-    expect(reload).not.toHaveBeenCalled()
+    expect(replace).not.toHaveBeenCalled()
   })
 
   it('should stay put when its entry is not served', async () => {
-    const { reload } = install({ references: STALE_PAGE })
+    const { replace } = install({ references: STALE_PAGE })
 
     await expect(ensureFreshWebview('charts', serveHashes)).resolves.toBe(false)
 
-    expect(reload).not.toHaveBeenCalled()
+    expect(replace).not.toHaveBeenCalled()
   })
 
   it('should stay put when fetching the hashes fails', async () => {
-    const { reload } = install({ references: STALE_PAGE })
+    const { replace } = install({ references: STALE_PAGE })
 
     await expect(
       ensureFreshWebview(
@@ -163,21 +211,21 @@ describe(ensureFreshWebview, () => {
       ),
     ).resolves.toBe(false)
 
-    expect(reload).not.toHaveBeenCalled()
+    expect(replace).not.toHaveBeenCalled()
   })
 
-  it('should reload even when the guard cannot be written', async () => {
-    const { reload } = install({ isWriteDenied: true, references: STALE_PAGE })
+  it('should refetch even when the guard cannot be written', async () => {
+    const { replace } = install({ isWriteDenied: true, references: STALE_PAGE })
 
     await expect(
       ensureFreshWebview('ata-group-setting', serveHashes),
     ).resolves.toBe(true)
 
-    expect(reload).toHaveBeenCalledTimes(1)
+    expect(replace).toHaveBeenCalledTimes(1)
   })
 
-  it('should read denied storage as already reloaded', async () => {
-    const { reload } = install({
+  it('should read denied storage as already refetched', async () => {
+    const { replace } = install({
       isStorageDenied: true,
       references: STALE_PAGE,
     })
@@ -186,6 +234,6 @@ describe(ensureFreshWebview, () => {
       ensureFreshWebview('ata-group-setting', serveHashes),
     ).resolves.toBe(false)
 
-    expect(reload).not.toHaveBeenCalled()
+    expect(replace).not.toHaveBeenCalled()
   })
 })

--- a/widgets/ata-group-setting/public/index.mts
+++ b/widgets/ata-group-setting/public/index.mts
@@ -15,6 +15,7 @@ import {
   type Homey,
   fireAndForget,
   homeyApiGet,
+  homeyApiPost,
   runWebview,
   surfaceError,
   trySetDocumentLanguage,
@@ -62,8 +63,20 @@ class WidgetApp {
     // A stale cached page reloads itself once instead of booting: skip
     // the init — the document is about to be replaced.
     if (
-      await ensureFreshWebview('ata-group-setting', async () =>
-        homeyApiGet(this.#homey, '/webview-hashes'),
+      await ensureFreshWebview(
+        'ata-group-setting',
+        async () => homeyApiGet(this.#homey, '/webview-hashes'),
+        (message) => {
+          fireAndForget(
+            homeyApiPost(this.#homey, '/boot-error', {
+              message,
+              name: 'WebviewFreshness',
+            }),
+            () => {
+              // A missed freshness breadcrumb is acceptable.
+            },
+          )
+        },
       )
     ) {
       return

--- a/widgets/ata-group-setting/public/index.mts
+++ b/widgets/ata-group-setting/public/index.mts
@@ -15,12 +15,11 @@ import {
   type Homey,
   fireAndForget,
   homeyApiGet,
-  homeyApiPost,
   runWebview,
   surfaceError,
   trySetDocumentLanguage,
 } from '../../../public/homey-api.mts'
-import { ensureFreshWebview } from '../../../public/webview-freshness.mts'
+import { ensureFreshWidget } from '../../../public/webview-freshness-boot.mts'
 import { AnimationController, AnimationDelay } from './animation.mts'
 import { AtaValueManager } from './ata-values.mts'
 
@@ -60,25 +59,10 @@ class WidgetApp {
   // `ready()` always fires — an unbounded await here would hold Homey's
   // loading overlay open forever on a single hung or failed call.
   public async init(): Promise<void> {
-    // A stale cached page reloads itself once instead of booting: skip
-    // the init — the document is about to be replaced.
-    if (
-      await ensureFreshWebview(
-        'ata-group-setting',
-        async () => homeyApiGet(this.#homey, '/webview-hashes'),
-        (message) => {
-          fireAndForget(
-            homeyApiPost(this.#homey, '/boot-error', {
-              message,
-              name: 'WebviewFreshness',
-            }),
-            () => {
-              // A missed freshness breadcrumb is acceptable.
-            },
-          )
-        },
-      )
-    ) {
+    // A stale cached page refetches itself once (never-cached address)
+    // instead of booting: skip the init — the document is about to be
+    // replaced.
+    if (await ensureFreshWidget(this.#homey, 'ata-group-setting')) {
       return
     }
     await runWebview(this.#homey, this.#run(), {

--- a/widgets/charts/public/index.mts
+++ b/widgets/charts/public/index.mts
@@ -43,12 +43,11 @@ import {
   type Homey,
   fireAndForget,
   homeyApiGet,
-  homeyApiPost,
   runWebview,
   surfaceError,
   trySetDocumentLanguage,
 } from '../../../public/homey-api.mts'
-import { ensureFreshWebview } from '../../../public/webview-freshness.mts'
+import { ensureFreshWidget } from '../../../public/webview-freshness-boot.mts'
 import { getZoneId, getZonePath } from '../../../public/zones.mts'
 import {
   type DaysQuery,
@@ -873,25 +872,10 @@ class ChartWidget {
   // `ready()` always fires — an unbounded await here would hold Homey's
   // loading overlay open forever on a single hung or failed call.
   public async init(): Promise<void> {
-    // A stale cached page reloads itself once instead of booting: skip
-    // the init — the document is about to be replaced.
-    if (
-      await ensureFreshWebview(
-        'charts',
-        async () => homeyApiGet(this.#homey, '/webview-hashes'),
-        (message) => {
-          fireAndForget(
-            homeyApiPost(this.#homey, '/boot-error', {
-              message,
-              name: 'WebviewFreshness',
-            }),
-            () => {
-              // A missed freshness breadcrumb is acceptable.
-            },
-          )
-        },
-      )
-    ) {
+    // A stale cached page refetches itself once (never-cached address)
+    // instead of booting: skip the init — the document is about to be
+    // replaced.
+    if (await ensureFreshWidget(this.#homey, 'charts')) {
       return
     }
     await runWebview(this.#homey, this.#run(), {

--- a/widgets/charts/public/index.mts
+++ b/widgets/charts/public/index.mts
@@ -43,6 +43,7 @@ import {
   type Homey,
   fireAndForget,
   homeyApiGet,
+  homeyApiPost,
   runWebview,
   surfaceError,
   trySetDocumentLanguage,
@@ -875,8 +876,20 @@ class ChartWidget {
     // A stale cached page reloads itself once instead of booting: skip
     // the init — the document is about to be replaced.
     if (
-      await ensureFreshWebview('charts', async () =>
-        homeyApiGet(this.#homey, '/webview-hashes'),
+      await ensureFreshWebview(
+        'charts',
+        async () => homeyApiGet(this.#homey, '/webview-hashes'),
+        (message) => {
+          fireAndForget(
+            homeyApiPost(this.#homey, '/boot-error', {
+              message,
+              name: 'WebviewFreshness',
+            }),
+            () => {
+              // A missed freshness breadcrumb is acceptable.
+            },
+          )
+        },
       )
     ) {
       return


### PR DESCRIPTION
Hardens the freshness handshake against the failure just proven on-device: a mismatch triggered a bare `location.reload()`, which the HTTP cache can answer with the **same stale document** — the sessionStorage guard then marks the identity as attempted and the page stays stale for good. Olivier's phone showed exactly that end state: a mixed-generation page (fieldset-era HTML rendered with pre-freeze CSS — visible frames), immune to the handshake.

- The refetch now navigates to the page URL with a `fresh=<identity>` query key the cache has never seen, forcing a network fetch of the document. The key is overwritten, never accumulated, and derives from the stale identity — deterministic, so the per-identity one-shot guard keeps its semantics (no clock or random read, which would mint a new address every boot and sidestep the guard).
- New optional `report` channel on `ensureFreshWebview`, wired at every call site (settings + both widgets) to the surface's declared `POST /boot-error`: `homey app run` now SHOWS each handshake decision — including the new "mismatch persists after its refetch" breadcrumb, the stuck-state detector.
- Twin discipline: module byte-identical ×3 (md5-checked), test identical up to its import path, same doctrine sentence updated in the three CLAUDE.md.
- 12 tests; 6 fail under the old reload-based module (mutation-checked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3