### PR TITLE
fix: parse on Homey Pro 2016-2019 and log the platform split

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -349,8 +349,14 @@ coverage.
   checks the import CLOSURE, and the webview-facing types import the
   drivers' type barrel, reaching node-side es2024/2025 code. Revisit
   only if webview-facing types get decoupled from driver classes
-  (pure DTOs). Node-side code may use the newer APIs
-  freely.
+  (pure DTOs). Node-side use of newer APIs is UNDER
+  REVIEW: the es2024 `v` regex flag proved to be a parse-time
+  SyntaxError on Homey Pro 2016-2019 (Node < 20) and killed the app at
+  boot there (2026-08 crash report) — shipped regexes stay on `u`
+  (overlay verdict), and the full node device-floor decision
+  (`toSorted`, `Object.groupBy`, iterator helpers…) awaits the
+  platform-split measurement now logged at boot. Do not widen shipped
+  node code to newer runtime APIs meanwhile.
 
 ## Tooling boundary (@olivierzal/configs)
 

--- a/app.mts
+++ b/app.mts
@@ -1317,7 +1317,7 @@ export default class MELCloudApp extends App {
   #holidayModeEndTime(time: unknown): Temporal.PlainTime {
     if (
       typeof time !== 'string' ||
-      !/^(?:[01]\d|2[0-3]):[0-5]\d$/v.test(time)
+      !/^(?:[01]\d|2[0-3]):[0-5]\d$/u.test(time)
     ) {
       throw new RangeError(this.homey.__('errors.invalidTime'))
     }
@@ -1431,7 +1431,17 @@ export default class MELCloudApp extends App {
 
   async #logBootReady(): Promise<void> {
     await this.homey.ready()
-    this.log('Boot: ready after', process.uptime().toFixed(1), 's')
+    // Measurement breadcrumb (2026-08): the installed base's platform
+    // split (1 = Homey Pro 2016-2019, 2 = Pro 2023+) decides the node
+    // device-floor policy — read it from diagnostics reports.
+    this.log(
+      'Boot: ready after',
+      process.uptime().toFixed(1),
+      's — platform',
+      this.homey.platformVersion ?? 'unknown',
+      '— node',
+      process.version,
+    )
   }
 
   // User-facing half of melcloud-api's onAuthenticationLost contract:

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -74,6 +74,14 @@ const config: Config[] = defineConfig([
       'max-classes-per-file': 'off',
     },
   },
+  {
+    // Shipped node-side regexes stay on the `u` flag: the es2024 `v`
+    // flag is a parse-time SyntaxError on Homey Pro 2016-2019
+    // (Node < 20) — the 2026-08 boot-crash root cause. The full node
+    // device-floor policy is pending the platform-split measurement.
+    files: ['*.mts', 'drivers/**/*.mts', 'lib/**/*.mts'],
+    rules: { 'require-unicode-regexp': ['error', { requireFlag: 'u' }] },
+  },
 ])
 
 export default config

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "GPL-3.0-only",
       "dependencies": {
         "@olivierzal/homey-kit": "3.1.0",
-        "@olivierzal/melcloud-api": "47.0.0",
+        "@olivierzal/melcloud-api": "47.0.1",
         "source-map-support": "^0.5.21",
         "temporal-polyfill": "^1.0.1"
       },
@@ -1116,9 +1116,9 @@
       }
     },
     "node_modules/@olivierzal/melcloud-api": {
-      "version": "47.0.0",
-      "resolved": "https://npm.pkg.github.com/download/@olivierzal/melcloud-api/47.0.0/38e45d7bd5d874a048bb3a16f06faf077018746f",
-      "integrity": "sha512-j23onqaNhuQTpxEwjG4d5x/hfahlWTUfgE+xoPu3DtADL+1NOLCXpNuu5rGzIX4v+KSAIAJbo8nwd+osvXErOQ==",
+      "version": "47.0.1",
+      "resolved": "https://npm.pkg.github.com/download/@olivierzal/melcloud-api/47.0.1/b70087d60c27674a161c0b34c9168c9865813242",
+      "integrity": "sha512-hjbNP86i2Rsbmr1cI0YAzn7C8EE2we5wme99B7wx9oE0V+jUUfilA2uM5BT+4O2k5DycpT80Rlh92GDetO8nOw==",
       "license": "MIT",
       "dependencies": {
         "temporal-polyfill": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "prettier": "@olivierzal/configs/prettier",
   "dependencies": {
     "@olivierzal/homey-kit": "3.1.0",
-    "@olivierzal/melcloud-api": "47.0.0",
+    "@olivierzal/melcloud-api": "47.0.1",
     "source-map-support": "^0.5.21",
     "temporal-polyfill": "^1.0.1"
   },

--- a/tests/unit/app.test.ts
+++ b/tests/unit/app.test.ts
@@ -894,7 +894,10 @@ describe('melCloudApp', () => {
       expect(app.log).toHaveBeenCalledWith(
         'Boot: ready after',
         expect.any(String),
-        's',
+        's — platform',
+        expect.anything(),
+        '— node',
+        process.version,
       )
     })
 


### PR DESCRIPTION
Three moves, one goal — start on Homey Pro 2016-2019 again and measure how many are out there before deciding the full node device floor:

- **melcloud-api 47.0.1** (exact pin): the library's eight shipped `v`-flag regexes move to `u` — they were a parse-time `SyntaxError` on Node < 20, killing this app at boot on 2016-2019 hardware since the 43.0.1 adoption (crash report, firmware 13.2.4).
- **The app's own unreleased `v`-flag regex** (`app.mts`, time validation) moves to `u` before it ships the same defect back; the overlay pins `require-unicode-regexp` to `u` for node-side code with the incident documented.
- **Measurement breadcrumb**: the existing boot-ready log line now carries `homey.platformVersion` (1 = 2016-2019, 2 = Pro 2023+) and `process.version` — diagnostics reports will show the installed-base split that the pending floor decision needs. No new telemetry channel, one log line.

CLAUDE.md's « node-side code may use the newer APIs freely » is amended to UNDER REVIEW pending that measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3