### PR TITLE
fix: freeze the credentials section while a request is in flight

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,8 +130,9 @@ coverage.
   instead of a silent pass, and what makes separate "the regex still
   matches" clauses redundant.
 - Dirty-gating: `public/dirty-gate.mts` is the ONE primitive behind every
-  webview Apply/Refresh pair (settings sections, frost/holiday panels, the
-  ATA group widget) — never re-derive its invariant at a call site. The gate also freezes the gated
+  webview Apply/Refresh pair (settings sections, frost/holiday/overheat
+  panels, the credentials section, the ATA group widget) — never
+  re-derive its invariant at a call site. The gate also freezes the gated
   fieldsets while a request is in flight (container `disabled` +
   `aria-busy`, so a control's own domain `disabled` survives the thaw):
   every success path rewrites the fields, so a mid-flight edit would be
@@ -141,7 +142,9 @@ coverage.
   from the request), the call site supplies `isActionable` — Apply arms
   only when the request would carry something — while `serialize` stays
   the pure snapshot; the ATA group widget arms through its body builder
-  this way. Its
+  this way, and the credentials section arms only when both fields are
+  filled (its Reset button rides the gate as a Refresh — greyed by busy
+  alone). Its
   `serialize` must stay a PURE form snapshot, never a request-body builder
   (those filter null deltas out and desync the pristine check — the
   historical heatzy bug), and disabled greying styles

--- a/settings/index.html
+++ b/settings/index.html
@@ -56,34 +56,39 @@
             credentials are settled), expanded while at least one is not. -->
         <details id="authentication" class="homey-form-fieldset">
             <summary class="homey-form-legend" data-i18n="settings.authenticate.legend">Credentials</summary>
-            <div class="homey-form-group">
-                <!-- The accessible name "API" is language-neutral (reads
-                    identically in all 13 locales), so it deliberately
-                    carries no data-i18n-aria-label. -->
-                <select
-                    id="api"
-                    class="homey-form-select"
-                    aria-label="API"
-                >
-                    <option value="classic">Classic</option>
-                    <option value="home">Home</option>
-                </select>
-            </div>
-            <div id="login"></div>
-            <div class="homey-form-group container">
-                <button
-                    id="reset_credentials"
-                    type="button"
-                    class="homey-button-primary-full"
-                    data-i18n="settings.authenticate.reset"
-                >Reset</button>
-                <button
-                    id="authenticate"
-                    type="button"
-                    class="homey-button-primary-full"
-                    data-i18n="settings.authenticate.button"
-                >Log in</button>
-            </div>
+            <!-- One fieldset so a single `disabled` flip freezes every
+                region the credentials snapshot reads (API choice
+                included) while a request is in flight. -->
+            <fieldset id="login_panel" class="busy-scope">
+                <div class="homey-form-group">
+                    <!-- The accessible name "API" is language-neutral (reads
+                        identically in all 13 locales), so it deliberately
+                        carries no data-i18n-aria-label. -->
+                    <select
+                        id="api"
+                        class="homey-form-select"
+                        aria-label="API"
+                    >
+                        <option value="classic">Classic</option>
+                        <option value="home">Home</option>
+                    </select>
+                </div>
+                <div id="login"></div>
+                <div class="homey-form-group container">
+                    <button
+                        id="reset_credentials"
+                        type="button"
+                        class="homey-button-primary-full"
+                        data-i18n="settings.authenticate.reset"
+                    >Reset</button>
+                    <button
+                        id="authenticate"
+                        type="button"
+                        class="homey-button-primary-full"
+                        data-i18n="settings.authenticate.button"
+                    >Log in</button>
+                </div>
+            </fieldset>
         </details>
         <!-- Shown when at least one API is authenticated — hidden by default to prevent flash -->
         <div id="content" hidden>

--- a/settings/index.mts
+++ b/settings/index.mts
@@ -506,6 +506,8 @@ class AuthManager {
     home: {},
   }
 
+  readonly #gate: DirtyGate
+
   readonly #homey: Homey
 
   readonly #loadPostLoginCallback: (api: Api) => Promise<void>
@@ -524,6 +526,15 @@ class AuthManager {
     return this.#apiSelect.value === 'home' ? 'home' : 'classic'
   }
 
+  // Trimmed: mobile keyboards append a space after autocompleted
+  // email addresses, invisible in the field and rejected by MELCloud.
+  get #loginInput(): LoginCredentials {
+    return {
+      password: this.#passwordInput?.value ?? '',
+      username: (this.#usernameInput?.value ?? '').trim(),
+    }
+  }
+
   public constructor(
     homey: Homey,
     loadPostLoginCallback: (api: Api) => Promise<void>,
@@ -537,6 +548,24 @@ class AuthManager {
     this.#authenticationSection = getDetails('authentication')
     this.#loginSection = getDiv('login')
     this.#resetButton = getButton('reset_credentials')
+    this.#gate = createDirtyGate({
+      applyElement: this.#authenticateButton,
+      fieldsetElements: [getFieldset('login_panel')],
+      refreshElements: [this.#resetButton],
+      // Arms only when both fields carry something: an empty field
+      // could only produce the "missing credentials" alert, never a
+      // request.
+      isActionable: (): boolean => {
+        const { password, username } = this.#loginInput
+        return username !== '' && password !== ''
+      },
+      serialize: (): string =>
+        JSON.stringify([
+          this.#apiSelect.value,
+          this.#usernameInput?.value ?? '',
+          this.#passwordInput?.value ?? '',
+        ]),
+    })
   }
 
   public addEventListeners(): void {
@@ -549,6 +578,13 @@ class AuthManager {
     this.#resetButton.addEventListener('click', () => {
       fireAndForget(this.resetCredentials())
     })
+    // Wired last so the dirty recompute runs after the API cascade has
+    // resynced the fields the snapshot reads.
+    this.#gate.wire(
+      [this.#apiSelect, this.#usernameInput, this.#passwordInput].filter(
+        (element) => element !== null,
+      ),
+    )
   }
 
   // Folded when the credentials are settled, expanded while attention
@@ -574,6 +610,7 @@ class AuthManager {
     // reset) so its empty fields are what the user sees first.
     this.#selectFirstIncompleteApi()
     this.#syncInputsFromCredentials()
+    this.#gate.markSaved()
   }
 
   // APIs whose stored credentials are missing a username or password —
@@ -587,17 +624,16 @@ class AuthManager {
    */
   public async login(): Promise<void> {
     const api = this.#currentApi
-    // Trimmed: mobile keyboards append a space after autocompleted
-    // email addresses, invisible in the field and rejected by MELCloud.
-    const username = (this.#usernameInput?.value ?? '').trim()
-    const password = this.#passwordInput?.value ?? ''
+    const { password, username } = this.#loginInput
+    // Belt for the arming predicate: keyboard activation of a stale
+    // reference could still submit an emptied form.
     if (username === '' || password === '') {
       fireAndForget(
         this.#homey.alert(this.#homey.__('settings.authenticate.failure')),
       )
       return
     }
-    await withDisablingButton(this.#authenticateButton.id, async () => {
+    await this.#gate.runBusy(async () => {
       try {
         await homeyApiPost(this.#homey, `/${api}/sessions`, {
           password,
@@ -626,7 +662,7 @@ class AuthManager {
       return
     }
     const api = this.#currentApi
-    await withDisablingButton(this.#resetButton.id, async () => {
+    await this.#gate.runBusy(async () => {
       try {
         // The app-side logout owns the teardown (session, credentials,
         // backoff, sync timer, registry) — the webview never touches the
@@ -634,6 +670,7 @@ class AuthManager {
         await homeyApiDelete(this.#homey, `/${api}/sessions`)
         this.#credentialsByApi[api] = {}
         this.#syncInputsFromCredentials()
+        this.#gate.markSaved()
         this.#onLogOutCallback(api)
       } catch (error) {
         await this.#homey.alert(getErrorMessage(error))

--- a/widgets/ata-group-setting/public/styles/layout.css
+++ b/widgets/ata-group-setting/public/styles/layout.css
@@ -116,8 +116,10 @@ select:not(.zone-select) {
 /* The values container is a fieldset so the dirty gate can freeze every
    control with one `disabled` flip while a request is in flight: no UA
    fieldset chrome, and the frozen state greys like the buttons. Explicit
-   `display: block` because WebKit renders inline fieldsets atomically. */
-fieldset.busy-scope {
+   `display: block` because WebKit renders inline fieldsets atomically.
+   The `body` ancestor lifts both rules above the injected sheet's
+   (0,1,1) fieldset styling, whatever the stylesheet order. */
+body fieldset.busy-scope {
   border: 0;
   display: block;
   margin: 0;
@@ -125,7 +127,7 @@ fieldset.busy-scope {
   padding: 0;
 }
 
-fieldset[disabled] {
+body fieldset[disabled] {
   cursor: not-allowed;
   opacity: 0.5;
   pointer-events: none;


### PR DESCRIPTION
Closes the gap Olivier spotted: during login (and reset), only the pressed button was disabled — username/password, the API selector and the sibling button stayed live, exactly the mid-flight clobber window the freeze doctrine closes everywhere else.

**Design — the existing primitive, no new machinery:**
- The section (API select + credential fields + button row) is wrapped in one `fieldset.busy-scope` (`login_panel`), so a single `disabled` flip freezes every region the snapshot reads — the doctrine's load-bearing clause.
- One `DirtyGate`: **Log in** is the Apply, arming through `isActionable` only when both fields are filled (the empty-fields alert stays as a belt); **Reset** rides as a Refresh (greyed by busy alone); both actions run through `runBusy`. `serialize` stays a pure snapshot; the gate wires after the API cascade so recompute sees resynced fields. `withDisablingButton` keeps its one remaining consumer (error-log fetch) — the two auth call sites no longer re-derive the busy invariant.
- Baseline bookkeeping (`markSaved` after populate/reset) follows the gate contract; as at the heatzy settings site, `isActionable` short-circuits it — documented uniform-contract verdict.

**Preventive, from the #1533 review report:** the ATA widget's `fieldset.busy-scope` / `fieldset[disabled]` rules gain the `body` ancestor — the same (0,1,1) injected-sheet tie the settings family provably lost on-device; charts carries no freeze rules (no gate there).

**Tests:** nothing new is coverage-reachable (settings is browser glue, excluded); the gate's decision table stays pinned by the byte-identical twin `dirty-gate.test.ts` (untouched). Route guards pass unchanged (same path literals).

**On-device check requested:** during a login, the whole credentials section should dim and freeze (fields, API select, Reset), Log in staying greyed until both fields are filled; the ATA group widget should render unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3