### PR TITLE
build(deps): adopt melcloud-api 46.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "46.0.0",
       "license": "GPL-3.0-only",
       "dependencies": {
-        "@olivierzal/melcloud-api": "45.1.0",
+        "@olivierzal/melcloud-api": "46.0.0",
         "source-map-support": "^0.5.21",
         "temporal-polyfill": "^1.0.1"
       },
@@ -1065,14 +1065,14 @@
       }
     },
     "node_modules/@olivierzal/melcloud-api": {
-      "version": "45.1.0",
-      "resolved": "https://npm.pkg.github.com/download/@olivierzal/melcloud-api/45.1.0/fb63ae5bc7750fa38a25fc8e9fab9da264c4727d",
-      "integrity": "sha512-gufRGGWeUNcGV3d99M1Cf3bJPgZblqM/RXdjTVxRYi8mDKh5e8O1Cs8q1GKyWxVmIKOJ8ZFuknmnUiVrcCaZnQ==",
+      "version": "46.0.0",
+      "resolved": "https://npm.pkg.github.com/download/@olivierzal/melcloud-api/46.0.0/68f849121704befebec605627d16b28f3853b29c",
+      "integrity": "sha512-zD4EnYqdR5pJo0HGqmIOGgH6pkbKIiIUffAP8RUttVHx45WdWiFKRAN4Ve7Ypx3IfLoJHDeqbEqJnyb2ErAwKA==",
       "license": "MIT",
       "dependencies": {
-        "temporal-polyfill": "^1.0.1",
+        "temporal-polyfill": "^1.0.3",
         "tough-cookie": "^6.0.2",
-        "undici": "^8.7.0",
+        "undici": "^8.9.0",
         "zod": "^4.4.3"
       },
       "engines": {
@@ -6718,19 +6718,19 @@
       }
     },
     "node_modules/temporal-polyfill": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-1.0.1.tgz",
-      "integrity": "sha512-N2SoI9olnW7BUsU8RosDphZQl9s+WJ8O7PoJMFCr/e5/1rFkVI4GNOWaSeySG+UoP04foPYsnLWbJmbXOiShZg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-1.0.3.tgz",
+      "integrity": "sha512-U8vuzZBc+dfMIfl8wXWcedfI7AJCxJjjVBIRpJUvIz5+UAp555UJDHguKsfZqHWaHRSdVUThm7mqqIWhN/xPBQ==",
       "license": "MIT",
       "dependencies": {
-        "temporal-spec": "1.0.0",
+        "temporal-spec": "1.0.1",
         "temporal-utils": "1.0.1"
       }
     },
     "node_modules/temporal-spec": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/temporal-spec/-/temporal-spec-1.0.0.tgz",
-      "integrity": "sha512-00Ahj1e1ifaERTMOIIGpOCdOo9IEk2m6GGSMedsn9a2SIsGLdOTbmME1Htv6IM82b6VHrzSUTIVc7YHy6hdhFQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/temporal-spec/-/temporal-spec-1.0.1.tgz",
+      "integrity": "sha512-wxVoanmDeavXie1vu2JaQ3WIc3JZnWAOYFBsJyATaVsXsycKYUflGsyBmrRSnoCpZJpwPyr38VpgSUlQ8CbFxg==",
       "license": "Apache-2.0"
     },
     "node_modules/temporal-utils": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "typecheck": "node ./node_modules/@typescript/native/bin/tsc --noEmit"
   },
   "dependencies": {
-    "@olivierzal/melcloud-api": "45.1.0",
+    "@olivierzal/melcloud-api": "46.0.0",
     "source-map-support": "^0.5.21",
     "temporal-polyfill": "^1.0.1"
   },


### PR DESCRIPTION
Exact-pin adoption of the 46.0.0 major. The breaking surface lands clean here: the published facade names now resolve to the interfaces the app was already typed against, and the dropped symbols (`NetworkError`, the Classic entity type predicates) had no consumer in this repo (verified during round 2). Full suite green: typecheck, lint, 100 % coverage, publish-level validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3