### PR TITLE
build: adopt configs 1.3.0

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -4,7 +4,7 @@ jobs:
     permissions:
       contents: read
       packages: read
-    uses: OlivierZal/configs/.github/workflows/reusable-audit.yml@3242d565365a1c7943f454ea74d40c95bfe49283 # v1.2.1
+    uses: OlivierZal/configs/.github/workflows/reusable-audit.yml@6932d7af8f2c21600bd7dc945062fe1a66d7db26 # v1.3.0
 name: Audit
 on:
   push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
       packages: read
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/reusable-ci.yml@3242d565365a1c7943f454ea74d40c95bfe49283 # v1.2.1
+    uses: OlivierZal/configs/.github/workflows/reusable-ci.yml@6932d7af8f2c21600bd7dc945062fe1a66d7db26 # v1.3.0
     with:
       check-node-version: '22'
       coverage-node-version: '22'

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -8,7 +8,7 @@ jobs:
       pull-requests: write
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/claude-code-review.yml@3242d565365a1c7943f454ea74d40c95bfe49283 # v1.2.1
+    uses: OlivierZal/configs/.github/workflows/claude-code-review.yml@6932d7af8f2c21600bd7dc945062fe1a66d7db26 # v1.3.0
 name: claude-code-review
 on:
   pull_request:

--- a/.github/workflows/claude-dependabot-fix.yml
+++ b/.github/workflows/claude-dependabot-fix.yml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: read
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/reusable-claude-dependabot-fix.yml@3242d565365a1c7943f454ea74d40c95bfe49283 # v1.2.1
+    uses: OlivierZal/configs/.github/workflows/reusable-claude-dependabot-fix.yml@6932d7af8f2c21600bd7dc945062fe1a66d7db26 # v1.3.0
     with:
       repo-guidance: 'API bugs surfacing through @olivierzal/melcloud-api are fixed in that library, never worked around in this app.'
       verify-commands: '`npm run format`, `npm run lint`, `npm run typecheck`, `npm test`, and `npm run build`'

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -6,7 +6,7 @@ jobs:
       issues: write
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/claude-issue-triage.yml@3242d565365a1c7943f454ea74d40c95bfe49283 # v1.2.1
+    uses: OlivierZal/configs/.github/workflows/claude-issue-triage.yml@6932d7af8f2c21600bd7dc945062fe1a66d7db26 # v1.3.0
 name: claude-issue-triage
 on:
   issues:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -11,7 +11,7 @@ jobs:
       pull-requests: read
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/claude.yml@3242d565365a1c7943f454ea74d40c95bfe49283 # v1.2.1
+    uses: OlivierZal/configs/.github/workflows/claude.yml@6932d7af8f2c21600bd7dc945062fe1a66d7db26 # v1.3.0
 name: claude
 on:
   # No pull_request_review(_comment): Copilot auto-review fires them as a

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -4,7 +4,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: OlivierZal/configs/.github/workflows/dependabot.yml@3242d565365a1c7943f454ea74d40c95bfe49283 # v1.2.1
+    uses: OlivierZal/configs/.github/workflows/dependabot.yml@6932d7af8f2c21600bd7dc945062fe1a66d7db26 # v1.3.0
 name: dependabot
 on:
   pull_request: {}

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -3,7 +3,7 @@ jobs:
   pr_title:
     permissions:
       pull-requests: read
-    uses: OlivierZal/configs/.github/workflows/pr-title.yml@3242d565365a1c7943f454ea74d40c95bfe49283 # v1.2.1
+    uses: OlivierZal/configs/.github/workflows/pr-title.yml@6932d7af8f2c21600bd7dc945062fe1a66d7db26 # v1.3.0
 name: pr-title
 on:
   pull_request:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -5,7 +5,7 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    uses: OlivierZal/configs/.github/workflows/zizmor.yml@3242d565365a1c7943f454ea74d40c95bfe49283 # v1.2.1
+    uses: OlivierZal/configs/.github/workflows/zizmor.yml@6932d7af8f2c21600bd7dc945062fe1a66d7db26 # v1.3.0
 name: zizmor
 on:
   merge_group: {}

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -30,6 +30,34 @@ const config: Config[] = defineConfig([
       'settings/**/*.mts',
       'widgets/*/public/**/*.mts',
     ],
+    wireNamingEntries: [
+      // MELCloud Classic state fields: the ATA group widget posts these
+      // names verbatim, so they are the wire's, not ours. Enumerated so
+      // that a new PascalCase property fails until it is recognised as
+      // wire vocabulary.
+      {
+        filter: {
+          match: true,
+          regex:
+            '^(FanSpeed|OperationMode|Power|SetTemperature|VaneHorizontalDirection|VaneHorizontalSwing|VaneVerticalDirection|VaneVerticalSwing)$',
+        },
+        format: null,
+        selector: 'typeProperty',
+      },
+      // The charts widget keys its color maps by the report series and
+      // mode names the wire speaks — the lookup is by runtime name, and
+      // the locales translate the same vocabulary under
+      // `widgets.charts.series.*`.
+      {
+        filter: {
+          match: true,
+          regex:
+            '^(ActualRecovery|Auto|AutoMode|Consumed|CoolMode|Cooling|Dry|DryMode|Fan|FansStopped|FlowTemperature|FlowTemperatureBoiler|FlowTemperatureZone1|FlowTemperatureZone2|FreezeStat|HeatMode|Heating|HotWater|LegionellaPrevention|MixingTankWaterTemperature|Other|OutdoorTemperature|Power|PowerOff|Produced|ProducedCooling|ProducedHeating|ProducedHotWater|ReturnTemperature|ReturnTemperatureBoiler|ReturnTemperatureZone1|ReturnTemperatureZone2|RoomTemperature|RoomTemperatureZone1|RoomTemperatureZone2|SetTankWaterTemperature|SetTemperature|SetTemperatureZone1|SetTemperatureZone2|Stop|TankWaterTemperature|VentilationMode)$',
+        },
+        format: null,
+        selector: 'objectLiteralProperty',
+      },
+    ],
   }),
   {
     // filename-case also checks directory names, but melcloud_atw and

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "temporal-polyfill": "^1.0.1"
       },
       "devDependencies": {
-        "@olivierzal/configs": "1.2.1",
+        "@olivierzal/configs": "1.3.0",
         "@types/homey": "npm:homey-apps-sdk-v3-types@^0.3.12",
         "@types/node": "^26.1.1",
         "@typescript/native": "npm:typescript@^7.0.2",
@@ -1069,9 +1069,9 @@
       }
     },
     "node_modules/@olivierzal/configs": {
-      "version": "1.2.1",
-      "resolved": "https://npm.pkg.github.com/download/@olivierzal/configs/1.2.1/7e651d38b234aa3d4b884729b295506b1da87358",
-      "integrity": "sha512-xYOtdvKcO+WU9tm6lv5fpsyxeqRi/p/FhbuVONb9JkdqxIa8vP/efU333EAKOpXe7TK4i+ij5hg462r3JmSw4Q==",
+      "version": "1.3.0",
+      "resolved": "https://npm.pkg.github.com/download/@olivierzal/configs/1.3.0/63ba02ae09575a48d7b0f9a88126384fa6e3ba25",
+      "integrity": "sha512-sM500YwFYAcME61eQ9Vvh5c1Aqued7DnjSeNF+qlATcq5wzbp5ZMmWFaPhJT1Lg67yiU/3a41SZgvu64OGqfzw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "temporal-polyfill": "^1.0.1"
   },
   "devDependencies": {
-    "@olivierzal/configs": "1.2.1",
+    "@olivierzal/configs": "1.3.0",
     "@types/homey": "npm:homey-apps-sdk-v3-types@^0.3.12",
     "@types/node": "^26.1.1",
     "@typescript/native": "npm:typescript@^7.0.2",


### PR DESCRIPTION
The strict naming core lands: properties are camelCase unless something outside this repo imposes otherwise.

Both departures are wire vocabulary, declared as narrow allowlists rather than a format relaxation — a new PascalCase property fails until it is recognised as the wire's (mutation-checked):

- `types/classic-ata.mts` (8): the Classic state fields the ATA group widget posts verbatim, each present in `@olivierzal/melcloud-api`.
- `widgets/charts/public/index.mts` (47): the color and band maps are looked up by runtime series/mode name, and `locales/*.json` translates the same vocabulary under `widgets.charts.series.*`.

No rename was warranted — every hit is protocol-imposed. No non-naming rule moved. Stub SHAs bumped to v1.3.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3