### PR TITLE
refactor: make the gate's arming source exclusive by type

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,16 +136,18 @@ coverage.
   fieldsets while a request is in flight (container `disabled` +
   `aria-busy`, so a control's own domain `disabled` survives the thaw):
   every success path rewrites the fields, so a mid-flight edit would be
-  silently clobbered — pass every region `serialize` reads through
-  `fieldsetElements`. When a wire protocol cannot express every form
-  divergence (an emptied field means "no instruction" and is omitted
-  from the request), the call site supplies `isActionable` — Apply arms
-  only when the request would carry something — while `serialize` stays
-  the pure snapshot; the ATA group widget arms through its body builder
-  this way, and the credentials section arms only when both fields are
-  filled (its Reset button rides the gate as a Refresh — greyed by busy
-  alone). Its
-  `serialize` must stay a PURE form snapshot, never a request-body builder
+  silently clobbered — pass every region the arming source reads through
+  `fieldsetElements`. Arming comes from exactly ONE source, exclusive by
+  type: baseline mode (`serialize`, a pure snapshot diffed against the
+  saved baseline) or predicate mode (`isActionable`, for wire protocols
+  that cannot express every form divergence — an emptied field means "no
+  instruction" and is omitted from the request — with no baseline to
+  retain stale form state); the ATA group widget arms through its body
+  builder this way, and the credentials section arms only when both
+  fields are filled (its Reset button rides the gate as a Refresh —
+  greyed by busy alone; in predicate mode `markSaved` only re-evaluates).
+  A baseline `serialize` must stay a PURE form snapshot, never a
+  request-body builder
   (those filter null deltas out and desync the pristine check — the
   historical heatzy bug), and disabled greying styles
   `[class*='homey-button']:disabled` generically, never a per-class list

--- a/public/dirty-gate.mts
+++ b/public/dirty-gate.mts
@@ -1,11 +1,12 @@
 // The webviews' shared dirty-gating primitive: one gate owns one Apply
-// button — greyed while the form matches its saved baseline OR a request
+// button — greyed while the form is not worth submitting OR a request
 // is in flight — its sibling Refresh buttons, greyed by busy alone so
 // they stay the escape hatch on a pristine form, and the form's
 // fieldsets, frozen by busy alone: every success path rewrites the
 // fields, so an edit slipped in mid-flight would be silently clobbered
 // when the response lands — the freeze closes that window. The factory
-// owns the whole invariant; a call site only supplies `serialize`.
+// owns the whole invariant; a call site only supplies its arming source
+// (a pure snapshot or a domain predicate, exclusively).
 // Byte-identical copies of this module live in the sibling Homey apps —
 // edit them together.
 
@@ -17,17 +18,39 @@ export interface DirtyGate {
   readonly wire: (targets: readonly EventTarget[]) => void
 }
 
-export interface DirtyGateOptions {
+// Arming comes from exactly ONE source. Baseline mode: `serialize` is a
+// PURE snapshot of the form's current values — never a request-body
+// builder: those filter defaults and null deltas out, which desyncs the
+// pristine check — and Apply arms when the snapshot diverges from the
+// saved baseline. Predicate mode: when the wire protocol cannot express
+// every form divergence (an emptied field means "no instruction" and is
+// omitted from the request), supply `isActionable` instead — Apply arms
+// only when pressing it would send something, and no baseline exists to
+// retain stale form state. The pair is exclusive by type: a predicate
+// site has no use for a baseline (the predicate would short-circuit it
+// into dead weight).
+export type DirtyGateOptions = {
   readonly applyElement: HTMLButtonElement
   readonly fieldsetElements?: readonly HTMLFieldSetElement[]
   readonly refreshElements?: readonly HTMLButtonElement[]
-  readonly serialize: () => string
-  readonly isActionable?: () => boolean
-}
+} & (
+  | { readonly isActionable?: undefined; readonly serialize: () => string }
+  | { readonly serialize?: undefined; readonly isActionable: () => boolean }
+)
+
+// Predicate mode consults the domain judgment; baseline mode diffs the
+// pure snapshot against the saved baseline.
+const isArmed = (
+  options: DirtyGateOptions,
+  saved: string | undefined,
+): boolean =>
+  options.isActionable === undefined
+    ? options.serialize() !== saved
+    : options.isActionable()
 
 // `input` covers live typing in number/date fields; `change` covers the
-// selects and the final commit (and, since `serialize` reads the whole
-// form, any field a cascade handler mutated).
+// selects and the final commit (and, since the arming source reads the
+// whole form, any field a cascade handler mutated).
 const wireRecompute = (
   targets: readonly EventTarget[],
   recompute: () => void,
@@ -53,40 +76,30 @@ const setFrozen = (
   }
 }
 
-// `serialize` must be a PURE snapshot of the form's current values — never
-// a request-body builder: those filter defaults and null deltas out, which
-// desyncs the pristine check. The gate snapshots it at creation, so Apply
-// starts greyed even when no data ever loads; call `markSaved` after every
-// (re)populate and successful save, `wire` on the controls the snapshot
-// reads, and route every request through `runBusy`. When the wire
-// protocol cannot express every form divergence (an emptied field means
-// "no instruction" and is omitted from the request), supply
-// `isActionable`: Apply then arms only when pressing it would send
-// something — the arming predicate gains domain judgment while the
-// baseline bookkeeping stays the pure snapshot. Buttons grey through
-// native `disabled` (not a CSS class): it blocks keyboard activation
-// during in-flight actions and is announced by screen readers.
-export const createDirtyGate = ({
-  applyElement,
-  fieldsetElements = [],
-  isActionable,
-  refreshElements = [],
-  serialize,
-}: DirtyGateOptions): DirtyGate => {
+// The gate evaluates its arming at creation, so Apply starts greyed even
+// when no data ever loads; call `markSaved` after every (re)populate and
+// successful save (in predicate mode it only re-evaluates — there is no
+// baseline to move), `recompute` after any programmatic field write (no
+// `input` event fires for those), `wire` on the controls the arming
+// source reads, and route every request through `runBusy`. Buttons grey
+// through native `disabled` (not a CSS class): it blocks keyboard
+// activation during in-flight actions and is announced by screen
+// readers.
+export const createDirtyGate = (options: DirtyGateOptions): DirtyGate => {
+  const { applyElement, fieldsetElements = [], refreshElements = [] } = options
   let busyGeneration = 0
   let isBusy = false
-  let saved = serialize()
+  let saved = options.serialize?.()
   const recompute = (): void => {
-    applyElement.disabled =
-      isBusy || !(isActionable?.() ?? serialize() !== saved)
+    applyElement.disabled = isBusy || !isArmed(options, saved)
   }
   const markSaved = (): void => {
-    saved = serialize()
+    saved = options.serialize?.()
     recompute()
   }
   // Refresh is gated by busy ALONE (never dirty); Apply folds the busy
-  // flag into its dirty check so a mid-request edit cannot re-enable it;
-  // the fieldsets freeze and thaw with it (`setFrozen`).
+  // flag into its arming check so a mid-request edit cannot re-enable
+  // it; the fieldsets freeze and thaw with it (`setFrozen`).
   const setBusy = (isBusyNow: boolean): void => {
     isBusy = isBusyNow
     for (const element of refreshElements) {
@@ -109,9 +122,14 @@ export const createDirtyGate = ({
       }
     }
   }
-  const wire = (targets: readonly EventTarget[]): void => {
-    wireRecompute(targets, recompute)
-  }
   recompute()
-  return { markSaved, recompute, runBusy, setBusy, wire }
+  return {
+    markSaved,
+    recompute,
+    runBusy,
+    setBusy,
+    wire: (targets: readonly EventTarget[]): void => {
+      wireRecompute(targets, recompute)
+    },
+  }
 }

--- a/settings/index.html
+++ b/settings/index.html
@@ -26,7 +26,7 @@
                         // fails on this device.
                         const script = document.querySelector('script[src*="index.js"]')
                         const report = (probe) => {
-                            homey.api('POST', '/boot-error', { message: 'The settings bundle did not boot within 10s', name: 'BootTimeout', probe, stack: '', userAgent: navigator.userAgent }, () => {})
+                            homey.api('POST', '/boot-error', { message: 'The settings bundle did not boot within 10s', name: 'BootTimeout', probe, userAgent: navigator.userAgent }, () => {})
                             homey.ready()
                             homey.alert(homey.__('settings.loadFailed')).catch(() => {})
                         }

--- a/settings/index.mts
+++ b/settings/index.mts
@@ -500,12 +500,6 @@ class AuthManager {
         const { password, username } = this.#loginInput
         return username !== '' && password !== ''
       },
-      serialize: (): string =>
-        JSON.stringify([
-          this.#apiSelect.value,
-          this.#usernameInput?.value ?? '',
-          this.#passwordInput?.value ?? '',
-        ]),
     })
   }
 

--- a/tests/unit/dirty-gate.test.ts
+++ b/tests/unit/dirty-gate.test.ts
@@ -123,18 +123,15 @@ describe('dirty gate', () => {
     expect(refreshElement.disabled).toBe(false)
   })
 
-  it('should arm Apply through isActionable instead of the snapshot diff', () => {
+  it('should arm Apply through isActionable with no baseline at all', () => {
     const applyElement = mock<HTMLButtonElement>({ disabled: false })
     const actionable = { value: false }
-    const form = { value: 'pristine' }
+    // Predicate mode carries NO serialize: the gate must construct and
+    // recompute without ever reaching for a snapshot.
     const gate = createDirtyGate({
       applyElement,
       isActionable: () => actionable.value,
-      serialize: () => form.value,
     })
-
-    form.value = 'edited'
-    gate.recompute()
 
     expect(applyElement.disabled).toBe(true)
 
@@ -144,6 +141,25 @@ describe('dirty gate', () => {
     expect(applyElement.disabled).toBe(false)
 
     gate.setBusy(true)
+
+    expect(applyElement.disabled).toBe(true)
+  })
+
+  it('should degrade markSaved to a re-evaluation in predicate mode', () => {
+    const applyElement = mock<HTMLButtonElement>({ disabled: false })
+    const actionable = { value: true }
+    const gate = createDirtyGate({
+      applyElement,
+      isActionable: () => actionable.value,
+    })
+
+    expect(applyElement.disabled).toBe(false)
+
+    // A successful save typically drains the predicate (the form now
+    // matches the persisted state); markSaved must pick that up even
+    // though it has no baseline to move.
+    actionable.value = false
+    gate.markSaved()
 
     expect(applyElement.disabled).toBe(true)
   })

--- a/widgets/ata-group-setting/public/ata-values.mts
+++ b/widgets/ata-group-setting/public/ata-values.mts
@@ -103,19 +103,17 @@ export class AtaValueManager {
     this.#homey = homey
     this.#ataValues = ataValuesElement
     this.#zone = zoneElement
-    // The gate snapshots its pristine baseline at creation: Update starts
-    // greyed even when no zone resolves and the first fetch never runs.
-    // Arming goes through `isActionable`, not the snapshot diff: an
-    // emptied field means "no instruction" and a value equal to the
-    // zone's known state is filtered out, so Update arms only when the
-    // request would actually carry something.
+    // Update starts greyed even when no zone resolves and the first
+    // fetch never runs. Arming goes through `isActionable`: an emptied
+    // field means "no instruction" and a value equal to the zone's known
+    // state is filtered out, so Update arms only when the request would
+    // actually carry something.
     this.#dirtyGate = createDirtyGate({
       applyElement: getButton('apply_values_melcloud'),
       fieldsetElements: [ataValuesElement],
       refreshElements: [getButton('refresh_values_melcloud')],
       isActionable: (): boolean =>
         Object.keys(this.#buildAtaValuesBody()).length > 0,
-      serialize: (): string => this.#serializeState(),
     })
   }
 
@@ -247,17 +245,6 @@ export class AtaValueManager {
 
   #isGroupAtaState(value: string): value is keyof Classic.GroupState {
     return Object.hasOwn(this.#defaultAtaValues, value)
-  }
-
-  // Serializes every control's id and value, in DOM order, into the string
-  // the dirty check diffs against. A control still on its mixed/empty state
-  // serializes as '', so picking a concrete value registers as a change.
-  #serializeState(): string {
-    return JSON.stringify(
-      [
-        ...this.#ataValues.querySelectorAll<HTMLValueElement>('input, select'),
-      ].map(({ id, value }) => [id, value]),
-    )
   }
 
   #syncAtaValues(): void {

--- a/widgets/ata-group-setting/public/index.html
+++ b/widgets/ata-group-setting/public/index.html
@@ -27,7 +27,7 @@
                         const script = document.querySelector('script[src*="index.js"]')
                         const report = (probe) => {
                             homey
-                                .api('POST', '/boot-error', { message: 'The widget bundle did not boot within 10s', name: 'BootTimeout', probe, stack: '', userAgent: navigator.userAgent })
+                                .api('POST', '/boot-error', { message: 'The widget bundle did not boot within 10s', name: 'BootTimeout', probe, userAgent: navigator.userAgent })
                                 .catch(() => {})
                             const message = document.querySelector('#init_error')
                             if (message) {

--- a/widgets/charts/public/index.html
+++ b/widgets/charts/public/index.html
@@ -27,7 +27,7 @@
                         const script = document.querySelector('script[src*="index.js"]')
                         const report = (probe) => {
                             homey
-                                .api('POST', '/boot-error', { message: 'The widget bundle did not boot within 10s', name: 'BootTimeout', probe, stack: '', userAgent: navigator.userAgent })
+                                .api('POST', '/boot-error', { message: 'The widget bundle did not boot within 10s', name: 'BootTimeout', probe, userAgent: navigator.userAgent })
                                 .catch(() => {})
                             const message = document.querySelector('#init_error')
                             if (message) {


### PR DESCRIPTION
Final twin chantier of wave B, part 1 of 3 (com.melcloud owner copy).

**Gate contract** — arming now comes from exactly ONE source, enforced by a discriminated options union: baseline mode (`serialize`, pure snapshot vs saved baseline) or predicate mode (`isActionable`, no baseline at all). At predicate sites the `??` short-circuit had left `saved`/`markSaved` as dead weight — and the baseline retained a serialized snapshot of the form (the credentials-retention concern raised by Copilot on com.heatzy, now impossible by construction). `markSaved` in predicate mode degrades to a re-evaluation (documented), so post-save call sites stay uniform. Site verdicts: settings sections + frost/holiday/overheat gates = baseline mode, unchanged; credentials + ATA widget = predicate mode, dead serializers dropped (the widget's orphaned `#serializeState` removed with them). Twin test extended: predicate mode without serialize (fails under the old contract — TypeError at construction, mutation-verified 2/9), markSaved degradation pinned.

**Diagnostics taxonomy** — the inline boot beacons already carry `name: 'BootTimeout'` (the freshness breadcrumbs carry `WebviewFreshness`); the one residue was the hard-coded `stack: ''` — dropped from the three inline scripts (settings + both widgets, kept byte-identical for the widget-styles pin). The handler types `body: unknown` and keeps accepting cached pages that still send it — not hardened.

Byte-identical propagation to com.heatzy and com.melcloud.extension follows in sibling PRs; md5s will be listed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3