### PR TITLE
chore(release): 46.2.1

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -1754,19 +1754,19 @@
     "ru": "Приложение больше не устанавливает большой набор файлов разработки, которые ему никогда не требовались: это освобождает место на вашем Homey и заодно устраняет обнаруженную уязвимость.",
     "sv": "Appen installerar inte längre en stor mängd utvecklingsfiler som den aldrig behövde, vilket frigör utrymme på din Homey och samtidigt tar bort en rapporterad sårbarhet."
   },
-  "46.2.0": {
-    "ar": "إصلاح تعذّر تشغيل التطبيق على Homey Pro (2016 – 2019).",
-    "da": "Retter at appen ikke kunne starte på Homey Pro (2016 – 2019).",
-    "de": "Behebt, dass die App auf dem Homey Pro (2016 – 2019) nicht starten konnte.",
-    "en": "Fixes the app failing to start on Homey Pro (2016 – 2019).",
-    "es": "Corrige que la aplicación no se iniciara en Homey Pro (2016 – 2019).",
-    "fr": "Corrige l'impossibilité de démarrer l'app sur Homey Pro (2016 – 2019).",
-    "it": "Corregge l'impossibilità di avviare l'app su Homey Pro (2016 – 2019).",
-    "ko": "Homey Pro(2016 – 2019)에서 앱이 시작되지 않던 문제를 수정했습니다.",
-    "nl": "Lost op dat de app niet startte op Homey Pro (2016 – 2019).",
-    "no": "Retter at appen ikke startet på Homey Pro (2016 – 2019).",
-    "pl": "Naprawia problem z uruchamianiem aplikacji na Homey Pro (2016 – 2019).",
-    "ru": "Исправлен запуск приложения на Homey Pro (2016 – 2019).",
-    "sv": "Åtgärdar att appen inte startade på Homey Pro (2016 – 2019)."
+  "46.2.1": {
+    "ar": "إصلاح تعذّر تشغيل التطبيق على Homey Pro (2016 – 2019) بنظام تشغيل قديم.",
+    "da": "Retter at appen ikke kunne starte på Homey Pro (2016 – 2019) med ældre firmware.",
+    "de": "Behebt, dass die App auf dem Homey Pro (2016 – 2019) mit älterer Firmware nicht starten konnte.",
+    "en": "Fixes the app failing to start on Homey Pro (2016 – 2019) running older firmware.",
+    "es": "Corrige que la aplicación no se iniciara en Homey Pro (2016 – 2019) con firmware antiguo.",
+    "fr": "Corrige l'impossibilité de démarrer l'app sur Homey Pro (2016 – 2019) sous un firmware ancien.",
+    "it": "Corregge l'impossibilità di avviare l'app su Homey Pro (2016 – 2019) con firmware datato.",
+    "ko": "이전 펌웨어를 사용하는 Homey Pro(2016 – 2019)에서 앱이 시작되지 않던 문제를 수정했습니다.",
+    "nl": "Lost op dat de app niet startte op Homey Pro (2016 – 2019) met oudere firmware.",
+    "no": "Retter at appen ikke startet på Homey Pro (2016 – 2019) med eldre fastvare.",
+    "pl": "Naprawia problem z uruchamianiem aplikacji na Homey Pro (2016 – 2019) ze starszym oprogramowaniem.",
+    "ru": "Исправлен запуск приложения на Homey Pro (2016 – 2019) со старой прошивкой.",
+    "sv": "Åtgärdar att appen inte startade på Homey Pro (2016 – 2019) med äldre firmware."
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -342,5 +342,5 @@
       "värmeåtervinning"
     ]
   },
-  "version": "46.2.0"
+  "version": "46.2.1"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -349,14 +349,11 @@ coverage.
   checks the import CLOSURE, and the webview-facing types import the
   drivers' type barrel, reaching node-side es2024/2025 code. Revisit
   only if webview-facing types get decoupled from driver classes
-  (pure DTOs). Node-side use of newer APIs is UNDER
-  REVIEW: the es2024 `v` regex flag proved to be a parse-time
-  SyntaxError on Homey Pro 2016-2019 (Node < 20) and killed the app at
-  boot there (2026-08 crash report) — shipped regexes stay on `u`
-  (overlay verdict), and the full node device-floor decision
-  (`toSorted`, `Object.groupBy`, iterator helpers…) awaits the
-  platform-split measurement now logged at boot. Do not widen shipped
-  node code to newer runtime APIs meanwhile.
+  (pure DTOs). Node-side code may use the newer APIs
+  freely — with ONE carve-out: shipped regexes stay on the `u` flag.
+  Older Homey Pro (2016-2019) firmwares run a pre-Node-20 runtime
+  where the es2024 `v` flag is a parse-time SyntaxError — it killed
+  the app at boot there (2026-08 crash report).
 
 ## Tooling boundary (@olivierzal/configs)
 

--- a/app.json
+++ b/app.json
@@ -343,7 +343,7 @@
       "värmeåtervinning"
     ]
   },
-  "version": "46.2.0",
+  "version": "46.2.1",
   "flow": {
     "triggers": [
       {

--- a/app.mts
+++ b/app.mts
@@ -1431,17 +1431,7 @@ export default class MELCloudApp extends App {
 
   async #logBootReady(): Promise<void> {
     await this.homey.ready()
-    // Measurement breadcrumb (2026-08): the installed base's platform
-    // split (1 = Homey Pro 2016-2019, 2 = Pro 2023+) decides the node
-    // device-floor policy — read it from diagnostics reports.
-    this.log(
-      'Boot: ready after',
-      process.uptime().toFixed(1),
-      's — platform',
-      this.homey.platformVersion ?? 'unknown',
-      '— node',
-      process.version,
-    )
+    this.log('Boot: ready after', process.uptime().toFixed(1), 's')
   }
 
   // User-facing half of melcloud-api's onAuthenticationLost contract:

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -75,10 +75,10 @@ const config: Config[] = defineConfig([
     },
   },
   {
-    // Shipped node-side regexes stay on the `u` flag: the es2024 `v`
-    // flag is a parse-time SyntaxError on Homey Pro 2016-2019
-    // (Node < 20) — the 2026-08 boot-crash root cause. The full node
-    // device-floor policy is pending the platform-split measurement.
+    // Shipped node-side regexes stay on the `u` flag: older Homey
+    // Pro (2016-2019) firmwares run a pre-Node-20 runtime where the
+    // es2024 `v` flag is a parse-time SyntaxError — the 2026-08
+    // boot-crash root cause.
     files: ['*.mts', 'drivers/**/*.mts', 'lib/**/*.mts'],
     rules: { 'require-unicode-regexp': ['error', { requireFlag: 'u' }] },
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "com.melcloud",
-  "version": "46.2.0",
+  "version": "46.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "com.melcloud",
-      "version": "46.2.0",
+      "version": "46.2.1",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@olivierzal/homey-kit": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.melcloud",
-  "version": "46.2.0",
+  "version": "46.2.1",
   "description": "MELCloud for Homey",
   "homepage": "https://github.com/OlivierZal/com.melcloud/",
   "bugs": {

--- a/tests/unit/app.test.ts
+++ b/tests/unit/app.test.ts
@@ -894,10 +894,7 @@ describe('melCloudApp', () => {
       expect(app.log).toHaveBeenCalledWith(
         'Boot: ready after',
         expect.any(String),
-        's — platform',
-        expect.anything(),
-        '— node',
-        process.version,
+        's',
       )
     })
 


### PR DESCRIPTION
Final-scope release replacing the never-promoted 46.2.0 (its build stays unpromoted; the tag remains as an honest trace, its changelog entry moves here). Drops the measurement breadcrumb per the product decision — the boot log returns to its plain form — and factualizes the CLAUDE.md/overlay notes. Changelog: the app starts again on Homey Pro (2016 – 2019) running older firmware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3