### PR TITLE
build(deps): adopt melcloud-api 46.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "46.0.0",
       "license": "GPL-3.0-only",
       "dependencies": {
-        "@olivierzal/melcloud-api": "46.0.0",
+        "@olivierzal/melcloud-api": "46.0.1",
         "source-map-support": "^0.5.21",
         "temporal-polyfill": "^1.0.1"
       },
@@ -1065,9 +1065,9 @@
       }
     },
     "node_modules/@olivierzal/melcloud-api": {
-      "version": "46.0.0",
-      "resolved": "https://npm.pkg.github.com/download/@olivierzal/melcloud-api/46.0.0/68f849121704befebec605627d16b28f3853b29c",
-      "integrity": "sha512-zD4EnYqdR5pJo0HGqmIOGgH6pkbKIiIUffAP8RUttVHx45WdWiFKRAN4Ve7Ypx3IfLoJHDeqbEqJnyb2ErAwKA==",
+      "version": "46.0.1",
+      "resolved": "https://npm.pkg.github.com/download/@olivierzal/melcloud-api/46.0.1/b4d3e63d09cf4d1a8ac9bf8eca3906233b071363",
+      "integrity": "sha512-4CVMnTBR7xWLuLkWnVI8e8bu1E7BQz4h8qJFw/RXMvlOn5/eZDmdfq/NMrn11u5nHdl6HKGoZdjYXRi05W9iMA==",
       "license": "MIT",
       "dependencies": {
         "temporal-polyfill": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "typecheck": "node ./node_modules/@typescript/native/bin/tsc --noEmit"
   },
   "dependencies": {
-    "@olivierzal/melcloud-api": "46.0.0",
+    "@olivierzal/melcloud-api": "46.0.1",
     "source-map-support": "^0.5.21",
     "temporal-polyfill": "^1.0.1"
   },


### PR DESCRIPTION
Exact-pin adoption of the credentials-persistence patch: a failed sign-in (settings page, pairing and repair alike — all three route through the same `authenticate`) leaves the stored pair and session untouched; only a server-accepted pair reaches the settings store. Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3