### PR TITLE
build: adopt configs 1.6.0 and homey-kit 4.0.0

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -4,7 +4,7 @@ jobs:
     permissions:
       contents: read
       packages: read
-    uses: OlivierZal/configs/.github/workflows/reusable-audit.yml@2acd68afe1a72f8bfdabdab88ba18f213b2927db # v1.4.0
+    uses: OlivierZal/configs/.github/workflows/reusable-audit.yml@262b014bfa89bca8ff1bf8799b50a95f8552b3f2 # v1.6.0
 name: Audit
 on:
   push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,11 @@ jobs:
       packages: read
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/reusable-ci.yml@2acd68afe1a72f8bfdabdab88ba18f213b2927db # v1.4.0
+    uses: OlivierZal/configs/.github/workflows/reusable-ci.yml@262b014bfa89bca8ff1bf8799b50a95f8552b3f2 # v1.6.0
     with:
       check-node-version: '22'
+      # The fleet's Node major — measured 22.20/22.23 on-device
+      # (2026-08); the coverage/Sonar leg tracks it, not lts/*.
       coverage-node-version: '22'
 name: CI
 on:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -8,7 +8,7 @@ jobs:
       pull-requests: write
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/claude-code-review.yml@2acd68afe1a72f8bfdabdab88ba18f213b2927db # v1.4.0
+    uses: OlivierZal/configs/.github/workflows/claude-code-review.yml@262b014bfa89bca8ff1bf8799b50a95f8552b3f2 # v1.6.0
 name: claude-code-review
 on:
   pull_request:

--- a/.github/workflows/claude-dependabot-fix.yml
+++ b/.github/workflows/claude-dependabot-fix.yml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: read
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/reusable-claude-dependabot-fix.yml@2acd68afe1a72f8bfdabdab88ba18f213b2927db # v1.4.0
+    uses: OlivierZal/configs/.github/workflows/reusable-claude-dependabot-fix.yml@262b014bfa89bca8ff1bf8799b50a95f8552b3f2 # v1.6.0
     with:
       repo-guidance: 'API bugs surfacing through @olivierzal/melcloud-api are fixed in that library, never worked around in this app. When the bump is @olivierzal/configs, realign every `uses: OlivierZal/configs/...` ref in .github/workflows to the tag matching the new npm pin, comment included — one version covers both channels. Stop and leave the pull request failing for human review when that release changes lint policy: adopting it needs per-repository judgement no automated fix can make.'
       verify-commands: '`npm run format`, `npm run lint`, `npm run typecheck`, `npm test`, and `npm run build`'

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -6,7 +6,7 @@ jobs:
       issues: write
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/claude-issue-triage.yml@2acd68afe1a72f8bfdabdab88ba18f213b2927db # v1.4.0
+    uses: OlivierZal/configs/.github/workflows/claude-issue-triage.yml@262b014bfa89bca8ff1bf8799b50a95f8552b3f2 # v1.6.0
 name: claude-issue-triage
 on:
   issues:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -11,7 +11,7 @@ jobs:
       pull-requests: read
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/claude.yml@2acd68afe1a72f8bfdabdab88ba18f213b2927db # v1.4.0
+    uses: OlivierZal/configs/.github/workflows/claude.yml@262b014bfa89bca8ff1bf8799b50a95f8552b3f2 # v1.6.0
 name: claude
 on:
   # No pull_request_review(_comment): Copilot auto-review fires them as a

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -4,7 +4,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: OlivierZal/configs/.github/workflows/dependabot.yml@2acd68afe1a72f8bfdabdab88ba18f213b2927db # v1.4.0
+    uses: OlivierZal/configs/.github/workflows/dependabot.yml@262b014bfa89bca8ff1bf8799b50a95f8552b3f2 # v1.6.0
 name: dependabot
 on:
   pull_request: {}

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -3,7 +3,7 @@ jobs:
   pr_title:
     permissions:
       pull-requests: read
-    uses: OlivierZal/configs/.github/workflows/pr-title.yml@2acd68afe1a72f8bfdabdab88ba18f213b2927db # v1.4.0
+    uses: OlivierZal/configs/.github/workflows/pr-title.yml@262b014bfa89bca8ff1bf8799b50a95f8552b3f2 # v1.6.0
 name: pr-title
 on:
   pull_request:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -5,7 +5,7 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    uses: OlivierZal/configs/.github/workflows/zizmor.yml@2acd68afe1a72f8bfdabdab88ba18f213b2927db # v1.4.0
+    uses: OlivierZal/configs/.github/workflows/zizmor.yml@262b014bfa89bca8ff1bf8799b50a95f8552b3f2 # v1.6.0
 name: zizmor
 on:
   merge_group: {}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,13 @@
       "version": "46.2.1",
       "license": "GPL-3.0-only",
       "dependencies": {
-        "@olivierzal/homey-kit": "3.1.0",
+        "@olivierzal/homey-kit": "4.0.0",
         "@olivierzal/melcloud-api": "47.0.1",
         "source-map-support": "^0.5.21",
         "temporal-polyfill": "^1.0.1"
       },
       "devDependencies": {
-        "@olivierzal/configs": "1.4.0",
+        "@olivierzal/configs": "1.6.0",
         "@types/homey": "npm:homey-apps-sdk-v3-types@^0.3.12",
         "@types/node": "^26.1.2",
         "@typescript/native": "npm:typescript@^7.0.2",
@@ -1070,9 +1070,9 @@
       }
     },
     "node_modules/@olivierzal/configs": {
-      "version": "1.4.0",
-      "resolved": "https://npm.pkg.github.com/download/@olivierzal/configs/1.4.0/07e9e8d271a240cd92725d86d7a7b2519954032f",
-      "integrity": "sha512-arD6N/2vLTTz7AWE228fZR1EP3AFUa21i4xmATGBGhRbpXDySbsxE0cQVjMpbLXXqlqXzPgQztp55frwM/mF/Q==",
+      "version": "1.6.0",
+      "resolved": "https://npm.pkg.github.com/download/@olivierzal/configs/1.6.0/474d9fe4cb9ff56cee39a9e62660cb26f9fd71ed",
+      "integrity": "sha512-l+JqAg4eXdPjQFxRKqK1jZg86ki67MAVqJq6wesx5ZrKULic+NDMG0UNT+zf3dC0He+6Jh/rpvZPdxYWlpO6nw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1107,9 +1107,9 @@
       }
     },
     "node_modules/@olivierzal/homey-kit": {
-      "version": "3.1.0",
-      "resolved": "https://npm.pkg.github.com/download/@olivierzal/homey-kit/3.1.0/43507d99a6540eba5154e9412317ea8648314e94",
-      "integrity": "sha512-yPeGHtzF33dMODL6p5uqIgsrUCgSiueeVtt3KXA1tDlnvqy2K/Z3tpJfhAWzll5xpWCOuaGsHtmm0pIAu79Q+w==",
+      "version": "4.0.0",
+      "resolved": "https://npm.pkg.github.com/download/@olivierzal/homey-kit/4.0.0/36ea8b1b0580f48d4217a855c9a743f45d3b6770",
+      "integrity": "sha512-BU0vAGhznx/Fx2TyJrWd7XzN2zLc/y8xFuWKXBZH5WU1z3wQW6i1d057viDZF/RpfYVqTgm1+9UOJa9n9xFnSw==",
       "license": "MIT",
       "engines": {
         "node": ">=22.19.0"

--- a/package.json
+++ b/package.json
@@ -32,13 +32,13 @@
   },
   "prettier": "@olivierzal/configs/prettier",
   "dependencies": {
-    "@olivierzal/homey-kit": "3.1.0",
+    "@olivierzal/homey-kit": "4.0.0",
     "@olivierzal/melcloud-api": "47.0.1",
     "source-map-support": "^0.5.21",
     "temporal-polyfill": "^1.0.1"
   },
   "devDependencies": {
-    "@olivierzal/configs": "1.4.0",
+    "@olivierzal/configs": "1.6.0",
     "@types/homey": "npm:homey-apps-sdk-v3-types@^0.3.12",
     "@types/node": "^26.1.2",
     "@typescript/native": "npm:typescript@^7.0.2",


### PR DESCRIPTION
Exact pins: configs 1.4.0 → 1.6.0 (skipping the stillborn 1.5.0) and homey-kit 3.1.0 → 4.0.0 (no imports of the removed testing factories — the suites already declare their own describe/it over the kit's analysis seams; verified by the green suite ×6 incl. build and homey:validate). 9 stub refs to `262b014b # v1.6.0`, check-pins green (14/12), and the `coverage-node-version` measurement comment. No runtime code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3