### PR TITLE
build: adopt melcloud-api 47.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "46.1.0",
       "license": "GPL-3.0-only",
       "dependencies": {
-        "@olivierzal/melcloud-api": "46.0.1",
+        "@olivierzal/melcloud-api": "47.0.0",
         "source-map-support": "^0.5.21",
         "temporal-polyfill": "^1.0.1"
       },
@@ -1106,9 +1106,9 @@
       }
     },
     "node_modules/@olivierzal/melcloud-api": {
-      "version": "46.0.1",
-      "resolved": "https://npm.pkg.github.com/download/@olivierzal/melcloud-api/46.0.1/b4d3e63d09cf4d1a8ac9bf8eca3906233b071363",
-      "integrity": "sha512-4CVMnTBR7xWLuLkWnVI8e8bu1E7BQz4h8qJFw/RXMvlOn5/eZDmdfq/NMrn11u5nHdl6HKGoZdjYXRi05W9iMA==",
+      "version": "47.0.0",
+      "resolved": "https://npm.pkg.github.com/download/@olivierzal/melcloud-api/47.0.0/38e45d7bd5d874a048bb3a16f06faf077018746f",
+      "integrity": "sha512-j23onqaNhuQTpxEwjG4d5x/hfahlWTUfgE+xoPu3DtADL+1NOLCXpNuu5rGzIX4v+KSAIAJbo8nwd+osvXErOQ==",
       "license": "MIT",
       "dependencies": {
         "temporal-polyfill": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "prettier": "@olivierzal/configs/prettier",
   "dependencies": {
-    "@olivierzal/melcloud-api": "46.0.1",
+    "@olivierzal/melcloud-api": "47.0.0",
     "source-map-support": "^0.5.21",
     "temporal-polyfill": "^1.0.1"
   },

--- a/widgets/ata-group-setting/public/ata-values.mts
+++ b/widgets/ata-group-setting/public/ata-values.mts
@@ -47,7 +47,7 @@ const coolModeNumbers: ReadonlySet<number> = classicCoolModes
 const getCoolingAdjustedMin = (id: string, min: string): string =>
   id === 'SetTemperature' &&
   coolModeNumbers.has(Number(getSelect('OperationMode').value))
-    ? String(ClassicTemperature.cooling_min)
+    ? String(ClassicTemperature.coolingMin)
     : min
 
 const clampNumericInput = ({


### PR DESCRIPTION
Exact-pin bump 46.0.1 → 47.0.0, the major that renames three published constants to their compliant names. One call site moves: the ATA group widget's cooling floor reads `ClassicTemperature.coolingMin`. The other two renamed names (`dayOfWeek`, `monthOfYear`) are unused here, and com.melcloud.extension uses none of the three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3