### PR TITLE
feat: announce every changelog entry a user has not seen

### DIFF
--- a/app.mts
+++ b/app.mts
@@ -1,6 +1,11 @@
 import 'source-map-support/register.js'
 
-import { fireAndForget, NotFoundError } from '@olivierzal/homey-kit'
+import {
+  fireAndForget,
+  NotFoundError,
+  selectChangelogEntries,
+  sequential,
+} from '@olivierzal/homey-kit'
 import {
   type DeviceType,
   type HolidayModeState,
@@ -1152,21 +1157,26 @@ export default class MELCloudApp extends App {
       notifications,
       settings,
     } = homey
-    if (settings.get('notifiedVersion') === version) {
-      return
-    }
-    const changelogByVersion = changelog as Record<
-      string,
-      Record<string, string>
-    >
-    const versionChangelog = changelogByVersion[version] ?? {}
-    const excerpt = versionChangelog[language]
-    if (excerpt === undefined) {
+    // Every release since the one already announced, not just the
+    // running one: a user who updates rarely would otherwise never hear
+    // about the versions in between. The SDK read is untyped, as
+    // everywhere else settings are read: a stored value that is not a
+    // string reads as no baseline at all.
+    const notified: unknown = settings.get('notifiedVersion')
+    const { entries } = selectChangelogEntries({
+      changelog,
+      from: typeof notified === 'string' ? notified : null,
+      language,
+      to: version,
+    })
+    if (entries.length === 0) {
       return
     }
     homey.setTimeout(async () => {
       try {
-        await notifications.createNotification({ excerpt })
+        await sequential(entries, async ({ excerpt }) => {
+          await notifications.createNotification({ excerpt })
+        })
         settings.set('notifiedVersion', version)
       } catch {
         // Non-critical: notification display is best-effort

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "46.1.2",
       "license": "GPL-3.0-only",
       "dependencies": {
-        "@olivierzal/homey-kit": "2.1.2",
+        "@olivierzal/homey-kit": "2.2.0",
         "@olivierzal/melcloud-api": "47.0.0",
         "source-map-support": "^0.5.21",
         "temporal-polyfill": "^1.0.1"
@@ -1107,9 +1107,9 @@
       }
     },
     "node_modules/@olivierzal/homey-kit": {
-      "version": "2.1.2",
-      "resolved": "https://npm.pkg.github.com/download/@olivierzal/homey-kit/2.1.2/328ffc55c2cdce36c8ac200f01d18797b94b45bc",
-      "integrity": "sha512-udxWSV9qMANAWn2lRIYqAdyBKUeTdM5Th03r1kBS9z0AdFZrNLoIaph/1c8pTq0L/HOYid9Fg6AJCsMKNbzWfA==",
+      "version": "2.2.0",
+      "resolved": "https://npm.pkg.github.com/download/@olivierzal/homey-kit/2.2.0/27059a7c757b5152fcb7842c7c04b4be04175356",
+      "integrity": "sha512-4fDzbvhx0LJ0C6mr44KLb4DgqAwUe/ymRq0QvSENREr1l+cFEdIGTGA7GlbbiT39MU8ZIM77WbkegCsVRK1xhg==",
       "license": "MIT",
       "engines": {
         "node": ">=22.19.0"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "prettier": "@olivierzal/configs/prettier",
   "dependencies": {
-    "@olivierzal/homey-kit": "2.1.2",
+    "@olivierzal/homey-kit": "2.2.0",
     "@olivierzal/melcloud-api": "47.0.0",
     "source-map-support": "^0.5.21",
     "temporal-polyfill": "^1.0.1"

--- a/tests/unit/app.test.ts
+++ b/tests/unit/app.test.ts
@@ -3382,17 +3382,24 @@ describe('melCloudApp', () => {
     })
   })
 
-  describe('notification when language not in changelog', () => {
-    it('should not set timeout when language is not in changelog', async () => {
+  describe('changelog language fallback', () => {
+    it('should still announce in English when the language is not in the changelog', async () => {
       mockGetLanguage.mockReturnValue('ja')
       mockSettingsGet.mockReturnValue('0.9.0')
       app = createApp()
       await app.onInit()
 
-      expect(mockSetTimeout).not.toHaveBeenCalled()
+      expect(mockSetTimeout).toHaveBeenCalledTimes(1)
+
+      const callback = getMockCallArg<() => Promise<void>>(mockSetTimeout, 0, 0)
+      await callback()
+
+      expect(mockCreateNotification).toHaveBeenCalledWith({
+        excerpt: 'English changelog',
+      })
     })
 
-    it('should not set timeout when version is missing from changelog', async () => {
+    it('should still announce the versions in between when the running version has no entry', async () => {
       mockSettingsGet.mockReturnValue('0.9.0')
       app = createApp()
       Object.defineProperty(app.homey, 'manifest', {
@@ -3401,7 +3408,7 @@ describe('melCloudApp', () => {
       })
       await app.onInit()
 
-      expect(mockSetTimeout).not.toHaveBeenCalled()
+      expect(mockSetTimeout).toHaveBeenCalledTimes(1)
     })
   })
 


### PR DESCRIPTION
The app announced only the running version's changelog, so a user who updates rarely never heard about the releases in between. It now announces every version above the one already recorded, oldest first, through the kit's `selectChangelogEntries` (kit 2.2.0).

It also closes a silent gap: the changelog is a plain JSON object indexed by hand, so the SDK's English fallback — which `homey.__()` gets elsewhere in this same file — never applied here. A user whose Homey language had no entry received **nothing at all**. Each version now falls back to English.

Two tests asserted the old behaviour and now assert the new one. The second is the more interesting: a user jumping from 0.9.0 to a version that has no entry of its own used to be told nothing, and now still hears about the versions in between.

The changelog rewrite for this app (117 versions, 65 of them a single line of developer notes) is **not** in this PR — see the report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3