### PR TITLE
docs: state each arming mode's initial Apply state

### DIFF
--- a/public/dirty-gate.mts
+++ b/public/dirty-gate.mts
@@ -76,8 +76,11 @@ const setFrozen = (
   }
 }
 
-// The gate evaluates its arming at creation, so Apply starts greyed even
-// when no data ever loads; call `markSaved` after every (re)populate and
+// The gate evaluates its arming at creation: in baseline mode Apply
+// starts greyed even when no data ever loads (the form matches its own
+// snapshot), in predicate mode it starts wherever `isActionable` puts
+// it — a prefilled form may legitimately arm at once. Call `markSaved`
+// after every (re)populate and
 // successful save (in predicate mode it only re-evaluates — there is no
 // baseline to move), `recompute` after any programmatic field write (no
 // `input` event fires for those), `wire` on the controls the arming


### PR DESCRIPTION
Twin-kernel comment fix mirrored from the Copilot thread on OlivierZal/com.melcloud.extension#1265: in predicate mode Apply legitimately starts wherever `isActionable` puts it (a prefilled form arms at once) — the old wording promised “starts greyed” unconditionally. Byte-identical ×3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3