### PR TITLE
refactor: share the generated-form builders across settings and widget

### DIFF
--- a/api.mts
+++ b/api.mts
@@ -25,7 +25,7 @@ import type {
 } from './types/zone.mts'
 import { getClassicBuildings } from './lib/classic-facade-manager.mts'
 import { getErrorMessage } from './lib/get-error-message.mts'
-import { toDeviceOrZoneData } from './lib/validation.mts'
+import { toDeviceOrZoneData, toNonNegativeInt } from './lib/validation.mts'
 import { getWebviewHashes } from './lib/webview-hashes.mts'
 
 // The user-facing service names, interpolated into the failure
@@ -86,16 +86,13 @@ const logSettingsRoute = (app: Homey['app'], route: string): void => {
   app.log({ dataType: 'Settings page', route })
 }
 
-const toNumber = (value: string | undefined): number | undefined => {
-  if (value === undefined) {
-    return undefined
-  }
-  const parsed = Number(value)
-  if (value === '' || !Number.isFinite(parsed)) {
-    throw new Error(`Invalid numeric query param: ${JSON.stringify(value)}`)
-  }
-  return parsed
-}
+// Optional query params: absent stays absent, present must satisfy the
+// error-log paging contract — a non-negative integer.
+const toOptionalNonNegativeInt = (
+  value: string | undefined,
+  field: string,
+): number | undefined =>
+  value === undefined ? undefined : toNonNegativeInt(value, { field })
 
 const api = {
   classicAuthenticate: async ({
@@ -170,8 +167,8 @@ const api = {
     homey: Homey
     query: Partial<ErrorLogQueryParams>
   }): Promise<FormattedErrorLog> => {
-    const parsedOffset = toNumber(offset)
-    const parsedPeriod = toNumber(period)
+    const parsedOffset = toOptionalNonNegativeInt(offset, 'offset')
+    const parsedPeriod = toOptionalNonNegativeInt(period, 'period')
     return app.getErrorLog({
       from,
       offset: parsedOffset,

--- a/app.mts
+++ b/app.mts
@@ -5,7 +5,6 @@ import {
   type HolidayModeState,
   type HolidayModeUpdate,
   type Hour,
-  type Logger,
   type ProtectionState,
   type ProtectionUpdate,
   type ReportChartLineOptions,
@@ -67,7 +66,7 @@ import { type Homey, App } from './lib/homey.mts'
 import { getTimeZone } from './lib/temporal.mts'
 import { typedFromEntries } from './lib/typed-object.mts'
 import { unwrapResult } from './lib/unwrap-result.mts'
-import { toZoneValueData } from './lib/validation.mts'
+import { toNonNegativeInt, toZoneValueData } from './lib/validation.mts'
 import {
   getHomeBuildingId,
   getHomeDeviceId,
@@ -128,16 +127,6 @@ const chartDaysStart = (days: number, timezone: string): string =>
 // dropped into the field can carry anything at runtime. Only numbers
 // and numeric strings are accepted — coercing other types (false,
 // null, '') would silently read as 0 and turn holiday mode off.
-const toDurationDays = (duration: unknown): number => {
-  if (typeof duration === 'number') {
-    return duration
-  }
-  if (typeof duration === 'string' && duration.trim() !== '') {
-    return Number(duration)
-  }
-  return Number.NaN
-}
-
 // Flow-action arguments shared by the holiday-mode cards: `zone` always,
 // `duration`/`time` only on the cards that declare them. The zone carries
 // its `${model}_${id}` option value as `id` — the shape stored card args
@@ -462,13 +451,7 @@ export default class MELCloudApp extends App {
     // Poke any open webview to re-run its freshness handshake: an app
     // (re)boot is exactly when the served hashes may have moved.
     this.homey.api.realtime('webview_hashes_changed', null)
-    fireAndForget(
-      this.#logBootReady(),
-      (...args: unknown[]) => {
-        this.error(...args)
-      },
-      'Boot readiness tracking failed:',
-    )
+    fireAndForget(this.#logBootReady(), this, 'Boot readiness tracking failed:')
   }
 
   public override async onUninit(): Promise<void> {
@@ -1163,17 +1146,6 @@ export default class MELCloudApp extends App {
     }
   }
 
-  #createLogger(): Logger {
-    return {
-      error: (...args: unknown[]): void => {
-        this.error(...args)
-      },
-      log: (...args: unknown[]): void => {
-        this.log(...args)
-      },
-    }
-  }
-
   #createNotification(language: string): void {
     const { homey } = this
     const {
@@ -1400,16 +1372,15 @@ export default class MELCloudApp extends App {
     )
   }
 
+  // The zero lower bound (`HOLIDAY_MODE_OFF_DURATION`) is what
+  // `toNonNegativeInt` already enforces; the boundary only translates
+  // the failure into the user's language.
   #holidayModeDays(duration: unknown): number {
-    const days = toDurationDays(duration)
-    if (
-      !Number.isSafeInteger(days) ||
-      days < HOLIDAY_MODE_OFF_DURATION ||
-      days > HOLIDAY_MODE_MAX_DURATION_DAYS
-    ) {
+    try {
+      return toNonNegativeInt(duration, { max: HOLIDAY_MODE_MAX_DURATION_DAYS })
+    } catch {
       throw new RangeError(this.homey.__('errors.invalidDuration'))
     }
-    return days
   }
 
   #holidayModeEndTime(time: unknown): Temporal.PlainTime {
@@ -1468,7 +1439,7 @@ export default class MELCloudApp extends App {
           this.#notifySessionRestored('classic')
         },
       },
-      logger: this.#createLogger(),
+      logger: this,
       settingManager: this.#createSettingManager(),
       shouldResumeSessionInBackground: true,
     })
@@ -1502,7 +1473,7 @@ export default class MELCloudApp extends App {
         },
       },
       locale: language,
-      logger: this.#createLogger(),
+      logger: this,
       settingManager: this.#createSettingManager('home'),
       shouldResumeSessionInBackground: true,
       timezone: getTimeZone(this.homey),

--- a/drivers/base-device.mts
+++ b/drivers/base-device.mts
@@ -381,13 +381,7 @@ export abstract class BaseMELCloudDevice<
 
   async #init(): Promise<void> {
     await this.#setCapabilities()
-    fireAndForget(
-      this.#finishInit(),
-      (...args: unknown[]) => {
-        this.error(...args)
-      },
-      'Deferred device init failed:',
-    )
+    fireAndForget(this.#finishInit(), this, 'Deferred device init failed:')
   }
 
   #isThermostatModeSupportingOff(): boolean {

--- a/lib/fire-and-forget.mts
+++ b/lib/fire-and-forget.mts
@@ -1,13 +1,16 @@
+import type { Logger } from '@olivierzal/melcloud-api'
+
 // The one sanctioned fire-and-forget seam (melcloud-api's shape):
 // detach already-started work from the caller's critical path, logging
-// a rejection instead of propagating it.
+// a rejection instead of propagating it. The logger is an object so an
+// app or device instance passes itself — no per-site error adapter.
 export const fireAndForget = (
   promise: Promise<unknown>,
-  logError: (...args: unknown[]) => void,
+  logger: Logger,
   message: string,
 ): void => {
   // eslint-disable-next-line unicorn/prefer-await -- the single fire-and-forget seam: rejections are logged, never propagated
   promise.catch((error: unknown) => {
-    logError(message, error)
+    logger.error(message, error)
   })
 }

--- a/lib/validation.mts
+++ b/lib/validation.mts
@@ -42,7 +42,12 @@ export const toNonNegativeInt = (
       `${fieldPrefix(field)}expected number or numeric string`,
     )
   }
-  const parsed = Number(value)
+  // `Number('')` (and whitespace) is 0 — a JS coercion wart, not an
+  // integer representation; reject it before the numeric checks.
+  const parsed =
+    typeof value === 'string' && value.trim() === ''
+      ? Number.NaN
+      : Number(value)
   if (!Number.isSafeInteger(parsed) || parsed < 0) {
     throw new RangeError(
       `${fieldPrefix(field)}expected non-negative integer, got ${String(value)}`,

--- a/public/dom.mts
+++ b/public/dom.mts
@@ -1,4 +1,12 @@
+import type HomeyWidget from 'homey/lib/HomeyWidget'
+
 import { getErrorMessage } from '../lib/get-error-message.mts'
+import {
+  type PickerZone,
+  getSubzones,
+  getZoneId,
+  getZoneName,
+} from './zones.mts'
 
 export type HTMLValueElement = HTMLInputElement | HTMLSelectElement
 
@@ -49,6 +57,134 @@ export const createOption = (
 ): void => {
   if (select.querySelector(`option[value="${CSS.escape(id)}"]`) === null) {
     select.append(new Option(label, id))
+  }
+}
+
+// Fallback options for a generated select: the translated boolean pair,
+// shared by every select whose capability declares no explicit values.
+export const booleanOptions = (
+  homey: Pick<HomeyWidget, '__'>,
+): { id: string; label: string }[] =>
+  booleanStrings.map((value) => ({
+    id: value,
+    label: homey.__(`settings.boolean.${value}`),
+  }))
+
+// Shared form-control builders for the generated settings and widget
+// forms. The optional class hooks carry the settings page's
+// `homey-form-*` decoration; the widgets style the bare elements through
+// element selectors instead.
+export const createLabel = (
+  formControl: HTMLValueElement,
+  text: string,
+  className?: string,
+): HTMLLabelElement => {
+  const label = document.createElement('label')
+  if (className !== undefined) {
+    label.classList.add(className)
+  }
+  label.htmlFor = formControl.id
+  label.textContent = text
+  label.append(formControl)
+  return label
+}
+
+export const appendFormControl = (
+  parent: HTMLElement,
+  {
+    formControl,
+    title,
+  }: { formControl: HTMLValueElement | null; title: string },
+): void => {
+  if (formControl !== null) {
+    parent.append(createLabel(formControl, title))
+  }
+}
+
+export const createInput = ({
+  className,
+  id,
+  max,
+  min,
+  placeholder,
+  type,
+  value,
+}: {
+  id: string
+  type: string
+  className?: string
+  max?: number | undefined
+  min?: number | undefined
+  placeholder?: string | undefined
+  value?: string | null
+}): HTMLInputElement => {
+  const input = document.createElement('input')
+  if (className !== undefined) {
+    input.classList.add(className)
+  }
+  input.id = id
+  input.value = value ?? ''
+  input.type = type
+  configureNumericInput(input, { max, min })
+  if (placeholder !== undefined) {
+    input.placeholder = placeholder
+  }
+  return input
+}
+
+export const createSelect = (
+  id: string,
+  values: readonly { id: string; label: string }[],
+  className?: string,
+): HTMLSelectElement => {
+  const select = document.createElement('select')
+  if (className !== undefined) {
+    select.classList.add(className)
+  }
+  select.id = id
+  for (const option of [{ id: '', label: '' }, ...values]) {
+    createOption(select, option)
+  }
+  return select
+}
+
+// Shared form-value reader: checkbox → tri-state, bounded number input →
+// the caller's number strategy (the settings page throws on an
+// out-of-range value, the ATA widget clamps it), boolean string →
+// boolean, anything else → number when finite, else the raw string.
+export const parseFormValue = (
+  element: HTMLValueElement,
+  parseNumber: (input: HTMLInputElement) => number,
+): boolean | number | string | null => {
+  if (element.value !== '') {
+    if (element.type === 'checkbox') {
+      return element.indeterminate ? null : element.checked
+    }
+    if (element.type === 'number' && element.min !== '' && element.max !== '') {
+      return parseNumber(element)
+    }
+    if (booleanStrings.includes(element.value)) {
+      return element.value === 'true'
+    }
+    const numberValue = Number(element.value)
+    return Number.isFinite(numberValue) ? numberValue : element.value
+  }
+  return null
+}
+
+// Fills a zone select by walking the picker tree in list order, one
+// option per zone, subzones right below their parent.
+export const populateZoneOptions = (
+  select: HTMLSelectElement,
+  zones: readonly PickerZone[],
+): void => {
+  for (const zone of zones) {
+    const { id, level, model, name } = zone
+    createOption(select, {
+      id: getZoneId(id, model),
+      label: getZoneName(name, level),
+    })
+    populateZoneOptions(select, getSubzones(zone))
   }
 }
 

--- a/public/zones.mts
+++ b/public/zones.mts
@@ -1,3 +1,19 @@
+import type * as Classic from '@olivierzal/melcloud-api/classic'
+
+import type { HomeBuildingZone, HomeDeviceZone } from '../types/zone.mts'
+
+// Everything the zone pickers can list: a Classic zone at any level, or
+// a Home building and its devices.
+export type PickerZone = Classic.Zone | HomeBuildingZone | HomeDeviceZone
+
+// Only Classic zones nest — the Home entries carry none of the subzone
+// keys, so the walk bottoms out on them.
+export const getSubzones = (zone: PickerZone): Classic.Zone[] => [
+  ...('devices' in zone ? zone.devices : []),
+  ...('areas' in zone ? zone.areas : []),
+  ...('floors' in zone ? zone.floors : []),
+]
+
 export const getZoneId = (id: number | string, model: string): string =>
   `${model}_${String(id)}`
 

--- a/settings/index.mts
+++ b/settings/index.mts
@@ -30,9 +30,10 @@ import { getErrorMessage } from '../lib/get-error-message.mts'
 import { type DirtyGate, createDirtyGate } from '../public/dirty-gate.mts'
 import {
   type HTMLValueElement,
-  booleanStrings,
-  configureNumericInput,
-  createOption,
+  booleanOptions,
+  createInput,
+  createLabel as createPlainLabel,
+  createSelect,
   getButton,
   getDetails,
   getDiv,
@@ -40,15 +41,17 @@ import {
   getInput,
   getSelect,
   getSpan,
+  parseFormValue,
+  populateZoneOptions as populateZoneSelect,
   translateAriaLabels,
 } from '../public/dom.mts'
 import { fireAndForget, runWebview } from '../public/homey-api.mts'
 import { ensureFreshWebview } from '../public/webview-freshness.mts'
 import {
+  type PickerZone,
   getHomeBuildingId,
   getHomeDeviceId,
   getZoneId,
-  getZoneName,
   getZonePath,
   isHomeBuildingValue,
   isHomeDeviceValue,
@@ -202,16 +205,13 @@ const createLabel = (
   formControl: HTMLValueElement,
   text: string,
 ): HTMLLabelElement => {
-  const isCheckbox = formControl.type === 'checkbox'
-  const label = document.createElement('label')
-  label.classList.add(isCheckbox ? 'homey-form-checkbox' : 'homey-form-label')
-  label.htmlFor = formControl.id
-  if (isCheckbox) {
-    addTextToCheckbox(label, formControl, text)
-    return label
+  if (formControl.type !== 'checkbox') {
+    return createPlainLabel(formControl, text, 'homey-form-label')
   }
-  label.textContent = text
-  label.append(formControl)
+  const label = document.createElement('label')
+  label.classList.add('homey-form-checkbox')
+  label.htmlFor = formControl.id
+  addTextToCheckbox(label, formControl, text)
   return label
 }
 
@@ -236,33 +236,6 @@ const appendFormControl = (
 
   const label = createLabel(formControl, title)
   parent.append(shouldWrapWithDiv ? createDiv(label) : label)
-}
-
-const createInput = ({
-  id,
-  max,
-  min,
-  placeholder,
-  type,
-  value,
-}: {
-  id: string
-  type: string
-  max?: number
-  min?: number
-  placeholder?: string | undefined
-  value?: string | null
-}): HTMLInputElement => {
-  const input = document.createElement('input')
-  input.classList.add('homey-form-input')
-  input.id = id
-  input.value = value ?? ''
-  input.type = type
-  configureNumericInput(input, { max, min })
-  if (placeholder !== undefined) {
-    input.placeholder = placeholder
-  }
-  return input
 }
 
 const createLegend = (fieldSet: HTMLFieldSetElement, text?: string): void => {
@@ -340,27 +313,6 @@ const createCheckbox = (id: string, driverId: string): HTMLInputElement => {
   return checkbox
 }
 
-const createSelect = (
-  homey: Homey,
-  id: string,
-  values?: readonly { id: string; label: string }[],
-): HTMLSelectElement => {
-  const select = document.createElement('select')
-  select.classList.add('homey-form-select')
-  select.id = id
-  for (const option of [
-    { id: '', label: '' },
-    ...(values ??
-      booleanStrings.map((value) => ({
-        id: value,
-        label: homey.__(`settings.boolean.${value}`),
-      }))),
-  ]) {
-    createOption(select, option)
-  }
-  return select
-}
-
 const parseNumericInput = (
   homey: Homey,
   { id, max, min, value }: HTMLInputElement,
@@ -420,11 +372,6 @@ const createValuesGate = (
       JSON.stringify(elements.map((element) => element.value)),
   })
 
-// Everything the zone picker can list: a Classic zone at any level, or a
-// Home building and its devices. Named once because the three overheat
-// helpers and `populateZoneOptions` all speak it.
-type PickerZone = Classic.Zone | HomeBuildingZone | HomeDeviceZone
-
 // Option values driving the Home-only overheat panel: `capable` lists
 // every Home ATA device plus each building owning one (the flat target
 // list puts a building right before its devices); `atwBuildings` lists
@@ -450,12 +397,6 @@ const collectOverheatZoneValues = (
   }
   return { atwBuildings, capable }
 }
-
-const getSubzones = (zone: PickerZone): Classic.Zone[] => [
-  ...('devices' in zone ? zone.devices : []),
-  ...('areas' in zone ? zone.areas : []),
-  ...('floors' in zone ? zone.floors : []),
-]
 
 // Serialize a device-settings section's controls as a pure form snapshot for
 // its DirtyGate — the same value-only shape the frost/holiday gates use. A
@@ -690,7 +631,12 @@ class AuthManager {
     )
     if (loginSetting !== undefined) {
       const { id, placeholder, title, type } = loginSetting
-      const formControl = createInput({ id, placeholder, type })
+      const formControl = createInput({
+        className: 'homey-form-input',
+        id,
+        placeholder,
+        type,
+      })
       applyCredentialHints(formControl, credentialKey)
       appendFormControl(this.#loginSection, { formControl, title })
       return formControl
@@ -898,7 +844,11 @@ class DeviceSettingsManager {
         continue
       }
 
-      const formControl = createSelect(this.#homey, id, values)
+      const formControl = createSelect(
+        id,
+        values ?? booleanOptions(this.#homey),
+        'homey-form-select',
+      )
       formControl.dataset.settingId = id
       formControl.dataset.driverId = 'common'
       appendFormControl(this.#settingsCommon, { formControl, title })
@@ -949,27 +899,6 @@ class DeviceSettingsManager {
     ) {
       hide(getDiv('auto_adjust_section'), false)
     }
-  }
-
-  #parseFormValue(element: HTMLValueElement): Settings[keyof Settings] {
-    if (element.value !== '') {
-      if (element.type === 'checkbox') {
-        return element.indeterminate ? null : element.checked
-      }
-      if (
-        element.type === 'number' &&
-        element.min !== '' &&
-        element.max !== ''
-      ) {
-        return parseNumericInput(this.#homey, element)
-      }
-      if (booleanStrings.includes(element.value)) {
-        return element.value === 'true'
-      }
-      const numberValue = Number(element.value)
-      return Number.isFinite(numberValue) ? numberValue : element.value
-    }
-    return null
   }
 
   // Re-sync a section's controls from the cached device settings (client-side,
@@ -1034,7 +963,9 @@ class DeviceSettingsManager {
       dataset: { driverId, settingId },
     } = element
     if (settingId !== undefined) {
-      const value = this.#parseFormValue(element)
+      const value = parseFormValue(element, (input) =>
+        parseNumericInput(this.#homey, input),
+      )
       if (
         this.#shouldUpdate(
           settingId,
@@ -1516,14 +1447,7 @@ class ZoneSettingsManager {
 
   public populateZoneOptions(zones: PickerZone[]): void {
     this.#registerOverheatZones(zones)
-    for (const zone of zones) {
-      const { id, level, model, name } = zone
-      createOption(this.#zone, {
-        id: getZoneId(id, model),
-        label: getZoneName(name, level),
-      })
-      this.populateZoneOptions(getSubzones(zone))
-    }
+    populateZoneSelect(this.#zone, zones)
   }
 
   /**

--- a/tests/unit/api.test.ts
+++ b/tests/unit/api.test.ts
@@ -260,7 +260,7 @@ describe('api', () => {
           homey,
           query: mock<Partial<ErrorLogQueryParams>>({ offset: '' }),
         }),
-      ).rejects.toThrow('Invalid numeric query param: ""')
+      ).rejects.toThrow('offset: expected non-negative integer, got ')
       expect(mockApp.getErrorLog).not.toHaveBeenCalled()
     })
 
@@ -270,7 +270,7 @@ describe('api', () => {
           homey,
           query: mock<Partial<ErrorLogQueryParams>>({ period: 'abc' }),
         }),
-      ).rejects.toThrow('Invalid numeric query param: "abc"')
+      ).rejects.toThrow('period: expected non-negative integer, got abc')
       expect(mockApp.getErrorLog).not.toHaveBeenCalled()
     })
 
@@ -280,7 +280,7 @@ describe('api', () => {
           homey,
           query: mock<Partial<ErrorLogQueryParams>>({ period: 'Infinity' }),
         }),
-      ).rejects.toThrow('Invalid numeric query param: "Infinity"')
+      ).rejects.toThrow('period: expected non-negative integer, got Infinity')
       expect(mockApp.getErrorLog).not.toHaveBeenCalled()
     })
   })

--- a/tests/unit/fire-and-forget.test.ts
+++ b/tests/unit/fire-and-forget.test.ts
@@ -3,21 +3,29 @@ import { describe, expect, it, vi } from 'vitest'
 import { fireAndForget } from '../../lib/fire-and-forget.mts'
 import { settleDetached } from '../helpers.ts'
 
+const createLogger = (): {
+  error: ReturnType<typeof vi.fn<(...args: unknown[]) => void>>
+  log: ReturnType<typeof vi.fn<(...args: unknown[]) => void>>
+} => ({
+  error: vi.fn<(...args: unknown[]) => void>(),
+  log: vi.fn<(...args: unknown[]) => void>(),
+})
+
 describe(fireAndForget, () => {
   it('should keep a resolved promise silent', async () => {
-    const logError = vi.fn<(...args: unknown[]) => void>()
-    fireAndForget(Promise.resolve('done'), logError, 'Detached work failed:')
+    const logger = createLogger()
+    fireAndForget(Promise.resolve('done'), logger, 'Detached work failed:')
     await settleDetached()
 
-    expect(logError).not.toHaveBeenCalled()
+    expect(logger.error).not.toHaveBeenCalled()
   })
 
   it('should log a rejection with the given message', async () => {
     const failure = new Error('boom')
-    const logError = vi.fn<(...args: unknown[]) => void>()
-    fireAndForget(Promise.reject(failure), logError, 'Detached work failed:')
+    const logger = createLogger()
+    fireAndForget(Promise.reject(failure), logger, 'Detached work failed:')
     await settleDetached()
 
-    expect(logError).toHaveBeenCalledWith('Detached work failed:', failure)
+    expect(logger.error).toHaveBeenCalledWith('Detached work failed:', failure)
   })
 })

--- a/types/capabilities.mts
+++ b/types/capabilities.mts
@@ -79,7 +79,7 @@ export type EnergyCapabilities<T extends Classic.DeviceType> =
       ? classicAtw.EnergyCapabilities
       : T extends typeof Classic.DeviceType.Erv
         ? classicErv.EnergyCapabilities
-        : Record<string, never>
+        : never
 
 export type EnergyCapabilityTagEntry<T extends Classic.DeviceType> = [
   capability: string & keyof EnergyCapabilities<T>,

--- a/widgets/ata-group-setting/public/ata-values.mts
+++ b/widgets/ata-group-setting/public/ata-values.mts
@@ -4,18 +4,19 @@ import {
   classicCoolModes,
 } from '@olivierzal/melcloud-api/constants'
 
-import type { Settings } from '../../../types/device-settings.mts'
 import type { DriverCapabilitiesOptions } from '../../../types/driver-settings.mts'
 import type { AtaGroupSettingWidgetSettings } from '../../../types/widgets.mts'
-import type { HomeBuildingZone, HomeDeviceZone } from '../../../types/zone.mts'
 import { type DirtyGate, createDirtyGate } from '../../../public/dirty-gate.mts'
 import {
   type HTMLValueElement,
-  booleanStrings,
-  configureNumericInput,
-  createOption,
+  appendFormControl,
+  booleanOptions,
+  createInput,
+  createSelect,
   getButton,
   getSelect,
+  parseFormValue,
+  populateZoneOptions,
 } from '../../../public/dom.mts'
 import {
   type Homey,
@@ -23,93 +24,19 @@ import {
   homeyApiPut,
 } from '../../../public/homey-api.mts'
 import {
+  type PickerZone,
   getHomeBuildingId,
   getHomeDeviceId,
   getZoneId,
-  getZoneName,
   getZonePath,
   isHomeBuildingValue,
   isHomeDeviceValue,
 } from '../../../public/zones.mts'
 
-type TargetZone = Classic.Zone | HomeBuildingZone | HomeDeviceZone
-
-// ── DOM helpers ──
-
+// The generated controls are styled by element selectors in
+// `styles/layout.css` (Homey design tokens) — no utility classes needed,
+// so the shared builders run without their class hooks.
 const elementTypes = new Set(['boolean', 'enum'])
-
-// ── DOM creation helpers ──
-
-// Labels, inputs and selects are styled by element selectors in
-// `styles/layout.css` (Homey design tokens) — no utility classes needed.
-const createLabel = (
-  formControl: HTMLValueElement,
-  text: string,
-): HTMLLabelElement => {
-  const label = document.createElement('label')
-  label.htmlFor = formControl.id
-  label.textContent = text
-  label.append(formControl)
-  return label
-}
-
-const appendFormControl = (
-  parent: HTMLElement,
-  {
-    formControl,
-    title,
-  }: { formControl: HTMLValueElement | null; title: string },
-): void => {
-  if (formControl !== null) {
-    parent.append(createLabel(formControl, title))
-  }
-}
-
-const createInput = ({
-  id,
-  max,
-  min,
-  placeholder,
-  type,
-  value,
-}: {
-  id: string
-  type: string
-  max?: number | undefined
-  min?: number | undefined
-  placeholder?: string
-  value?: string
-}): HTMLInputElement => {
-  const input = document.createElement('input')
-  input.id = id
-  input.value = value ?? ''
-  input.type = type
-  configureNumericInput(input, { max, min })
-  if (placeholder !== undefined) {
-    input.placeholder = placeholder
-  }
-  return input
-}
-
-const createSelect = (
-  homey: Homey,
-  id: string,
-  values?: readonly { id: string; label: string }[],
-): HTMLSelectElement => {
-  const select = document.createElement('select')
-  select.id = id
-  for (const option of [
-    { id: '', label: '' },
-    ...(values ??
-      booleanStrings.map((value) => ({
-        id: value,
-        label: homey.__(`settings.boolean.${value}`),
-      }))),
-  ]) {
-    createOption(select, option)
-  }
-  return select
-}
 
 // ── Value processing ──
 
@@ -137,31 +64,6 @@ const clampNumericInput = ({
   }
   return Math.min(Math.max(numberValue, newMin), newMax)
 }
-
-const parseFormValue = (
-  element: HTMLValueElement,
-): Settings[keyof Settings] => {
-  if (element.value !== '') {
-    if (element.type === 'checkbox') {
-      return element.indeterminate ? null : element.checked
-    }
-    if (element.type === 'number' && element.min !== '' && element.max !== '') {
-      return clampNumericInput(element)
-    }
-    if (booleanStrings.includes(element.value)) {
-      return element.value === 'true'
-    }
-    const numberValue = Number(element.value)
-    return Number.isFinite(numberValue) ? numberValue : element.value
-  }
-  return null
-}
-
-const getSubzones = (zone: TargetZone): TargetZone[] => [
-  ...('devices' in zone ? zone.devices : []),
-  ...('areas' in zone ? zone.areas : []),
-  ...('floors' in zone ? zone.floors : []),
-]
 
 // Routes a `${model}_${id}` option value to its state endpoint.
 const getAtaStatePath = (value: string): string => {
@@ -277,17 +179,8 @@ export class AtaValueManager {
     return values
   }
 
-  public populateZoneOptions(zones: TargetZone[] = []): void {
-    if (zones.length > 0) {
-      for (const zone of zones) {
-        const { id, level, model, name } = zone
-        createOption(this.#zone, {
-          id: getZoneId(id, model),
-          label: getZoneName(name, level),
-        })
-        this.populateZoneOptions(getSubzones(zone))
-      }
-    }
+  public populateZoneOptions(zones: PickerZone[] = []): void {
+    populateZoneOptions(this.#zone, zones)
   }
 
   public async setValues(): Promise<void> {
@@ -322,7 +215,10 @@ export class AtaValueManager {
               this.#zoneMapping[this.#zone.value]?.[id]?.toString(),
             ].includes(value),
         )
-        .map((element) => [element.id, parseFormValue(element)]),
+        .map((element) => [
+          element.id,
+          parseFormValue(element, clampNumericInput),
+        ]),
     )
   }
 
@@ -336,7 +232,7 @@ export class AtaValueManager {
     values?: readonly { id: string; label: string }[] | undefined
   }): HTMLValueElement | null {
     if (elementTypes.has(type)) {
-      return createSelect(this.#homey, id, values)
+      return createSelect(id, values ?? booleanOptions(this.#homey))
     }
     if (type === 'number') {
       return createInput({


### PR DESCRIPTION
The deferred B-wave webview factoring, every review claim re-verified against the current tree before editing:

- **Shared once in `public/`** — `PickerZone` + `getSubzones` (zones.mts), `populateZoneOptions`, `createInput`/`createSelect`/`createLabel`/bare `appendFormControl`, `booleanOptions` and the strategy-parameterized `parseFormValue` (dom.mts). The one systematic divergence — the settings page's `homey-form-*` decoration — rides optional class hooks; the widget keeps styling bare elements. The settings page keeps its own `appendFormControl` and checkbox label: div-wrapping and the checkbox span structure are settings-only chrome, and a strategy-parameterized merge would read worse than the six lines it saves (documented verdict).
- **Numeric coercion folds onto `toNonNegativeInt`** — `api.mts`'s hand-rolled `toNumber` and `app.mts`'s `toDurationDays` are gone; the holiday-duration boundary translates failures into the user's language with a try/catch instead of an options-bag message (simpler than extending the shared API). The shared helper now rejects empty/whitespace strings (`Number('') === 0` is a coercion wart, not an integer) — the suite caught that the consolidation would otherwise have turned `''` into a legal zero; three message pins updated to the field-prefixed contract.
- **`fireAndForget` realigns on the lib's logger-object shape** it always claimed to mirror — `this` passes as the logger, dissolving the three per-site error adapters AND the app's `#createLogger` factory.
- **Energy ladder terminal** `Record<string, never>` → `never`: typecheck-proven drift, the five ladders now agree.
- Skipped as out of this diff's path: the two micro-reads (#26/#27) flagged low-confidence by the review.

Net −52 lines; suite: 752 tests, 100 % everywhere, publish-level validation green. Closing cleanup pass ran on this diff itself (its own dead imports were caught and dropped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3