### PR TITLE
test(widgets): bring the shared webview modules and the ATA widget to 100%

### DIFF
--- a/public/dom.mts
+++ b/public/dom.mts
@@ -1,7 +1,6 @@
 import { getErrorMessage } from '@olivierzal/homey-kit'
 import {
   type HTMLValueElement,
-  booleanStrings,
   createLabel,
   createOption,
 } from '@olivierzal/homey-kit/dom'
@@ -23,30 +22,6 @@ export const appendFormControl = (
   if (formControl !== null) {
     parent.append(createLabel(formControl, title))
   }
-}
-
-// Shared form-value reader: checkbox → tri-state, bounded number input →
-// the caller's number strategy (the settings page throws on an
-// out-of-range value, the ATA widget clamps it), boolean string →
-// boolean, anything else → number when finite, else the raw string.
-export const parseFormValue = (
-  element: HTMLValueElement,
-  parseNumber: (input: HTMLInputElement) => number,
-): boolean | number | string | null => {
-  if (element.value !== '') {
-    if (element.type === 'checkbox') {
-      return element.indeterminate ? null : element.checked
-    }
-    if (element.type === 'number' && element.min !== '' && element.max !== '') {
-      return parseNumber(element)
-    }
-    if (booleanStrings.includes(element.value)) {
-      return element.value === 'true'
-    }
-    const numberValue = Number(element.value)
-    return Number.isFinite(numberValue) ? numberValue : element.value
-  }
-  return null
 }
 
 // Fills a zone select by walking the picker tree in list order, one

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,5 +3,5 @@ sonar.organization=olivierzal
 sonar.sourceEncoding=UTF-8
 sonar.javascript.lcov.reportPaths=./coverage/lcov.info
 sonar.exclusions=**/*.jpg,**/*.png,coverage/**
-sonar.coverage.exclusions=tests/**,**/*.config.*,**/public/**,scripts/**
+sonar.coverage.exclusions=tests/**,**/*.config.*,widgets/charts/public/**,scripts/**
 sonar.cpd.exclusions=**/*.config.*,settings/index.html,widgets/*/public/index.html

--- a/tests/ata-group-harness.ts
+++ b/tests/ata-group-harness.ts
@@ -1,0 +1,299 @@
+import { readFileSync } from 'node:fs'
+
+import type * as Classic from '@olivierzal/melcloud-api/classic'
+import { vi } from 'vitest'
+
+import type { Homey } from '../public/widget.mts'
+import type { DriverCapabilitiesOptions } from '../types/driver-settings.mts'
+import type { AtaGroupSettingWidgetSettings } from '../types/widgets.mts'
+import { mock } from './helpers.ts'
+
+// A plain relative path: under the happy-dom environment
+// `import.meta.url` is an http URL the fs module refuses.
+const widgetHtml = readFileSync(
+  'widgets/ata-group-setting/public/index.html',
+  'utf8',
+)
+
+// DOMParser never executes scripts — the sanctioned way to load the real
+// page into the simulated DOM.
+export const loadWidgetPage = (): void => {
+  const parser = new DOMParser()
+  const parsed = parser.parseFromString(widgetHtml, 'text/html')
+  document.head.replaceChildren(...parsed.head.children)
+  document.body.replaceChildren(...parsed.body.children)
+}
+
+// ── Web Animations API stand-in ──
+// happy-dom ships no WAAPI: the fake records every `animate` call and
+// lets a test drive `onfinish` by hand.
+
+export interface AnimationRecord {
+  readonly animation: FakeAnimation
+  readonly element: HTMLElement
+  readonly keyframes: Keyframe[] | PropertyIndexedKeyframes | null
+  readonly options: number | KeyframeAnimationOptions | undefined
+}
+
+export class FakeAnimation {
+  public readonly cancel: ReturnType<typeof vi.fn<() => void>> =
+    vi.fn<() => void>()
+
+  public onfinish: (() => void) | null = null
+
+  public playbackRate = 1
+
+  public finish(): void {
+    this.onfinish?.()
+  }
+
+  public reverse(): void {
+    this.playbackRate = -this.playbackRate
+  }
+}
+
+// happy-dom ships no Web Animations API. Each freshly created element
+// gets its own pair, closing over the element instead of reading `this`
+// off a patched prototype — the animated elements all come from
+// `createElement`, and a closure keeps the helpers plain arrows.
+const HTML_NAMESPACE = 'http://www.w3.org/1999/xhtml'
+
+export const installAnimationApi = (): AnimationRecord[] => {
+  const records: AnimationRecord[] = []
+  vi.spyOn(document, 'createElement').mockImplementation((tagName: string) => {
+    // Built through the namespaced API: the spy owns `createElement`, and
+    // reaching back for its original would hand a method around unbound.
+    const element = document.createElementNS(HTML_NAMESPACE, tagName)
+    if (!(element instanceof HTMLElement)) {
+      throw new TypeError(`Cannot create <${tagName}>`)
+    }
+    Object.defineProperties(element, {
+      animate: {
+        value: (
+          keyframes: Keyframe[] | PropertyIndexedKeyframes | null,
+          options?: number | KeyframeAnimationOptions,
+        ): Animation => {
+          const animation = new FakeAnimation()
+          records.push({ animation, element, keyframes, options })
+          return mock<Animation>(animation)
+        },
+      },
+      getAnimations: {
+        value: (): Animation[] =>
+          records
+            .filter((record) => record.element === element)
+            .map(({ animation }) => mock<Animation>(animation)),
+      },
+    })
+    return element
+  })
+  return records
+}
+
+export const animationsOf = (
+  records: readonly AnimationRecord[],
+  element: HTMLElement,
+): FakeAnimation[] =>
+  records
+    .filter((record) => record.element === element)
+    .map(({ animation }) => animation)
+
+// Pins the CSPRNG so every generated delay and style value is exact:
+// zero collapses all spawn delays, letting a scene tick per macrotask.
+export const stubRandomUint32 = (value: number): void => {
+  vi.spyOn(crypto, 'getRandomValues').mockImplementation((array) => {
+    if (array instanceof Uint32Array) {
+      array.fill(value)
+    }
+    return array
+  })
+}
+
+// ── Fixtures ──
+
+export const ataCapabilitiesFixture = (): [
+  string,
+  DriverCapabilitiesOptions,
+][] => [
+  ['Power', { title: 'Power', type: 'boolean' }],
+  [
+    'OperationMode',
+    {
+      title: 'Mode',
+      type: 'enum',
+      values: [
+        { id: '1', label: 'Heat' },
+        { id: '2', label: 'Dry' },
+        { id: '3', label: 'Cool' },
+        { id: '7', label: 'Fan' },
+        { id: '8', label: 'Auto' },
+      ],
+    },
+  ],
+  ['SetTemperature', { title: 'Temperature', type: 'number' }],
+  ['FanSpeed', { title: 'Fan speed', type: 'number' }],
+  // A capability no control type maps to: the builder yields null and
+  // the form skips it.
+  ['SilentMode', { title: 'Silent', type: 'string' }],
+]
+
+export const groupStateFixture = (): Partial<Classic.GroupState> => ({
+  FanSpeed: 3,
+  OperationMode: 1,
+  Power: true,
+  SetTemperature: 22,
+})
+
+export const classicAtaBuildingsFixture = (): unknown => [
+  {
+    areas: [],
+    devices: [{ id: 11, level: 1, model: 'devices', name: 'Living room' }],
+    floors: [],
+    id: 1,
+    level: 0,
+    model: 'buildings',
+    name: 'Home',
+  },
+]
+
+export const homeAtaTargetsFixture = (): unknown => [
+  {
+    buildingName: 'Villa',
+    id: 'b_1',
+    level: 0,
+    model: 'homeBuildings',
+    name: 'Villa',
+  },
+  {
+    buildingName: 'Villa',
+    deviceType: 'ata',
+    id: 'ata_1',
+    level: 1,
+    model: 'homeDevices',
+    name: 'Salon',
+  },
+]
+
+export const widgetRoutes = (): Record<string, unknown> => ({
+  'GET /classic/buildings?type=0': classicAtaBuildingsFixture(),
+  'GET /classic/capabilities/ata': ataCapabilitiesFixture(),
+  'GET /classic/zones/buildings/1/ata': groupStateFixture(),
+  'GET /home/targets/ata': homeAtaTargetsFixture(),
+  'GET /language': 'fr',
+  'PUT /classic/zones/buildings/1/ata': undefined,
+})
+
+// ── Widget SDK mock ──
+
+export interface WidgetHarness {
+  readonly api: ReturnType<
+    typeof vi.fn<
+      (method: string, path: string, body?: object) => Promise<unknown>
+    >
+  >
+  readonly hapticFeedback: ReturnType<typeof vi.fn>
+  readonly homey: Homey<AtaGroupSettingWidgetSettings>
+  readonly ready: ReturnType<typeof vi.fn>
+  readonly setHeight: ReturnType<
+    typeof vi.fn<(height: number) => Promise<void>>
+  >
+  readonly emit: (event: string) => void
+}
+
+export interface WidgetHarnessOptions {
+  // Deferred routes: the test controls when (and with what) they settle.
+  readonly deferredRoutes?: Readonly<Record<string, () => Promise<unknown>>>
+  readonly failures?: Readonly<Record<string, Error>>
+  readonly routes?: Record<string, unknown>
+  readonly settings?: Partial<AtaGroupSettingWidgetSettings>
+}
+
+export const createWidgetHomey = (
+  options: WidgetHarnessOptions = {},
+): WidgetHarness => {
+  const {
+    deferredRoutes = {},
+    failures = {},
+    routes = widgetRoutes(),
+    settings = {},
+  } = options
+  const listeners = new Map<string, (() => void)[]>()
+  const api = vi
+    .fn<(method: string, path: string, body?: object) => Promise<unknown>>()
+    .mockImplementation(async (method, path) => {
+      const key = `${method} ${path}`
+      const failure = failures[key]
+      if (failure !== undefined) {
+        throw failure
+      }
+      const deferred = deferredRoutes[key]
+      if (deferred !== undefined) {
+        return deferred()
+      }
+      return routes[key]
+    })
+  const hapticFeedback = vi.fn<() => void>()
+  const ready = vi.fn<() => void>()
+  const setHeight = vi
+    .fn<(height: number) => Promise<void>>()
+    .mockResolvedValue(undefined)
+  const homey = mock<Homey<AtaGroupSettingWidgetSettings>>({
+    api,
+    hapticFeedback,
+    ready,
+    setHeight,
+    __: (key: string): string => key,
+    getSettings: (): AtaGroupSettingWidgetSettings =>
+      mock<AtaGroupSettingWidgetSettings>({
+        animations: null,
+        default_zone: null,
+        ...settings,
+      }),
+    on: (event: string, listener: () => void): void => {
+      const bucket = listeners.get(event) ?? []
+      bucket.push(listener)
+      listeners.set(event, bucket)
+    },
+  })
+  return {
+    api,
+    hapticFeedback,
+    homey,
+    ready,
+    setHeight,
+    emit: (event: string): void => {
+      const bucket = listeners.get(event)
+      if (bucket === undefined) {
+        return
+      }
+      for (const listener of bucket) {
+        listener()
+      }
+    },
+  }
+}
+
+export const setDocumentVisibility = (state: DocumentVisibilityState): void => {
+  Object.defineProperty(document, 'visibilityState', {
+    configurable: true,
+    value: state,
+  })
+  document.dispatchEvent(new Event('visibilitychange'))
+}
+
+// Real-timer pause long enough for zero-delay spawn loops to tick a few
+// times (each iteration crosses one macrotask).
+export const waitForSpawnTicks = async (ms = 20): Promise<void> =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms)
+  })
+
+// Polls a plain predicate (no `expect` inside a retried callback, whose
+// call count assertion counting could not pin down) until it holds.
+export const waitUntil = async (predicate: () => boolean): Promise<void> => {
+  await vi.waitFor(() => {
+    if (!predicate()) {
+      throw new Error('Condition not reached in time')
+    }
+  })
+}

--- a/tests/unit/animation.test.ts
+++ b/tests/unit/animation.test.ts
@@ -1,0 +1,460 @@
+// @vitest-environment happy-dom
+// @vitest-environment-options {"settings": {"disableCSSFileLoading": true, "disableJavaScriptFileLoading": true, "navigation": {"disableMainFrameNavigation": true}}}
+
+import type * as Classic from '@olivierzal/melcloud-api/classic'
+import { getDiv, getSelect } from '@olivierzal/homey-kit/dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { AnimationController } from '../../widgets/ata-group-setting/public/animation.mts'
+import {
+  type AnimationRecord,
+  type WidgetHarnessOptions,
+  animationsOf,
+  createWidgetHomey,
+  installAnimationApi,
+  loadWidgetPage,
+  setDocumentVisibility,
+  stubRandomUint32,
+  waitForSpawnTicks,
+  waitUntil,
+  widgetRoutes,
+} from '../ata-group-harness.ts'
+import { mock } from '../helpers.ts'
+
+const HEAT = 1
+const DRY = 2
+const COOL = 3
+const FAN = 7
+const MIXED = 0
+
+// Overrides are typed as loosely as the wire: a device may report a
+// speed or mode outside the declared vocabulary, which is exactly what
+// the degradation paths must survive.
+const state = (
+  overrides: Partial<Record<keyof Classic.GroupState, unknown>> = {},
+): Classic.GroupState =>
+  mock<Classic.GroupState>({
+    FanSpeed: 3,
+    OperationMode: HEAT,
+    Power: true,
+    SetTemperature: 22,
+    ...overrides,
+  })
+
+interface ControllerHarness {
+  readonly container: HTMLDivElement
+  readonly controller: AnimationController
+  readonly records: AnimationRecord[]
+}
+
+const createController = (
+  options: WidgetHarnessOptions = {},
+): ControllerHarness => {
+  const records = installAnimationApi()
+  const harness = createWidgetHomey(options)
+  const container = getDiv('animation')
+  const controller = new AnimationController(harness.homey, container)
+  return { container, controller, records }
+}
+
+const addZone = (value: string): void => {
+  const option = document.createElement('option')
+  option.value = value
+  getSelect('zones').append(option)
+  getSelect('zones').value = value
+}
+
+const elementsIn = (
+  container: HTMLDivElement,
+  selector: string,
+): HTMLElement[] => [...container.querySelectorAll<HTMLElement>(selector)]
+
+const countIn = (container: HTMLDivElement, selector: string): number =>
+  container.querySelectorAll(selector).length
+
+describe('animation controller', () => {
+  beforeEach(() => {
+    loadWidgetPage()
+    stubRandomUint32(0)
+    vi.stubGlobal('reportError', vi.fn())
+    setDocumentVisibility('visible')
+  })
+
+  afterEach(() => {
+    // Stop every live spawn loop before the next test.
+    setDocumentVisibility('hidden')
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  it('should stay empty when everything is off', async () => {
+    const { container, controller } = createController()
+    await controller.applyAnimation(state({ Power: false }))
+    await waitForSpawnTicks()
+
+    expect(container.childElementCount).toBe(0)
+  })
+
+  it('should stay empty when animations are opted out', async () => {
+    const { container, controller } = createController({
+      settings: { animations: false },
+    })
+    await controller.applyAnimation(state())
+    await waitForSpawnTicks()
+
+    expect(container.childElementCount).toBe(0)
+  })
+
+  it('should stay empty when the OS asks for reduced motion', async () => {
+    const { container, controller } = createController()
+    vi.stubGlobal('matchMedia', (): MediaQueryList =>
+      mock<MediaQueryList>({ matches: true }),
+    )
+    await controller.applyAnimation(state())
+    await waitForSpawnTicks()
+
+    expect(container.childElementCount).toBe(0)
+  })
+
+  it('should spawn flickering flames and their smoke on heat', async () => {
+    const { container, controller, records } = createController()
+    await controller.applyAnimation(state())
+    await waitUntil(
+      () =>
+        countIn(container, '.flame') > 0 && countIn(container, '.smoke') > 0,
+    )
+    const [flame] = elementsIn(container, '.flame')
+
+    expect(flame?.textContent).toBe('🔥')
+    // Scale, rotate and brightness flickers compose per flame.
+    expect(animationsOf(records, flame ?? container)).toHaveLength(3)
+  })
+
+  it('should space flames and wrap past the window edge', async () => {
+    Object.defineProperty(globalThis, 'innerWidth', {
+      configurable: true,
+      value: 30,
+    })
+    const { container, controller } = createController()
+    await controller.applyAnimation(state())
+    await waitUntil(() => countIn(container, '.flame') > 4)
+    const positions = elementsIn(container, '.flame').map(
+      ({ style }) => style.insetInlineStart,
+    )
+
+    // First flame lands at -gap*2 + gap; each next one gap further; past
+    // the 30px window the position wraps back to -gap.
+    expect(positions.slice(0, 5)).toStrictEqual([
+      '-20px',
+      '0px',
+      '20px',
+      '40px',
+      '-20px',
+    ])
+  })
+
+  it('should remove the flames when the scene leaves fire', async () => {
+    const { container, controller } = createController()
+    await controller.applyAnimation(state())
+    await waitUntil(() => countIn(container, '.flame') > 0)
+    // A flame nobody ignited (no controller) is simply skipped.
+    const rogue = document.createElement('div')
+    rogue.classList.add('flame')
+    container.append(rogue)
+    await controller.applyAnimation(state({ OperationMode: COOL }))
+    await waitUntil(
+      () =>
+        countIn(container, '.flame') === 1 &&
+        countIn(container, '.snowflake') > 0,
+    )
+
+    expect(elementsIn(container, '.flame')).toStrictEqual([rogue])
+  })
+
+  it('should keep the flames across a heat-to-heat update', async () => {
+    const { container, controller } = createController()
+    await controller.applyAnimation(state())
+    await waitUntil(() => countIn(container, '.flame') > 0)
+    const flames = elementsIn(container, '.flame')
+    await controller.applyAnimation(state({ FanSpeed: 4 }))
+    await waitForSpawnTicks()
+
+    expect(flames.every((flame) => flame.isConnected)).toBe(true)
+  })
+
+  it('should drop a snowflake and remove it on arrival', async () => {
+    const { container, controller, records } = createController()
+    await controller.applyAnimation(state({ OperationMode: COOL }))
+    await waitUntil(() => countIn(container, '.snowflake') > 0)
+    const [snowflake] = elementsIn(container, '.snowflake')
+    const [fall] = animationsOf(records, snowflake ?? container)
+    fall?.finish()
+
+    expect(snowflake?.isConnected).toBe(false)
+  })
+
+  it('should loop a leaf and clear it when the drift ends', async () => {
+    const { container, controller, records } = createController()
+    await controller.applyAnimation(state({ OperationMode: FAN }))
+    await waitUntil(() => countIn(container, '.leaf') > 0)
+    const [leaf] = elementsIn(container, '.leaf')
+
+    expect(leaf?.style.offsetPath).toContain('path(')
+
+    const leafAnimations = animationsOf(records, leaf ?? container)
+
+    // Wobble plus drift; finishing the drift cancels both and removes.
+    expect(leafAnimations).toHaveLength(2)
+
+    leafAnimations.at(-1)?.finish()
+
+    expect(leaf?.isConnected).toBe(false)
+    expect(
+      leafAnimations.some(({ cancel }) => cancel.mock.calls.length > 0),
+    ).toBe(true)
+  })
+
+  it('should fly the sun in, spin it and reuse it', async () => {
+    const { container, controller, records } = createController()
+    await controller.applyAnimation(state({ OperationMode: DRY }))
+    const [sun] = elementsIn(container, '.sun')
+
+    expect(sun?.textContent).toBe('☀')
+
+    const [shine, motion] = animationsOf(records, sun ?? container)
+
+    expect(shine?.playbackRate).toBe(3)
+
+    // A finish while still inbound keeps the sun.
+    motion?.finish()
+
+    expect(sun?.isConnected).toBe(true)
+
+    // Same scene again: the running animations are reused as-is.
+    await controller.applyAnimation(state({ OperationMode: DRY }))
+
+    expect(animationsOf(records, sun ?? container)).toHaveLength(2)
+  })
+
+  it('should reverse the sun out and rebuild it later', async () => {
+    const { container, controller, records } = createController()
+    await controller.applyAnimation(state({ OperationMode: DRY }))
+    const [sun] = elementsIn(container, '.sun')
+    const [, motion] = animationsOf(records, sun ?? container)
+
+    // Leaving the scene reverses the motion; a second sunless scene
+    // leaves the outbound flight alone; returning reverses it back.
+    await controller.applyAnimation(state({ OperationMode: HEAT }))
+
+    expect(motion?.playbackRate).toBeLessThan(0)
+
+    await controller.applyAnimation(state({ OperationMode: COOL }))
+
+    expect(motion?.playbackRate).toBeLessThan(0)
+
+    await controller.applyAnimation(state({ OperationMode: DRY }))
+
+    expect(motion?.playbackRate).toBeGreaterThan(0)
+
+    // Reversed out: the finish removes the sun and its animations.
+    await controller.applyAnimation(state({ OperationMode: HEAT }))
+    motion?.finish()
+
+    expect(sun?.isConnected).toBe(false)
+
+    // A later dry scene builds a fresh sun.
+    await controller.applyAnimation(state({ OperationMode: DRY }))
+
+    expect(elementsIn(container, '.sun')).toHaveLength(1)
+  })
+
+  it('should leave the sun untouched when it never flew', async () => {
+    const { container, controller } = createController()
+    await controller.applyAnimation(state({ OperationMode: HEAT }))
+    await controller.applyAnimation(state({ OperationMode: COOL }))
+
+    expect(elementsIn(container, '.sun')).toHaveLength(0)
+  })
+
+  it('should merge the member scenes of a mixed classic zone', async () => {
+    const { container, controller } = createController({
+      routes: {
+        ...widgetRoutes(),
+        'GET /classic/zones/devices/11/ata/details?status=on': {
+          // The unknown vocabulary entry maps to no scene element.
+          OperationMode: [HEAT, COOL, 99],
+        },
+      },
+    })
+    addZone('devices_11')
+    await controller.applyAnimation(state({ OperationMode: MIXED }))
+    await waitUntil(
+      () =>
+        countIn(container, '.flame') > 0 &&
+        countIn(container, '.snowflake') > 0,
+    )
+
+    expect(countIn(container, '.leaf')).toBe(0)
+  })
+
+  it('should read a mixed home building from its modes endpoint', async () => {
+    const { container, controller } = createController({
+      routes: {
+        ...widgetRoutes(),
+        'GET /home/buildings/b_1/ata/modes': [COOL],
+      },
+    })
+    addZone('homeBuildings_b_1')
+    // An absent mode reads as mixed.
+    await controller.applyAnimation(state({ OperationMode: undefined }))
+    await waitUntil(() => countIn(container, '.snowflake') > 0)
+
+    expect(elementsIn(container, '.flame')).toHaveLength(0)
+  })
+
+  it('should keep the running scene when the mode fetch fails', async () => {
+    const { container, controller } = createController({
+      failures: {
+        'GET /classic/zones/devices/11/ata/details?status=on': new Error(
+          'modes down',
+        ),
+      },
+    })
+    addZone('devices_11')
+    await controller.applyAnimation(state())
+    await waitUntil(() => countIn(container, '.flame') > 0)
+    await controller.applyAnimation(state({ OperationMode: MIXED }))
+    await waitForSpawnTicks()
+
+    // The failure surfaced; the fire scene kept spawning.
+    expect(vi.mocked(reportError).mock.calls.length).toBeGreaterThan(0)
+    expect(countIn(container, '.flame')).toBeGreaterThan(0)
+  })
+
+  it('should let a newer apply win over a slower one', async () => {
+    const modes = Promise.withResolvers<unknown>()
+    const { container, controller } = createController({
+      deferredRoutes: {
+        'GET /classic/zones/devices/11/ata/details?status=on': async () =>
+          modes.promise,
+      },
+    })
+    addZone('devices_11')
+    const slower = controller.applyAnimation(state({ OperationMode: MIXED }))
+    await controller.applyAnimation(state({ OperationMode: HEAT }))
+    modes.resolve({ OperationMode: [COOL] })
+    await slower
+    await waitForSpawnTicks()
+
+    // The slower pass resolved into a superseded generation: no snow.
+    expect(elementsIn(container, '.snowflake')).toHaveLength(0)
+    expect(countIn(container, '.flame')).toBeGreaterThan(0)
+  })
+
+  it('should park while hidden and replay when shown', async () => {
+    const { container, controller } = createController()
+    await controller.applyAnimation(state())
+    await waitUntil(() => countIn(container, '.flame') > 0)
+    setDocumentVisibility('hidden')
+    // A state landing while hidden is remembered, not built.
+    await controller.applyAnimation(state({ OperationMode: COOL }))
+    await waitForSpawnTicks()
+
+    expect(countIn(container, '.snowflake')).toBe(0)
+
+    // Smoke chains survive the hide but stand down.
+    const smokeBefore = countIn(container, '.smoke')
+    await waitForSpawnTicks()
+
+    expect(countIn(container, '.smoke')).toBe(smokeBefore)
+
+    setDocumentVisibility('visible')
+    await waitUntil(() => countIn(container, '.snowflake') > 0)
+
+    // The replayed cool scene also swept the lingering flames.
+    await waitUntil(() => countIn(container, '.flame') === 0)
+
+    expect(countIn(container, '.flame')).toBe(0)
+  })
+
+  it('should do nothing on show before any state landed', async () => {
+    const { container } = createController()
+    setDocumentVisibility('hidden')
+    setDocumentVisibility('visible')
+    await waitForSpawnTicks()
+
+    expect(container.childElementCount).toBe(0)
+  })
+
+  it('should keep the cadence alive on an underflowing speed', async () => {
+    const { container, controller } = createController()
+    await controller.applyAnimation(state({ FanSpeed: -1_000_000 }))
+    await waitUntil(() => countIn(container, '.flame') > 0)
+
+    expect(countIn(container, '.flame')).toBeGreaterThan(0)
+  })
+
+  it('should treat a zero fan speed as moderate', async () => {
+    const { container, controller } = createController()
+    await controller.applyAnimation(state({ FanSpeed: 0 }))
+    await waitUntil(() => countIn(container, '.flame') > 0)
+
+    expect(countIn(container, '.flame')).toBeGreaterThan(0)
+  })
+
+  it('should cap the live smoke at the particle budget', async () => {
+    Object.defineProperty(globalThis, 'innerWidth', {
+      configurable: true,
+      value: 30,
+    })
+    const { container, controller } = createController()
+    await controller.applyAnimation(state())
+    await waitUntil(() => countIn(container, '.smoke') === 500)
+    await waitForSpawnTicks()
+
+    expect(countIn(container, '.smoke')).toBe(500)
+  })
+
+  it('should surface a platform failure out of the spawn loop', async () => {
+    const { controller } = createController()
+    const broken = new Error('animate broken')
+    vi.spyOn(document, 'createElement').mockImplementation(() =>
+      mock<HTMLDivElement>({
+        classList: mock<DOMTokenList>({
+          add: vi.fn<(token: string) => void>(),
+        }),
+        style: mock<CSSStyleDeclaration>({
+          setProperty: vi.fn<(property: string, value: string) => void>(),
+        }),
+        animate: (): Animation => {
+          throw broken
+        },
+      }),
+    )
+    await controller.applyAnimation(state())
+    await waitUntil(() =>
+      vi.mocked(reportError).mock.calls.some(([error]) => error === broken),
+    )
+
+    expect(vi.mocked(reportError)).toHaveBeenCalledWith(broken)
+  })
+
+  it('should recycle a finished smoke particle', async () => {
+    const { container, controller, records } = createController()
+    await controller.applyAnimation(state())
+    await waitUntil(() => countIn(container, '.smoke') > 0)
+    const [particle] = elementsIn(container, '.smoke')
+    animationsOf(records, particle ?? container)[0]?.finish()
+
+    expect(particle?.isConnected).toBe(false)
+  })
+
+  it('should clamp a short-lived particle to one frame', async () => {
+    const { container, controller } = createController()
+    // A huge speed drives the viewport-exit term below one frame.
+    await controller.applyAnimation(state({ FanSpeed: 20_000_000 }))
+    await waitUntil(() => countIn(container, '.smoke') > 0)
+
+    expect(countIn(container, '.smoke')).toBeGreaterThan(0)
+  })
+})

--- a/tests/unit/ata-group-setting.test.ts
+++ b/tests/unit/ata-group-setting.test.ts
@@ -1,0 +1,223 @@
+// @vitest-environment happy-dom
+// @vitest-environment-options {"settings": {"disableCSSFileLoading": true, "disableJavaScriptFileLoading": true, "navigation": {"disableMainFrameNavigation": true}}}
+
+import { getButton, getInput, getSelect } from '@olivierzal/homey-kit/dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { HomeDeviceZone } from '../../types/zone.mts'
+import { start } from '../../widgets/ata-group-setting/public/index.mts'
+import {
+  type WidgetHarness,
+  type WidgetHarnessOptions,
+  createWidgetHomey,
+  groupStateFixture,
+  installAnimationApi,
+  loadWidgetPage,
+  setDocumentVisibility,
+  stubRandomUint32,
+  widgetRoutes,
+} from '../ata-group-harness.ts'
+import { mock, settleDetached } from '../helpers.ts'
+
+const bootWidget = async (
+  options: WidgetHarnessOptions = {},
+): Promise<WidgetHarness> => {
+  const harness = createWidgetHomey(options)
+  await start(harness.homey)
+  await settleDetached()
+  await settleDetached()
+  return harness
+}
+
+const calledPaths = (harness: WidgetHarness): string[] =>
+  harness.api.mock.calls.map(([method, path]) => `${method} ${path}`)
+
+const commit = (
+  element: HTMLElement & { value: string },
+  value: string,
+): void => {
+  element.value = value
+  element.dispatchEvent(new Event('change', { bubbles: true }))
+}
+
+describe('ata group setting widget', () => {
+  beforeEach(() => {
+    sessionStorage.clear()
+    loadWidgetPage()
+    installAnimationApi()
+    stubRandomUint32(0)
+    vi.stubGlobal('reportError', vi.fn())
+    setDocumentVisibility('visible')
+  })
+
+  afterEach(() => {
+    setDocumentVisibility('hidden')
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+    vi.useRealTimers()
+  })
+
+  it('should boot, build the form and end the overlay once', async () => {
+    const harness = await bootWidget()
+
+    expect(document.documentElement.lang).toBe('fr')
+    expect(getSelect('zones').ariaLabel).toBe('widgets.zones')
+    expect(
+      [...getSelect('zones').options].map(({ value }) => value),
+    ).toStrictEqual([
+      'buildings_1',
+      'devices_11',
+      'homeBuildings_b_1',
+      'homeDevices_ata_1',
+    ])
+    expect(getInput('SetTemperature').value).toBe('22')
+    expect(harness.ready).toHaveBeenCalledTimes(1)
+  })
+
+  it('should skip the boot when the page is stale', async () => {
+    const stamp = document.createElement('script')
+    stamp.setAttribute('src', 'index.js?v=aaaaaaaa')
+    document.head.append(stamp)
+    const harness = await bootWidget({
+      routes: {
+        ...widgetRoutes(),
+        'GET /webview-hashes': { 'ata-group-setting': 'bbbbbbbb' },
+      },
+    })
+
+    expect(harness.ready).not.toHaveBeenCalled()
+    expect(calledPaths(harness)).not.toContain('GET /classic/capabilities/ata')
+  })
+
+  it('should keep one selector source alive when the other fails', async () => {
+    const harness = await bootWidget({
+      failures: { 'GET /classic/buildings?type=0': new Error('classic down') },
+      routes: {
+        ...widgetRoutes(),
+        'GET /home/buildings/b_1/ata': groupStateFixture(),
+      },
+    })
+
+    expect(
+      [...getSelect('zones').options].map(({ value }) => value),
+    ).toStrictEqual(['homeBuildings_b_1', 'homeDevices_ata_1'])
+    expect(harness.ready).toHaveBeenCalledTimes(1)
+  })
+
+  it('should build nothing without any target', async () => {
+    const harness = await bootWidget({
+      routes: {
+        ...widgetRoutes(),
+        'GET /classic/buildings?type=0': [],
+        'GET /home/targets/ata': [],
+      },
+    })
+
+    expect(document.querySelector('#values_melcloud select')).toBeNull()
+    expect(calledPaths(harness)).not.toContain(
+      'GET /classic/zones/buildings/1/ata',
+    )
+    expect(harness.ready).toHaveBeenCalledTimes(1)
+  })
+
+  it('should apply the stored default zone', async () => {
+    await bootWidget({
+      settings: {
+        default_zone: mock<HomeDeviceZone>({ id: 11, model: 'devices' }),
+      },
+    })
+
+    expect(getSelect('zones').value).toBe('devices_11')
+  })
+
+  it('should refetch and re-animate on a zone change', async () => {
+    const harness = await bootWidget({
+      routes: {
+        ...widgetRoutes(),
+        'GET /classic/zones/devices/11/ata': {
+          ...groupStateFixture(),
+          SetTemperature: 19,
+        },
+      },
+    })
+    commit(getSelect('zones'), 'devices_11')
+    await settleDetached()
+
+    expect(getInput('SetTemperature').value).toBe('19')
+    expect(harness.ready).toHaveBeenCalledTimes(1)
+  })
+
+  it('should update through the gate with haptic feedback', async () => {
+    const harness = await bootWidget()
+    const apply = getButton('apply_values_melcloud')
+
+    expect(apply.disabled).toBe(true)
+
+    commit(getInput('SetTemperature'), '25')
+
+    expect(apply.disabled).toBe(false)
+
+    apply.click()
+    await settleDetached()
+
+    expect(harness.hapticFeedback).toHaveBeenCalledTimes(1)
+
+    const put = harness.api.mock.calls.findLast(([method]) => method === 'PUT')
+
+    expect(put?.[2]).toStrictEqual({ SetTemperature: 25 })
+  })
+
+  it('should refresh the form back to the known state', async () => {
+    const harness = await bootWidget()
+    commit(getInput('SetTemperature'), '25')
+    getButton('refresh_values_melcloud').click()
+
+    expect(getInput('SetTemperature').value).toBe('22')
+    expect(getButton('apply_values_melcloud').disabled).toBe(true)
+    expect(harness.hapticFeedback).toHaveBeenCalledTimes(1)
+  })
+
+  it('should debounce bursts of device updates into one refetch', async () => {
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
+    const harness = await bootWidget()
+    const stateFetches = (): number =>
+      calledPaths(harness).filter(
+        (key) => key === 'GET /classic/zones/buildings/1/ata',
+      ).length
+    const before = stateFetches()
+    harness.emit('deviceupdate')
+    harness.emit('deviceupdate')
+    await vi.advanceTimersByTimeAsync(1000)
+    await settleDetached()
+
+    expect(stateFetches()).toBe(before + 1)
+  })
+
+  it('should recover a load that outlives the overlay timeout', async () => {
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
+    const targets = Promise.withResolvers<unknown>()
+    const harness = createWidgetHomey({
+      deferredRoutes: { 'GET /home/targets/ata': async () => targets.promise },
+    })
+    const boot = start(harness.homey)
+    await settleDetached()
+    await vi.advanceTimersByTimeAsync(10_000)
+    await boot
+
+    // The overlay ended on the timeout, degraded but visible.
+    expect(harness.ready).toHaveBeenCalledTimes(1)
+
+    const initError = document.querySelector('#init_error')
+
+    expect(initError?.textContent).not.toBe('')
+
+    // The late success repaints over the degraded state and resizes.
+    targets.resolve([])
+    await settleDetached()
+    await settleDetached()
+
+    expect(initError?.textContent).toBe('')
+    // happy-dom lays nothing out, so the measured height is zero.
+    expect(harness.setHeight).toHaveBeenCalledWith(expect.any(Number))
+  })
+})

--- a/tests/unit/ata-values.test.ts
+++ b/tests/unit/ata-values.test.ts
@@ -1,0 +1,238 @@
+// @vitest-environment happy-dom
+// @vitest-environment-options {"settings": {"disableCSSFileLoading": true, "disableJavaScriptFileLoading": true, "navigation": {"disableMainFrameNavigation": true}}}
+
+import { getFieldset, getInput, getSelect } from '@olivierzal/homey-kit/dom'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import type { HomeDeviceZone } from '../../types/zone.mts'
+import { AtaValueManager } from '../../widgets/ata-group-setting/public/ata-values.mts'
+import {
+  type WidgetHarness,
+  type WidgetHarnessOptions,
+  createWidgetHomey,
+  groupStateFixture,
+  loadWidgetPage,
+  widgetRoutes,
+} from '../ata-group-harness.ts'
+import { mock } from '../helpers.ts'
+
+interface ManagerHarness extends WidgetHarness {
+  readonly manager: AtaValueManager
+}
+
+const classicZones = (): HomeDeviceZone[] => [
+  mock<HomeDeviceZone>({ id: 1, level: 0, model: 'buildings', name: 'Home' }),
+  mock<HomeDeviceZone>({ id: 11, level: 1, model: 'devices', name: 'Living' }),
+]
+
+const createManager = async (
+  options: WidgetHarnessOptions = {},
+): Promise<ManagerHarness> => {
+  const harness = createWidgetHomey(options)
+  const manager = new AtaValueManager(
+    harness.homey,
+    getFieldset('values_melcloud'),
+    getSelect('zones'),
+  )
+  await manager.fetchCapabilities()
+  manager.createAtaFormControls()
+  manager.populateZoneOptions(classicZones())
+  return { ...harness, manager }
+}
+
+const lastPutBody = (harness: WidgetHarness): unknown =>
+  harness.api.mock.calls.findLast(([method]) => method === 'PUT')?.[2]
+
+describe('ata value manager', () => {
+  beforeEach(() => {
+    loadWidgetPage()
+  })
+
+  it('should build one control per mappable capability', async () => {
+    await createManager()
+    const fieldset = getFieldset('values_melcloud')
+
+    // Each select opens on the blank "no instruction" option.
+    expect(getSelect('Power').options).toHaveLength(3)
+    expect(getSelect('OperationMode').options).toHaveLength(6)
+    expect(getInput('SetTemperature').min).toBe('10')
+    expect(getInput('SetTemperature').max).toBe('31')
+    expect(getInput('FanSpeed').min).toBe('')
+    // The unmappable capability yields no control and no label.
+    expect(fieldset.querySelector('#SilentMode')).toBeNull()
+    expect([...fieldset.querySelectorAll('label')]).toHaveLength(4)
+  })
+
+  it('should fetch and display the zone state', async () => {
+    const { manager } = await createManager()
+    await manager.fetchValues()
+
+    expect(getSelect('Power').value).toBe('true')
+    expect(getSelect('OperationMode').value).toBe('1')
+    expect(getInput('SetTemperature').value).toBe('22')
+    expect(getInput('FanSpeed').value).toBe('3')
+  })
+
+  it('should route each zone kind to its state endpoint', async () => {
+    const { api, manager } = await createManager({
+      routes: {
+        ...widgetRoutes(),
+        'GET /home/buildings/b_1/ata': {},
+        'GET /home/devices/ata_1/ata': {},
+      },
+    })
+    const zone = getSelect('zones')
+    for (const value of ['homeBuildings_b_1', 'homeDevices_ata_1']) {
+      const option = document.createElement('option')
+      option.value = value
+      zone.append(option)
+    }
+    for (const value of ['homeBuildings_b_1', 'homeDevices_ata_1']) {
+      zone.value = value
+      // eslint-disable-next-line no-await-in-loop -- sequential by design: one endpoint probe at a time
+      await manager.fetchValues()
+    }
+    const paths = harnessPaths(api)
+
+    expect(paths).toContain('GET /home/buildings/b_1/ata')
+    expect(paths).toContain('GET /home/devices/ata_1/ata')
+  })
+
+  it('should apply a matching default zone and skip the rest', async () => {
+    const { manager } = await createManager()
+    const zone = getSelect('zones')
+    manager.applyDefaultZone(null)
+
+    expect(zone.value).toBe('buildings_1')
+
+    manager.applyDefaultZone(mock<HomeDeviceZone>({ id: 11, model: 'devices' }))
+
+    expect(zone.value).toBe('devices_11')
+
+    manager.applyDefaultZone(
+      mock<HomeDeviceZone>({ id: 'missing', model: 'homeDevices' }),
+    )
+
+    expect(zone.value).toBe('devices_11')
+  })
+
+  it('should keep an empty populate call harmless', async () => {
+    const { manager } = await createManager()
+    const count = getSelect('zones').options.length
+    manager.populateZoneOptions()
+
+    expect(getSelect('zones').options).toHaveLength(count)
+  })
+
+  it('should send only the actionable divergence', async () => {
+    const { manager, ...harness } = await createManager()
+    await manager.fetchValues()
+    // Same as the zone state → filtered; emptied → no instruction.
+    getSelect('OperationMode').value = '1'
+    getInput('FanSpeed').value = ''
+    getInput('SetTemperature').value = '25'
+    getSelect('Power').value = 'true'
+    await manager.setValues()
+
+    expect(lastPutBody(harness)).toStrictEqual({ SetTemperature: 25 })
+  })
+
+  it('should skip a foreign control in the body', async () => {
+    const { manager, ...harness } = await createManager()
+    await manager.fetchValues()
+    const rogue = document.createElement('input')
+    rogue.id = 'NotACapability'
+    rogue.value = '7'
+    getFieldset('values_melcloud').append(rogue)
+    getInput('SetTemperature').value = '25'
+    await manager.setValues()
+
+    expect(lastPutBody(harness)).toStrictEqual({ SetTemperature: 25 })
+  })
+
+  it('should clamp the temperature to the mode floor', async () => {
+    const { manager, ...harness } = await createManager()
+    await manager.fetchValues()
+    getSelect('OperationMode').value = '3'
+    getInput('SetTemperature').value = '12'
+    await manager.setValues()
+
+    // Cooling raises the floor to the API's cooling minimum.
+    expect(lastPutBody(harness)).toStrictEqual({
+      OperationMode: 3,
+      SetTemperature: 16,
+    })
+  })
+
+  it('should clamp the temperature to the manifest bounds', async () => {
+    const { manager, ...harness } = await createManager()
+    await manager.fetchValues()
+    getInput('SetTemperature').value = '5'
+    await manager.setValues()
+
+    expect(lastPutBody(harness)).toStrictEqual({ SetTemperature: 10 })
+
+    getInput('SetTemperature').value = '40'
+    await manager.setValues()
+
+    expect(lastPutBody(harness)).toStrictEqual({ SetTemperature: 31 })
+  })
+
+  it('should reject a non-finite temperature before the wire', async () => {
+    const { api, manager } = await createManager()
+    await manager.fetchValues()
+    // Valid floating-point syntax the control keeps, overflowing to
+    // Infinity — the one non-finite value a number input can carry.
+    getInput('SetTemperature').value = '1e999'
+
+    await expect(manager.setValues()).rejects.toThrow('Invalid number')
+    expect(harnessPaths(api)).not.toContain(
+      'PUT /classic/zones/buildings/1/ata',
+    )
+  })
+
+  it('should absorb an accepted write into the zone state', async () => {
+    const { manager, ...harness } = await createManager()
+    await manager.fetchValues()
+    getInput('SetTemperature').value = '25'
+    await manager.setValues()
+    // The known state took the write: re-sending the same form value
+    // nets an empty body, so the gate cannot arm.
+    getInput('SetTemperature').value = '25'
+
+    expect(
+      getButtonDisabled('apply_values_melcloud') || lastPutBody(harness),
+    ).toBe(true)
+  })
+
+  it('should restore the known state on refresh', async () => {
+    const { manager } = await createManager()
+    await manager.fetchValues()
+    getInput('SetTemperature').value = '25'
+    manager.displayValues()
+
+    expect(getInput('SetTemperature').value).toBe('22')
+  })
+
+  it('should skip a value slot without a control', async () => {
+    const { manager } = await createManager()
+    // A rogue non-control carrying a capability id must not take the
+    // sync write.
+    const rogue = document.createElement('div')
+    rogue.id = 'FanSpeed'
+    getInput('FanSpeed').remove()
+    getFieldset('values_melcloud').append(rogue)
+
+    await expect(manager.fetchValues()).resolves.toStrictEqual(
+      groupStateFixture(),
+    )
+  })
+})
+
+const harnessPaths = (api: WidgetHarness['api']): string[] =>
+  api.mock.calls.map(([method, path]) => `${method} ${path}`)
+
+const getButtonDisabled = (id: string): boolean => {
+  const element = document.querySelector(`#${CSS.escape(id)}`)
+  return element instanceof HTMLButtonElement && element.disabled
+}

--- a/tests/unit/dom.test.ts
+++ b/tests/unit/dom.test.ts
@@ -1,0 +1,120 @@
+// @vitest-environment happy-dom
+// @vitest-environment-options {"settings": {"disableCSSFileLoading": true, "disableJavaScriptFileLoading": true, "navigation": {"disableMainFrameNavigation": true}}}
+
+import type * as Classic from '@olivierzal/melcloud-api/classic'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  appendFormControl,
+  hideInitError,
+  populateZoneOptions,
+  showInitError,
+  translateAriaLabels,
+} from '../../public/dom.mts'
+import { mock } from '../helpers.ts'
+
+describe('webview dom helpers', () => {
+  beforeEach(() => {
+    document.body.replaceChildren()
+  })
+
+  describe(appendFormControl, () => {
+    it('should append a labelled control', () => {
+      const parent = document.createElement('div')
+      const formControl = document.createElement('input')
+      formControl.id = 'field'
+      appendFormControl(parent, { formControl, title: 'Field' })
+      const label = parent.querySelector('label')
+
+      expect(label?.htmlFor).toBe('field')
+      expect(label?.textContent).toBe('Field')
+    })
+
+    it('should skip a null control', () => {
+      const parent = document.createElement('div')
+      appendFormControl(parent, { formControl: null, title: 'Absent' })
+
+      expect(parent.childElementCount).toBe(0)
+    })
+  })
+
+  describe(populateZoneOptions, () => {
+    it('should walk the classic tree in list order', () => {
+      const select = document.createElement('select')
+      document.body.append(select)
+      const zones = [
+        mock<Classic.BuildingZone>({
+          areas: [],
+          devices: [{ id: 11, level: 1, model: 'devices', name: 'Living' }],
+          floors: [
+            {
+              areas: [{ id: 31, level: 2, model: 'areas', name: 'Corner' }],
+              devices: [],
+              id: 21,
+              level: 1,
+              model: 'floors',
+              name: 'Upstairs',
+            },
+          ],
+          id: 1,
+          level: 0,
+          model: 'buildings',
+          name: 'Home',
+        }),
+      ]
+      populateZoneOptions(select, zones)
+
+      expect(
+        [...select.options].map(({ textContent, value }) => ({
+          label: textContent,
+          value,
+        })),
+      ).toStrictEqual([
+        { label: ' Home', value: 'buildings_1' },
+        { label: '··· Living', value: 'devices_11' },
+        { label: '··· Upstairs', value: 'floors_21' },
+        { label: '······ Corner', value: 'areas_31' },
+      ])
+    })
+  })
+
+  describe(translateAriaLabels, () => {
+    it('should translate marked elements and skip empty markers', () => {
+      const marked = document.createElement('span')
+      marked.dataset.i18nAriaLabel = 'widgets.zones'
+      const empty = document.createElement('span')
+      empty.dataset.i18nAriaLabel = ''
+      empty.ariaLabel = 'untouched'
+      document.body.append(marked, empty)
+      translateAriaLabels((key) => `translated:${key}`)
+
+      expect(marked.ariaLabel).toBe('translated:widgets.zones')
+      expect(empty.ariaLabel).toBe('untouched')
+    })
+  })
+
+  describe('init error', () => {
+    it('should show then hide the message element', () => {
+      const element = document.createElement('p')
+      element.id = 'init_error'
+      element.hidden = true
+      document.body.append(element)
+      showInitError(new Error('boom'))
+
+      expect(element.hidden).toBe(false)
+      expect(element.textContent).toBe('boom')
+
+      hideInitError()
+
+      expect(element.hidden).toBe(true)
+      expect(element.textContent).toBe('')
+    })
+
+    it('should tolerate a page without the element', () => {
+      expect(() => {
+        showInitError(new Error('boom'))
+        hideInitError()
+      }).not.toThrow()
+    })
+  })
+})

--- a/tests/unit/style-helpers.test.ts
+++ b/tests/unit/style-helpers.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  generateStyleNumber,
+  generateStyleString,
+  randomFraction,
+} from '../../widgets/ata-group-setting/public/style-helpers.mts'
+
+const UINT32_RANGE = 4_294_967_296
+
+// Pins the CSPRNG output so every derived style value is exact.
+const stubRandomUint32 = (value: number): void => {
+  vi.spyOn(crypto, 'getRandomValues').mockImplementation((array) => {
+    if (array instanceof Uint32Array) {
+      array.fill(value)
+    }
+    return array
+  })
+}
+
+describe('style helpers', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('should scale the full uint32 range onto [0, 1)', () => {
+    stubRandomUint32(0)
+
+    expect(randomFraction()).toBe(0)
+
+    stubRandomUint32(UINT32_RANGE - 1)
+
+    expect(randomFraction()).toBeCloseTo(1, 9)
+    expect(randomFraction()).toBeLessThan(1)
+  })
+
+  it('should span min to min plus gap with the default factors', () => {
+    stubRandomUint32(0)
+
+    expect(generateStyleNumber({ gap: 4, min: 3 })).toBe(3)
+
+    stubRandomUint32(UINT32_RANGE / 2)
+
+    expect(generateStyleNumber({ gap: 4, min: 3 })).toBe(5)
+  })
+
+  it('should apply multiplier and divisor', () => {
+    stubRandomUint32(0)
+
+    expect(
+      generateStyleNumber({ divisor: 2, gap: 1, min: 3, multiplier: 1000 }),
+    ).toBe(1500)
+  })
+
+  it('should treat a zero divisor as one', () => {
+    stubRandomUint32(0)
+
+    expect(generateStyleNumber({ divisor: 0, gap: 1, min: 3 })).toBe(3)
+  })
+
+  it('should append the unit to the stringified value', () => {
+    stubRandomUint32(0)
+
+    expect(generateStyleString({ gap: 1, min: 2 }, 'rem')).toBe('2rem')
+    expect(generateStyleString({ gap: 1, min: 2 })).toBe('2')
+  })
+})

--- a/tests/unit/webview-freshness-boot.test.ts
+++ b/tests/unit/webview-freshness-boot.test.ts
@@ -1,126 +1,104 @@
-import type HomeyWidget from 'homey/lib/HomeyWidget'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+// @vitest-environment happy-dom
+// @vitest-environment-options {"settings": {"disableCSSFileLoading": true, "disableJavaScriptFileLoading": true, "navigation": {"disableMainFrameNavigation": true}}}
+
+import { beforeEach, describe, expect, it } from 'vitest'
 
 import { watchWidgetFreshness } from '../../public/webview-freshness-boot.mts'
-import { mock } from '../helpers.ts'
+import { createWidgetHomey } from '../ata-group-harness.ts'
+import { settleDetached } from '../helpers.ts'
 
-// The wrapper feeds the transport-free twin primitive the widget
-// transport, so the primitive's own suite covers the decision table;
-// these tests pin the wiring — event name, re-run, fail-open poke.
-const globals = globalThis as {
-  document?: unknown
-  location?: unknown
-  sessionStorage?: unknown
+const ENTRY = 'ata-group-setting'
+
+const stampPage = (hash: string): void => {
+  const script = document.createElement('script')
+  script.setAttribute('src', `index.js?v=${hash}`)
+  document.head.append(script)
 }
 
-const installFreshPage = (): void => {
-  globals.document = {
-    querySelectorAll: (): readonly {
-      getAttribute: (name: string) => string | null
-    }[] => [
-      {
-        getAttribute: (name: string): string | null =>
-          name === 'src' ? 'index.js?v=aaaa1111' : null,
-      },
-    ],
-  }
-  globals.location = {
-    href: 'https://webview.invalid/page',
-    replace: vi.fn<(url: string) => void>(),
-  }
-  const store = new Map<string, string>()
-  globals.sessionStorage = {
-    getItem: (key: string): string | null => store.get(key) ?? null,
-    setItem: (key: string, value: string): void => {
-      store.set(key, value)
-    },
-  }
-}
-
-const flushMicrotasks = async (): Promise<void> =>
-  new Promise((resolve) => {
-    setTimeout(resolve, 0)
-  })
-
-describe(watchWidgetFreshness, () => {
-  afterEach(() => {
-    delete globals.document
-    delete globals.location
-    delete globals.sessionStorage
-  })
-
-  it('should subscribe to the app boot poke', async () => {
-    const on = vi.fn<(event: string, callback: () => void) => void>()
-    installFreshPage()
-
-    await watchWidgetFreshness(mock<HomeyWidget>({ on }), 'ata-group-setting')
-
-    expect(on).toHaveBeenCalledTimes(1)
-    expect(on).toHaveBeenCalledWith(
-      'webview_hashes_changed',
-      expect.any(Function),
-    )
-  })
-
-  it('should re-run the handshake when the poke fires', async () => {
-    const api = vi
-      .fn<(method: string, path: string) => Promise<unknown>>()
-      .mockResolvedValue({ 'ata-group-setting': 'aaaa1111' })
-    const on = vi.fn<(event: string, callback: () => void) => void>()
-    installFreshPage()
-    await watchWidgetFreshness(
-      mock<HomeyWidget>({ api, on }),
-      'ata-group-setting',
-    )
-
-    on.mock.calls[0]?.[1]()
-    await flushMicrotasks()
-
-    expect(api).toHaveBeenCalledWith('GET', '/webview-hashes')
-  })
-
-  it('should swallow a failing recheck', async () => {
-    const api = vi
-      .fn<(method: string, path: string) => Promise<unknown>>()
-      .mockRejectedValue(new Error('bridge down'))
-    const on = vi.fn<(event: string, callback: () => void) => void>()
-    installFreshPage()
-    await watchWidgetFreshness(
-      mock<HomeyWidget>({ api, on }),
-      'ata-group-setting',
-    )
-
-    expect(() => {
-      on.mock.calls[0]?.[1]()
-    }).not.toThrow()
-
-    await flushMicrotasks()
-  })
+const hashRoutes = (hash: string): Record<string, unknown> => ({
+  'GET /webview-hashes': { [ENTRY]: hash },
 })
 
-describe(`${watchWidgetFreshness.name} boot check`, () => {
-  afterEach(() => {
-    delete globals.document
-    delete globals.location
-    delete globals.sessionStorage
+describe('widget freshness boot', () => {
+  beforeEach(() => {
+    sessionStorage.clear()
+    document.head.replaceChildren()
   })
 
-  it('should resolve false on a fresh page without navigating', async () => {
-    const api = vi
-      .fn<(method: string, path: string) => Promise<unknown>>()
-      .mockResolvedValue({ 'ata-group-setting': 'aaaa1111' })
-    installFreshPage()
+  it('should keep an unstamped page booting without any fetch', async () => {
+    const { api, homey } = createWidgetHomey({ routes: hashRoutes('aaaaaaaa') })
 
-    await expect(
-      watchWidgetFreshness(
-        mock<HomeyWidget>({
-          api,
-          on: vi.fn<(event: string, callback: () => void) => void>(),
-        }),
-        'ata-group-setting',
-      ),
-    ).resolves.toBe(false)
+    await expect(watchWidgetFreshness(homey, ENTRY)).resolves.toBe(false)
 
-    expect(api).toHaveBeenCalledWith('GET', '/webview-hashes')
+    expect(api).not.toHaveBeenCalledWith('GET', '/webview-hashes')
+  })
+
+  it('should keep a matching page booting', async () => {
+    stampPage('aaaaaaaa')
+    const { homey } = createWidgetHomey({ routes: hashRoutes('aaaaaaaa') })
+
+    await expect(watchWidgetFreshness(homey, ENTRY)).resolves.toBe(false)
+  })
+
+  it('should report a mismatch that survived its refetch', async () => {
+    stampPage('aaaaaaaa')
+    // The guard already carries this identity: the one refetch was spent.
+    sessionStorage.setItem('webview_refetched_for', 'aaaaaaaa')
+    const { api, homey } = createWidgetHomey({ routes: hashRoutes('bbbbbbbb') })
+
+    await expect(watchWidgetFreshness(homey, ENTRY)).resolves.toBe(false)
+
+    await settleDetached()
+
+    expect(api).toHaveBeenCalledWith(
+      'POST',
+      '/boot-error',
+      expect.objectContaining({ name: 'WebviewFreshness' }),
+    )
+  })
+
+  it('should swallow a failing breadcrumb post', async () => {
+    stampPage('aaaaaaaa')
+    sessionStorage.setItem('webview_refetched_for', 'aaaaaaaa')
+    const { homey } = createWidgetHomey({
+      failures: { 'POST /boot-error': new Error('channel down') },
+      routes: hashRoutes('bbbbbbbb'),
+    })
+
+    await expect(watchWidgetFreshness(homey, ENTRY)).resolves.toBe(false)
+
+    await settleDetached()
+  })
+
+  it('should swallow a failing hash fetch and stay put', async () => {
+    stampPage('aaaaaaaa')
+    const { emit, homey } = createWidgetHomey({
+      failures: { 'GET /webview-hashes': new Error('bridge down') },
+    })
+
+    await expect(watchWidgetFreshness(homey, ENTRY)).resolves.toBe(false)
+
+    // The poke's recheck fails the same way and must not throw either.
+    expect(() => {
+      emit('webview_hashes_changed')
+    }).not.toThrow()
+
+    await settleDetached()
+  })
+
+  it('should re-run the handshake on the app poke', async () => {
+    stampPage('aaaaaaaa')
+    const { api, emit, homey } = createWidgetHomey({
+      routes: hashRoutes('aaaaaaaa'),
+    })
+    await watchWidgetFreshness(homey, ENTRY)
+    const hashCalls = (): number =>
+      api.mock.calls.filter(([, path]) => path === '/webview-hashes').length
+    const before = hashCalls()
+
+    emit('webview_hashes_changed')
+    await settleDetached()
+
+    expect(hashCalls()).toBe(before + 1)
   })
 })

--- a/tests/unit/widget.test.ts
+++ b/tests/unit/widget.test.ts
@@ -1,0 +1,48 @@
+import type HomeyWidget from 'homey/lib/HomeyWidget'
+import { describe, expect, it, vi } from 'vitest'
+
+import { homeyApiGet, homeyApiPost, homeyApiPut } from '../../public/widget.mts'
+import { mock } from '../helpers.ts'
+
+const createWidgetHomey = (
+  result?: unknown,
+): {
+  api: ReturnType<
+    typeof vi.fn<
+      (method: string, path: string, body?: object) => Promise<unknown>
+    >
+  >
+  homey: HomeyWidget
+} => {
+  const api = vi
+    .fn<(method: string, path: string, body?: object) => Promise<unknown>>()
+    .mockResolvedValue(result)
+  return { api, homey: mock<HomeyWidget>({ api }) }
+}
+
+describe('widget transport', () => {
+  it('should read a route through GET', async () => {
+    const { api, homey } = createWidgetHomey(['a'])
+
+    await expect(
+      homeyApiGet<string[]>(homey, '/language'),
+    ).resolves.toStrictEqual(['a'])
+    expect(api).toHaveBeenCalledWith('GET', '/language')
+  })
+
+  it('should post a body', async () => {
+    const { api, homey } = createWidgetHomey()
+    await homeyApiPost(homey, '/boot-error', { name: 'X' })
+
+    expect(api).toHaveBeenCalledWith('POST', '/boot-error', { name: 'X' })
+  })
+
+  it('should put a body', async () => {
+    const { api, homey } = createWidgetHomey()
+    await homeyApiPut(homey, '/classic/zones/devices/1/ata', { Power: true })
+
+    expect(api).toHaveBeenCalledWith('PUT', '/classic/zones/devices/1/ata', {
+      Power: true,
+    })
+  })
+})

--- a/tests/unit/zones.test.ts
+++ b/tests/unit/zones.test.ts
@@ -1,0 +1,60 @@
+import type * as Classic from '@olivierzal/melcloud-api/classic'
+import { describe, expect, it } from 'vitest'
+
+import type { HomeDeviceZone } from '../../types/zone.mts'
+import {
+  getHomeBuildingId,
+  getHomeDeviceId,
+  getSubzones,
+  getZoneId,
+  getZoneName,
+  getZonePath,
+  isHomeBuildingValue,
+  isHomeDeviceValue,
+} from '../../public/zones.mts'
+import { mock } from '../helpers.ts'
+
+describe('zones', () => {
+  it('should flatten every classic subzone collection in order', () => {
+    const devices = [{ id: 1 }]
+    const areas = [{ id: 2 }]
+    const floors = [{ id: 3 }]
+
+    expect(
+      getSubzones(mock<Classic.BuildingZone>({ areas, devices, floors })),
+    ).toStrictEqual([{ id: 1 }, { id: 2 }, { id: 3 }])
+  })
+
+  it('should bottom out on a home zone carrying no subzone key', () => {
+    expect(getSubzones(mock<HomeDeviceZone>({ id: 'x' }))).toStrictEqual([])
+  })
+
+  it('should build a zone value from model and id', () => {
+    expect(getZoneId(11, 'devices')).toBe('devices_11')
+    expect(getZoneId('building_1', 'homeBuildings')).toBe(
+      'homeBuildings_building_1',
+    )
+  })
+
+  it('should replace only the first underscore in a zone path', () => {
+    expect(getZonePath('devices_11')).toBe('devices/11')
+    expect(getZonePath('floors_2_1')).toBe('floors/2_1')
+  })
+
+  it('should indent a zone name by its level', () => {
+    expect(getZoneName('Home', 0)).toBe(' Home')
+    expect(getZoneName('Corner', 2)).toBe('······ Corner')
+  })
+
+  it('should detect home values by fixed-length prefix only', () => {
+    expect(isHomeDeviceValue('homeDevices_abc_def')).toBe(true)
+    expect(isHomeDeviceValue('devices_11')).toBe(false)
+    expect(isHomeBuildingValue('homeBuildings_b_1')).toBe(true)
+    expect(isHomeBuildingValue('homeDevices_abc')).toBe(false)
+  })
+
+  it('should keep underscores inside a stripped home id', () => {
+    expect(getHomeDeviceId('homeDevices_abc_def')).toBe('abc_def')
+    expect(getHomeBuildingId('homeBuildings_b_1')).toBe('b_1')
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,7 +6,11 @@ const config: ViteUserConfig = defineConfig({
     coverage: {
       // The remaining webview exclusion shrinks as the real-coverage
       // campaign lands zone by zone; never widen it.
-      exclude: ['.homeybuild/**', '**/public/**/*.mts', 'scripts/**/*.mts'],
+      exclude: [
+        '.homeybuild/**',
+        'scripts/**/*.mts',
+        'widgets/charts/public/**/*.mts',
+      ],
       include: ['**/*.mts'],
       reporter: ['text', 'lcov'],
       thresholds: {

--- a/widgets/ata-group-setting/public/animation.mts
+++ b/widgets/ata-group-setting/public/animation.mts
@@ -122,10 +122,9 @@ const generateDelay = (delay: number, speed: number): number => {
     (SPEED_FACTOR_MAX / SPEED_FACTOR_MIN) **
       ((speed - ClassicFanSpeed.very_slow) /
         (ClassicFanSpeed.very_fast - ClassicFanSpeed.very_slow))
-  return (
-    (randomFraction() * delay) /
-    (speedFactor === 0 || Number.isNaN(speedFactor) ? 1 : speedFactor)
-  )
+  // An extreme wire speed underflows the exponential to zero — divide
+  // by one instead of freezing the cadence at Infinity.
+  return (randomFraction() * delay) / (speedFactor === 0 ? 1 : speedFactor)
 }
 
 const getZoneValue = (): string => getZonePath(getSelect('zones').value)
@@ -163,29 +162,33 @@ const isAbortError = (error: unknown): boolean =>
 // soon as `signal` aborts.
 const sleep = async (ms: number, signal: AbortSignal): Promise<void> =>
   new Promise((resolve, reject) => {
+    // A signal that is already aborted would never fire `abort`: fail
+    // fast (the executor turns the throw into a rejection) instead of
+    // wiring a listener that cannot fire.
+    signal.throwIfAborted()
     const done = AbortSignal.any([signal, AbortSignal.timeout(ms)])
-    const settle = (): void => {
-      if (signal.aborted) {
-        reject(newAbortError())
-        return
-      }
-      resolve()
-    }
-    // A signal that is already aborted never fires `abort`; settling
-    // synchronously keeps the promise from hanging in that case.
-    if (done.aborted) {
-      settle()
-      return
-    }
-    done.addEventListener('abort', settle, { once: true })
+    done.addEventListener(
+      'abort',
+      () => {
+        if (signal.aborted) {
+          reject(newAbortError())
+          return
+        }
+        resolve()
+      },
+      { once: true },
+    )
   })
 
+// The loop's only exit is the abort error: `sleep` rejects as soon as
+// the signal aborts, so a loop condition could never observe the abort
+// itself.
 const spawnUntilAborted = async (
   generateSpawnDelay: () => number,
   signal: AbortSignal,
   spawn: () => void,
 ): Promise<void> => {
-  while (!signal.aborted) {
+  for (;;) {
     // eslint-disable-next-line no-await-in-loop -- sequential by design: each spawn waits out its own randomized delay
     await sleep(generateSpawnDelay(), signal)
     // The abort can land between the sleep settling and this continuation
@@ -378,11 +381,10 @@ const expireFlame = async (
 ): Promise<void> => {
   try {
     await sleep(delayMs, controller.signal)
-  } catch (error) {
-    if (isAbortError(error)) {
-      return
-    }
-    throw error
+  } catch {
+    // Only the abort can reject the sleep: the flame already ended
+    // through another path.
+    return
   }
   cancelAnimations(flame)
   flame.remove()

--- a/widgets/ata-group-setting/public/ata-values.mts
+++ b/widgets/ata-group-setting/public/ata-values.mts
@@ -6,6 +6,7 @@ import {
   createSelect,
   getButton,
   getSelect,
+  parseFormValue,
 } from '@olivierzal/homey-kit/dom'
 import { type DirtyGate, createDirtyGate } from '@olivierzal/homey-kit/webview'
 import {
@@ -15,11 +16,7 @@ import {
 
 import type { DriverCapabilitiesOptions } from '../../../types/driver-settings.mts'
 import type { AtaGroupSettingWidgetSettings } from '../../../types/widgets.mts'
-import {
-  appendFormControl,
-  parseFormValue,
-  populateZoneOptions,
-} from '../../../public/dom.mts'
+import { appendFormControl, populateZoneOptions } from '../../../public/dom.mts'
 import {
   type Homey,
   homeyApiGet,
@@ -46,25 +43,21 @@ const elementTypes = new Set(['boolean', 'enum'])
 // asserting it down to ClassicOperationMode.
 const coolModeNumbers: ReadonlySet<number> = classicCoolModes
 
-const getCoolingAdjustedMin = (id: string, min: string): string =>
-  id === 'SetTemperature' &&
-  coolModeNumbers.has(Number(getSelect('OperationMode').value))
-    ? String(ClassicTemperature.coolingMin)
-    : min
-
-const clampNumericInput = ({
-  id,
-  max,
-  min,
-  value,
-}: HTMLInputElement): number => {
+// `SetTemperature` is the only control built with bounds (see
+// #createAtaControl), so the bounded-number strategy IS the temperature
+// clamp — no id dispatch. Cooling modes raise the floor to the API's
+// cooling minimum.
+const clampTemperature = ({ max, min, value }: HTMLInputElement): number => {
   const numberValue = Number(value)
-  const newMin = Number(getCoolingAdjustedMin(id, min))
-  const newMax = Number(max)
   if (!Number.isFinite(numberValue)) {
     throw new TypeError('Invalid number')
   }
-  return Math.min(Math.max(numberValue, newMin), newMax)
+  const activeMin = coolModeNumbers.has(
+    Number(getSelect('OperationMode').value),
+  )
+    ? ClassicTemperature.coolingMin
+    : Number(min)
+  return Math.min(Math.max(numberValue, activeMin), Number(max))
 }
 
 // Routes a `${model}_${id}` option value to its state endpoint.
@@ -217,7 +210,7 @@ export class AtaValueManager {
         )
         .map((element) => [
           element.id,
-          parseFormValue(element, clampNumericInput),
+          parseFormValue(element, clampTemperature),
         ]),
     )
   }

--- a/widgets/ata-group-setting/public/style-helpers.mts
+++ b/widgets/ata-group-setting/public/style-helpers.mts
@@ -7,16 +7,17 @@ const UINT32_RANGE = 4_294_967_296
 const UINT32_FRACTION_SCALE = 1 / UINT32_RANGE
 
 // Refilled in place on every sample so the per-frame jitter does not
-// allocate
+// allocate; the DataView reads the same bytes back without the indexed
+// access that would demand an unreachable undefined fallback.
 const randomSampleBuffer = new Uint32Array(1)
+const randomSampleView = new DataView(randomSampleBuffer.buffer)
 
 // Uniform fraction in [0, 1) backed by the Web Crypto API — the jitter is
 // purely cosmetic, but a CSPRNG costs nothing and satisfies security
 // analyzers flagging Math.random
 export const randomFraction = (): number => {
   crypto.getRandomValues(randomSampleBuffer)
-  const [value = 0] = randomSampleBuffer
-  return value * UINT32_FRACTION_SCALE
+  return randomSampleView.getUint32(0, true) * UINT32_FRACTION_SCALE
 }
 
 export const generateStyleNumber = ({


### PR DESCRIPTION
Second slice of the real-coverage campaign (after #1560). Everything under `public/` plus the whole `ata-group-setting` widget is now tested against its real HTML under happy-dom, and the coverage exclusion narrows from every `**/public/**` to the charts widget alone — in `vitest.config.ts` and `sonar-project.properties` together. Suite: 803 → 873 tests, all zones at 100% (statements, branches, functions).

| Zone | Before | After |
| --- | --- | --- |
| `public/dom.mts`, `zones.mts`, `widget.mts` | 0% | 100% |
| `widgets/ata-group-setting/public/**` (incl. the 882-line `animation.mts`) | 0% | 100% |

### Harness

happy-dom ships no Web Animations API, so the harness installs one: a recording fake per created element, closed over the element rather than patched onto `HTMLElement.prototype` (a prototype method would need `this`, which no arrow can carry — the closure keeps every helper lint-clean without a disable). A pinned CSPRNG collapses the randomized spawn delays, so a scene can be driven tick by tick: flame spacing and wrap-around, smoke budget saturation at 500 particles, the sun's fly-in/reverse-out lifecycle, the generation guard that lets a newer apply beat a slower one, and the hidden-page park/replay.

### Dead-defensive removals (not silent exceptions)

Same doctrine as #1560 — an unreachable net is dead code:

- The local `parseFormValue` is gone: the kit's own reader serves both webviews now (its number strategy went optional in kit 3.2.0), so the settings page and the widget share one reader.
- `spawnUntilAborted`'s loop condition and `expireFlame`'s rethrow: the abortable `sleep` can only ever reject with the abort error, so neither arm was reachable.
- `generateDelay`'s `Number.isNaN` arm: every caller normalizes its speed first (`parseStateParams` maps 0/NaN to moderate). The zero check stays and is pinned — an extreme wire speed really does underflow the exponential.
- `randomFraction`'s `[value = 0]` fallback: a `DataView` reads the same bytes back without an indexed access that would demand an unreachable default.

### Simplification

`clampNumericInput` → `clampTemperature`: `SetTemperature` is the only control the widget builds with bounds, so the bounded-number strategy *is* the temperature clamp — the id dispatch it carried was answering a question the call site had already settled.

Next: the charts widget (last exclusion) and a `scripts/` PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3