### PR TITLE
feat: poke open webviews with the freshness handshake at boot

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,10 @@ caught real failures that the others miss:
   document from the HTTP cache; sessionStorage guard,
   `webview-freshness.mts`), whose fresh stamps pull the fresh assets;
   a mismatch that survives its refetch is reported to
-  `POST /boot-error`. Every failure
+  `POST /boot-error`. The app also emits a `webview_hashes_changed`
+  realtime event at its own boot; an open page re-runs the same
+  handshake on it — a second trigger of the one primitive, covering a
+  page left open across an app restart or update. Every failure
   path stays open: an unstamped page, an absent route or denied
   storage must never take a working webview down.
 - `npm run homey:validate` — Homey validation at publish level; may
@@ -410,8 +413,10 @@ coverage.
   before acting either way (Copilot has been wrong about library
   semantics). Resolve the thread once settled; none left dangling.
 - SonarCloud must be spotless for a PR to merge: quality gate green,
-  zero open issues on its analysis, and 100 % coverage (within the
-  exclusions `sonar-project.properties` declares). A Sonar finding is
+  zero open issues on its analysis, 100 % coverage (within the
+  exclusions `sonar-project.properties` declares), and 0 % duplicated
+  lines across the WHOLE codebase — new and old alike, not just the
+  gate's new-code window. A Sonar finding is
   handled like a lint error — the code adapts, or the divergence is
   settled as a documented verdict (e.g. the `Number.NaN` convention in
   `eslint.config.ts`) — never merged over.

--- a/app.mts
+++ b/app.mts
@@ -459,6 +459,9 @@ export default class MELCloudApp extends App {
     this.#createNotification(language)
     this.#registerWidgetListeners()
     this.#registerFlowListeners()
+    // Poke any open webview to re-run its freshness handshake: an app
+    // (re)boot is exactly when the served hashes may have moved.
+    this.homey.api.realtime('webview_hashes_changed', null)
     fireAndForget(
       this.#logBootReady(),
       (...args: unknown[]) => {

--- a/public/webview-freshness-boot.mts
+++ b/public/webview-freshness-boot.mts
@@ -29,3 +29,17 @@ export const ensureFreshWidget = async (
       )
     },
   )
+
+// Second trigger of the same handshake: the app pokes open pages at its
+// own (re)boot, when the served hashes may have moved; a failed recheck
+// must never break a live page (every path inside is already fail-open).
+export const watchWebviewFreshness = (
+  homey: HomeyWidget,
+  entry: string,
+): void => {
+  homey.on('webview_hashes_changed', () => {
+    fireAndForget(ensureFreshWidget(homey, entry), () => {
+      // The next boot pull re-checks anyway.
+    })
+  })
+}

--- a/settings/index.mts
+++ b/settings/index.mts
@@ -1917,26 +1917,16 @@ class SettingsApp {
   // loading overlay open forever on a single hung or failed call.
   public async init(): Promise<void> {
     // A stale cached page refetches itself once (never-cached address)
-    // instead of booting: skip
-    // the init — the document is about to be replaced.
-    if (
-      await ensureFreshWebview(
-        'settings',
-        async () => homeyApiGet(this.#homey, '/webview-hashes'),
-        (message) => {
-          this.#homey.api(
-            'POST',
-            '/boot-error',
-            { message, name: 'WebviewFreshness' },
-            () => {
-              // A missed freshness breadcrumb is acceptable.
-            },
-          )
-        },
-      )
-    ) {
+    // instead of booting: skip the init — the document is about to be
+    // replaced.
+    if (await this.#checkFreshness()) {
       return
     }
+    // Second trigger of the same handshake: the app pokes open pages at
+    // its own (re)boot, when the served hashes may have moved.
+    this.#homey.on('webview_hashes_changed', () => {
+      fireAndForget(this.#checkFreshness())
+    })
     const { error, hasFailed } = await runWebview(this.#homey, this.#run())
     if (hasFailed) {
       // After `ready` (runWebview's finally): an alert raised under the
@@ -1955,6 +1945,25 @@ class SettingsApp {
         this.#homey.openURL('https://homey.app/a/com.mecloud.extension'),
       )
     })
+  }
+
+  // One freshness pass, shared by the boot pull and the app's realtime
+  // poke; its breadcrumbs ride the declared boot-error route.
+  async #checkFreshness(): Promise<boolean> {
+    return ensureFreshWebview(
+      'settings',
+      async () => homeyApiGet(this.#homey, '/webview-hashes'),
+      (message) => {
+        this.#homey.api(
+          'POST',
+          '/boot-error',
+          { message, name: 'WebviewFreshness' },
+          () => {
+            // A missed freshness breadcrumb is acceptable.
+          },
+        )
+      },
+    )
   }
 
   async #ensureDevicesForApi(api: Api): Promise<void> {

--- a/tests/unit/app.test.ts
+++ b/tests/unit/app.test.ts
@@ -161,6 +161,8 @@ const mockSettingsUnset = vi.fn<(key: string) => void>()
 const mockSetTimeout =
   vi.fn<(callback: () => Promise<void> | void, ms: number) => void>()
 const mockCreateNotification = vi.fn<() => Promise<void>>()
+
+const mockRealtime = vi.fn<(event: string, data: unknown) => void>()
 const mockHomeyReady = vi.fn<() => Promise<void>>().mockResolvedValue()
 const mockWidgetRegister =
   vi.fn<(id: string, listener: (query: string) => unknown) => void>()
@@ -332,6 +334,7 @@ const createApp = (): InstanceType<typeof MelCloudApp> => {
       configurable: true,
       value: {
         __: mockTranslate,
+        api: { realtime: mockRealtime },
         clock: { getTimezone: mockGetTimezone },
         dashboards: { getWidget: mockGetWidget },
         drivers: { getDrivers: mockGetDrivers },
@@ -614,6 +617,12 @@ describe('melCloudApp', () => {
   })
 
   describe('initialization', () => {
+    it('should poke open webviews with the freshness event at boot', async () => {
+      await app.onInit()
+
+      expect(mockRealtime).toHaveBeenCalledWith('webview_hashes_changed', null)
+    })
+
     it('should initialize the API and facade manager', async () => {
       await app.onInit()
 

--- a/tests/unit/webview-freshness-boot.test.ts
+++ b/tests/unit/webview-freshness-boot.test.ts
@@ -1,0 +1,117 @@
+import type HomeyWidget from 'homey/lib/HomeyWidget'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  ensureFreshWidget,
+  watchWebviewFreshness,
+} from '../../public/webview-freshness-boot.mts'
+import { mock } from '../helpers.ts'
+
+// The wrapper feeds the transport-free twin primitive the widget
+// transport, so the primitive's own suite covers the decision table;
+// these tests pin the wiring — event name, re-run, fail-open poke.
+const globals = globalThis as {
+  document?: unknown
+  location?: unknown
+  sessionStorage?: unknown
+}
+
+const installFreshPage = (): void => {
+  globals.document = {
+    querySelectorAll: (): readonly {
+      getAttribute: (name: string) => string | null
+    }[] => [
+      {
+        getAttribute: (name: string): string | null =>
+          name === 'src' ? 'index.js?v=aaaa1111' : null,
+      },
+    ],
+  }
+  globals.location = {
+    href: 'https://webview.invalid/page',
+    replace: vi.fn<(url: string) => void>(),
+  }
+  const store = new Map<string, string>()
+  globals.sessionStorage = {
+    getItem: (key: string): string | null => store.get(key) ?? null,
+    setItem: (key: string, value: string): void => {
+      store.set(key, value)
+    },
+  }
+}
+
+const flushMicrotasks = async (): Promise<void> =>
+  new Promise((resolve) => {
+    setTimeout(resolve, 0)
+  })
+
+describe(watchWebviewFreshness, () => {
+  afterEach(() => {
+    delete globals.document
+    delete globals.location
+    delete globals.sessionStorage
+  })
+
+  it('should subscribe to the app boot poke', () => {
+    const on = vi.fn<(event: string, callback: () => void) => void>()
+    installFreshPage()
+
+    watchWebviewFreshness(mock<HomeyWidget>({ on }), 'ata-group-setting')
+
+    expect(on).toHaveBeenCalledTimes(1)
+    expect(on).toHaveBeenCalledWith(
+      'webview_hashes_changed',
+      expect.any(Function),
+    )
+  })
+
+  it('should re-run the handshake when the poke fires', async () => {
+    const api = vi
+      .fn<(method: string, path: string) => Promise<unknown>>()
+      .mockResolvedValue({ 'ata-group-setting': 'aaaa1111' })
+    const on = vi.fn<(event: string, callback: () => void) => void>()
+    installFreshPage()
+    watchWebviewFreshness(mock<HomeyWidget>({ api, on }), 'ata-group-setting')
+
+    on.mock.calls[0]?.[1]()
+    await flushMicrotasks()
+
+    expect(api).toHaveBeenCalledWith('GET', '/webview-hashes')
+  })
+
+  it('should swallow a failing recheck', async () => {
+    const api = vi
+      .fn<(method: string, path: string) => Promise<unknown>>()
+      .mockRejectedValue(new Error('bridge down'))
+    const on = vi.fn<(event: string, callback: () => void) => void>()
+    installFreshPage()
+    watchWebviewFreshness(mock<HomeyWidget>({ api, on }), 'ata-group-setting')
+
+    expect(() => {
+      on.mock.calls[0]?.[1]()
+    }).not.toThrow()
+
+    await flushMicrotasks()
+  })
+})
+
+describe(ensureFreshWidget, () => {
+  afterEach(() => {
+    delete globals.document
+    delete globals.location
+    delete globals.sessionStorage
+  })
+
+  it('should resolve false on a fresh page without navigating', async () => {
+    const api = vi
+      .fn<(method: string, path: string) => Promise<unknown>>()
+      .mockResolvedValue({ 'ata-group-setting': 'aaaa1111' })
+    installFreshPage()
+
+    await expect(
+      ensureFreshWidget(mock<HomeyWidget>({ api }), 'ata-group-setting'),
+    ).resolves.toBe(false)
+
+    expect(api).toHaveBeenCalledWith('GET', '/webview-hashes')
+  })
+})

--- a/widgets/ata-group-setting/public/index.mts
+++ b/widgets/ata-group-setting/public/index.mts
@@ -19,7 +19,10 @@ import {
   surfaceError,
   trySetDocumentLanguage,
 } from '../../../public/homey-api.mts'
-import { ensureFreshWidget } from '../../../public/webview-freshness-boot.mts'
+import {
+  ensureFreshWidget,
+  watchWebviewFreshness,
+} from '../../../public/webview-freshness-boot.mts'
 import { AnimationController, AnimationDelay } from './animation.mts'
 import { AtaValueManager } from './ata-values.mts'
 
@@ -65,6 +68,7 @@ class WidgetApp {
     if (await ensureFreshWidget(this.#homey, 'ata-group-setting')) {
       return
     }
+    watchWebviewFreshness(this.#homey, 'ata-group-setting')
     await runWebview(this.#homey, this.#run(), {
       onError: showInitError,
       height: () => document.body.scrollHeight,

--- a/widgets/charts/public/index.mts
+++ b/widgets/charts/public/index.mts
@@ -47,7 +47,10 @@ import {
   surfaceError,
   trySetDocumentLanguage,
 } from '../../../public/homey-api.mts'
-import { ensureFreshWidget } from '../../../public/webview-freshness-boot.mts'
+import {
+  ensureFreshWidget,
+  watchWebviewFreshness,
+} from '../../../public/webview-freshness-boot.mts'
 import { getZoneId, getZonePath } from '../../../public/zones.mts'
 import {
   type DaysQuery,
@@ -878,6 +881,7 @@ class ChartWidget {
     if (await ensureFreshWidget(this.#homey, 'charts')) {
       return
     }
+    watchWebviewFreshness(this.#homey, 'charts')
     await runWebview(this.#homey, this.#run(), {
       onError: showInitError,
       height: () => document.body.scrollHeight,


### PR DESCRIPTION
Second trigger of the freshness primitive, approved design — same wave as OlivierZal/com.heatzy#1080 and OlivierZal/com.melcloud.extension#1259: the app emits `webview_hashes_changed` (realtime, no payload — the route stays the single source of truth) once at init, and every open webview re-runs the exact same `ensureFreshWebview` call it used at boot. Surfaces: the settings page (extracted `#checkFreshness`, subscription via the settings SDK's `homey.on`) and both widgets (shared `watchWebviewFreshness` in `public/webview-freshness-boot.mts`, the `deviceupdate` subscription precedent). The twin primitive `webview-freshness.mts` is untouched — its per-identity guard already does the right thing (a fresh page is never marked, so the first pushed mismatch refetches). Covers a page left open across an app restart or update — the dev-loop case; a page opened later boots through the already-merged pull trigger; a page cached before the handshake existed remains reachable by neither (one-time purge or natural eviction).

Note on overlap: a concurrent branch (`fix/busy-scope-chrome-cascade`) accidentally swept this feature's working-tree changes into its commit; this branch carries the feature alone (its CSS fix excluded), so whichever merges second reduces to its own diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3