### PR TITLE
fix: let the busy-scope chrome reset outweigh the injected cascade

### DIFF
--- a/settings/index.css
+++ b/settings/index.css
@@ -151,7 +151,11 @@ input.homey-form-checkbox-input:indeterminate
    whole dirty-gated form region: none of the UA fieldset chrome (border,
    padding, min-inline-size) may surface. Explicit `display: block`
    because WebKit renders inline fieldsets atomically. */
-fieldset.busy-scope {
+/* The `body` ancestor outweighs the injected sheet's fieldset styling
+   whatever the order — the same device as the hidden and disabled
+   rules, and the reason the panel frames survived a (0,1,1) tie
+   on-device while a headless probe (no injected sheet) showed none. */
+body fieldset.busy-scope {
   border: 0;
   margin: 0;
   min-inline-size: 0;


### PR DESCRIPTION
Third and last of the cascade-tie family, reported on-device with a FRESH page (the two body-prefixed rules from #1529 are live-confirmed fixed, so this is not cache): the zone-panel fieldsets still show their chrome frames. The `fieldset.busy-scope` border/padding reset was the one freeze rule left at (0,1,1) — an on-device tie against the injected sheet that a headless probe (no injected sheet) cannot reproduce, which is why #1529's probe showed `border: 0px`. Same remedy as its two siblings: the `body` ancestor, (0,1,2), order-proof. Extension hardened alike (latent); com.heatzy has no busy-scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3