### PR TITLE
chore: settle the session's comments and doctrine into intent form

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,8 +96,9 @@ coverage.
   and not available offline.
 - The settings page (`settings/`) uses Homey's official `homey-form-*` /
   `homey-button-*` classes; `settings/index.css` only fills documented SDK
-  gaps (date inputs, checkbox `:indeterminate`, `fieldset[hidden]`
-  specificity) and app-specific design.
+  gaps (date inputs, checkbox `:indeterminate`, disabled greying and
+  freeze dim, hidden/injected-cascade specificity) and app-specific
+  design.
 - App-API surface conventions: paths are kebab-case REST (`get*` for
   GET — except `is*` for a boolean GET —, `update*` for PUT — never
   `set*` —, and a business verb for POST: `*Authenticate` on
@@ -154,9 +155,16 @@ coverage.
   WebKit renders inline fieldsets atomically, so SIBLING sets tile side
   by side (the 45.7.5 settings regression; a single set per section had
   hidden it for years). `settings/index.css` restacks them with a
-  higher-specificity block rule. Any markup change that multiplies
-  `homey-form-*` elements needs an on-device cold-open check: the
-  injected sheet's resets make untested combinations render arbitrarily.
+  higher-specificity block rule. That is the general rule for ANY own
+  rule that must beat the injected sheet: its rules sit at (0,1,1) and
+  a tie falls to injection order, so the own rule needs an ancestor
+  selector — `body fieldset[hidden]`, `body fieldset[disabled]`,
+  `body fieldset.busy-scope`, the `.homey-form-group` restack — never a
+  bare (0,1,1) form. Only an on-device open can catch a lost tie (a
+  headless probe has no injected sheet), so any markup change that
+  multiplies `homey-form-*` elements needs an on-device cold-open
+  check: the injected sheet's resets make untested combinations render
+  arbitrarily.
 
 ## Driver conventions
 

--- a/settings/index.css
+++ b/settings/index.css
@@ -64,12 +64,11 @@ input[type='datetime-local']:focus {
   padding: calc(var(--homey-su-1) - 1px);
 }
 
-/* Ensure `hidden` works on fieldsets: the UA `[hidden] { display: none }`
-   rule ties with the injected sheet's explicit `display` rules and with
-   `fieldset.busy-scope` below, and a tie falls to source order. The
-   `body` ancestor lifts this to (0,1,2) so the `hidden` attribute is
-   authoritative whatever the stylesheet order — the same device as the
-   checkbox-set restack. */
+/* Ensure `hidden` works on fieldsets: explicit `display` rules — the
+   injected sheet's and `fieldset.busy-scope` below — tie with the UA
+   `[hidden]` rule, and a tie falls to stylesheet order. The `body`
+   ancestor keeps the attribute authoritative (see the injected-cascade
+   rule in CLAUDE.md). */
 body fieldset[hidden] {
   display: none;
 }
@@ -148,13 +147,9 @@ input.homey-form-checkbox-input:indeterminate
 }
 
 /* Plain containers promoted to fieldsets so one `disabled` flip freezes a
-   whole dirty-gated form region: none of the UA fieldset chrome (border,
-   padding, min-inline-size) may surface. Explicit `display: block`
-   because WebKit renders inline fieldsets atomically. */
-/* The `body` ancestor outweighs the injected sheet's fieldset styling
-   whatever the order — the same device as the hidden and disabled
-   rules, and the reason the panel frames survived a (0,1,1) tie
-   on-device while a headless probe (no injected sheet) showed none. */
+   whole dirty-gated form region: none of the fieldset chrome (border,
+   padding, min-inline-size) may surface — the `body` ancestor keeps this
+   reset above the injected sheet's own fieldset styling. */
 body fieldset.busy-scope {
   border: 0;
   margin: 0;
@@ -162,9 +157,9 @@ body fieldset.busy-scope {
   padding: 0;
 }
 
-/* `display` split off and gated on `:not([hidden])`: the block display
-   ties (0,1,1) with the hidden rule's old form and won by source order,
-   which kept a hidden panel visible (the overheat panel regression). */
+/* `display` lives apart, gated on `:not([hidden])` so it can never
+   contend with the hidden rule above; explicit `block` because WebKit
+   renders inline fieldsets atomically. */
 fieldset.busy-scope:not([hidden]) {
   display: block;
 }
@@ -173,11 +168,9 @@ fieldset.busy-scope:not([hidden]) {
    request is in flight — grey it like the buttons. Attribute (not
    `:disabled`) so nested fieldsets inside a frozen section do not
    compound the opacity; `pointer-events` because `disabled` only
-   reaches form controls, not arbitrary interactive descendants. */
-/* The `body` ancestor outweighs the injected sheet's `all: unset` on
-   checkbox-set fieldsets whatever the order: without it the section dim
-   lost the cascade on-device and the button neutralizer below left
-   in-flight Apply/Refresh fully opaque. */
+   reaches form controls, not arbitrary interactive descendants; the
+   `body` ancestor keeps the dim above the injected sheet's `all: unset`
+   resets — the button neutralizer below counts on it showing. */
 body fieldset[disabled] {
   cursor: not-allowed;
   opacity: 0.5;


### PR DESCRIPTION
Cleanup review of the session's seven-PR arc (#1525→#1532), per the pre-release sweep.

**Fixed** — the three cascade waves stacked history-narrating comment blocks on `settings/index.css` ("the overheat panel regression", "survived a (0,1,1) tie on-device while a headless probe…"): each of the three body-prefixed rules now carries ONE intent-only block; the body-ancestor pattern is stated once as doctrine in CLAUDE.md's injected-sheet gotcha — its rules sit at (0,1,1), a tie falls to injection order, only an on-device open can catch a lost tie — instead of being re-derived per comment; the "documented SDK gaps" list catches up with the freeze styling.

**Verified clean (refuted as residue)** — every freshness export has consumers (`ensureFreshWidget`, `watchWebviewFreshness`, `homeyApiPost`, the twin primitive); ignores and configs carry no orphans (`.prettierignore` down to four live entries, `.gitignore` lean, eslint/vitest excludes coherent); the CLAUDE.md freshness paragraph is accurate after its three rewrites; no history comments landed anywhere else in the session's 41-file diff; the widget CSS session diff was pure value alignment.

**Reported, not touched** — the ATA widget's own freeze rules (`fieldset.busy-scope`, `fieldset[disabled]` in `widgets/ata-group-setting/public/styles/layout.css`) are NOT body-prefixed: same theoretical tie class as the settings family, but the surface is live-verified on-device and widget-render churn requires fresh on-device evidence per doctrine — flagged for a future on-device-checked wave rather than changed blind. Twin files untouched throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3