### PR TITLE
fix(bundle): join a page identity over its unique stamps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,13 @@ caught real failures that the others miss:
   never comments. A second cache layer covers the HTML
   itself (phone webviews cache the page across app versions,
   force-close included): each bundle carries a freshness handshake —
-  the page's identity is the document-order join of its `?v=` stamps (a CSS-only ship moves it too), `GET /webview-hashes` serves the
+  the page's identity is the document-order join of its UNIQUE `?v=`
+  stamps — a CSS-only ship moves it too, and the dedup is by HASH VALUE
+  on BOTH sides (the kit's page-side join and `webview-stamp.mts`):
+  two assets with identical bytes carry one stamp on the page, so a
+  bundler counting them twice would mint an identity no page could ever
+  match — an endless refetch handshake (fixed and pinned, 2026-08) —,
+  `GET /webview-hashes` serves the
   live hashes (a manifest `bundle.mts` emits into the packaged app,
   read by `@olivierzal/homey-kit/node`; every `api.mts` — app and both
   widgets — passes the manifest URL explicitly, the kit's default
@@ -68,6 +74,16 @@ caught real failures that the others miss:
   breadcrumb). Never fold the visibility trigger into it. Every failure
   path stays open: an unstamped page, an absent route or denied
   storage must never take a working webview down.
+  The stamping pass itself lives in `scripts/webview-stamp.mts` (and the
+  vendored-JSON key sort in `scripts/sort-keys-deep.mts`), unit-tested
+  against a temp packaging tree; `bundle.mts` and
+  `sync-capability-definitions.mts` keep only their tables and the
+  esbuild/fs calls consuming them — the two named, file-scoped coverage
+  exclusions left in `vitest.config.ts` and `sonar-project.properties`
+  (never a directory sweep, and `npm run build` plus the drift test
+  exercise them end to end). esbuild runs in a service process with its
+  own cwd, so both the build and the stamping anchor on an explicit
+  repo root (`absWorkingDir`), never the launcher's.
 - `npm run homey:validate` — Homey validation at publish level; may
   rewrite files (see locales below), re-stage if it does.
 - `node scripts/sync-capability-definitions.mts` — refreshes the
@@ -79,6 +95,12 @@ caught real failures that the others miss:
   The `homey:*` wrappers are plain CLI calls: the CLI's own
   `npm run build` (post-copy) emits everything the package needs into
   `.homeybuild`, so no pre-build step is required anywhere.
+
+Test harnesses that simulate the clock stub `Temporal.Now`, NEVER
+`Date`: `temporal-polyfill` delegates to `globalThis.Temporal` wherever
+the runtime ships one (Node 26, i.e. the CI's "Node latest" leg), so a
+faked `Date` never reaches the page's clock — the failure mode is a
+suite that passes locally and fails only on that leg.
 
 Check real exit codes; never pipe a check's output through `tail`/`grep`
 to judge success. Remove any `.claude/worktrees/**` leftovers before

--- a/scripts/bundle.mts
+++ b/scripts/bundle.mts
@@ -6,20 +6,24 @@
 // the current classic-defer HTML, index.mjs (ESM) for cached ESM-era
 // HTMLs — and npm dependencies (Chart.js) are inlined so widgets work
 // offline with versions pinned by the lockfile.
-import { createHash } from 'node:crypto'
-import { readFile, writeFile } from 'node:fs/promises'
 import path from 'node:path'
 
 import { type BuildOptions, build } from 'esbuild'
 
+import { stampPackagedPages } from './webview-stamp.mts'
+
 // The IIFE global each page's inline `onHomeyReady` reads `start` from.
 const GLOBAL_NAME = 'MELCloudWebview'
 
+// esbuild runs its build in a service process with its own working
+// directory, while the stamping pass reads and writes through `node:fs`
+// (the launcher's cwd): both are anchored at the repo root so they
+// cannot disagree about where the packaged app lives.
+const ROOT = path.resolve(import.meta.dirname, '..')
+
 // The Homey CLI's packaging target: `tsc` already emits here (its
 // validated `outDir`), and the CLI packs exactly this directory.
-const OUT_ROOT = '.homeybuild'
-
-const HASH_LENGTH = 8
+const OUT_ROOT = path.join(ROOT, '.homeybuild')
 
 const entryPoints = [
   'widgets/ata-group-setting/public/index.mts',
@@ -40,12 +44,8 @@ const pages = [
   { entry: 'charts', page: 'widgets/charts/public/index.html' },
 ]
 
-// A local asset reference — an href/src attribute value, with an
-// optional existing stamp.
-const REFERENCE =
-  /(?<prefix>href="|src=")(?<file>[^"':?\/][^"':?]*)(?:\?v=[0-9a-f]+)?(?<suffix>")/gv
-
 const sharedOptions: BuildOptions = {
+  absWorkingDir: ROOT,
   bundle: true,
   legalComments: 'none',
   logLevel: 'info',
@@ -74,95 +74,4 @@ await Promise.all(
   }),
 )
 
-// Cache-bust the PACKAGED pages: phone webviews cache assets across app
-// versions, so a content hash per file forces a refetch exactly when a
-// file changes. The committed source HTML stays unstamped — `?v=` is a
-// package-time transform of the `.homeybuild` copy, which exists in the
-// CLI flow (its pre-process copy runs before `npm run build`) and is
-// absent in a standalone suite run, which only proves the bundles
-// compile.
-const hashOf = async (filePath: string): Promise<string> => {
-  const content = await readFile(filePath)
-  return createHash('sha256')
-    .update(content)
-    .digest('hex')
-    .slice(0, HASH_LENGTH)
-}
-
-const collectHashes = async (
-  html: string,
-  directory: string,
-): Promise<ReadonlyMap<string, string>> => {
-  const files = new Set<string>()
-  for (const match of html.matchAll(REFERENCE)) {
-    const { file = '' } = match.groups ?? {}
-    if (file !== '') {
-      files.add(file)
-    }
-  }
-  return new Map(
-    await Promise.all(
-      [...files].map(async (file): Promise<[string, string]> => [
-        file,
-        await hashOf(path.join(directory, file)),
-      ]),
-    ),
-  )
-}
-
-// Stamp only within a reference context, so the same filename written
-// elsewhere (e.g. a comment) is never rewritten. Rebuilt cursor-wise
-// rather than through a `replaceAll` callback, whose loosely typed rest
-// arguments cannot carry the named groups safely.
-const stampReferences = (
-  html: string,
-  hashes: ReadonlyMap<string, string>,
-): string => {
-  let stamped = ''
-  let cursor = 0
-  for (const match of html.matchAll(REFERENCE)) {
-    const { file = '', prefix = '', suffix = '' } = match.groups ?? {}
-    const hash = hashes.get(file) ?? ''
-    stamped += `${html.slice(cursor, match.index)}${prefix}${file}?v=${hash}${suffix}`
-    cursor = match.index + match[0].length
-  }
-  return stamped + html.slice(cursor)
-}
-
-const stampHtml = async (htmlPath: string): Promise<string | null> => {
-  let html: string
-  try {
-    html = await readFile(htmlPath, 'utf8')
-  } catch {
-    // The page copy only exists in the CLI flow; a standalone suite run
-    // has nothing to stamp.
-    return null
-  }
-  const hashes = await collectHashes(html, path.dirname(htmlPath))
-  const stamped = stampReferences(html, hashes)
-  if (stamped !== html) {
-    await writeFile(htmlPath, stamped)
-  }
-  // The page's identity is the join of every stamp it carries, in
-  // DOCUMENT order (the match order of `REFERENCE`, which the page's
-  // own collection mirrors): a change to any packaged asset (bundle,
-  // stylesheet) moves the identity, so CSS-only or markup-only ships
-  // self-heal too.
-  return hashes.size > 0 ? hashes.values().toArray().join('.') : null
-}
-
-// Emit the live-hash manifest the app serves (`GET /webview-hashes`) —
-// only in the CLI flow, where every page copy exists: a standalone
-// suite run stamps nothing and must not leave a partial manifest.
-const stampedEntries = await Promise.all(
-  pages.map(async ({ entry, page }): Promise<[string, string | null]> => [
-    entry,
-    await stampHtml(path.join(OUT_ROOT, page)),
-  ]),
-)
-if (stampedEntries.every(([, hash]) => hash !== null)) {
-  await writeFile(
-    path.join(OUT_ROOT, 'webview-hashes.json'),
-    JSON.stringify(Object.fromEntries(stampedEntries)),
-  )
-}
+await stampPackagedPages(OUT_ROOT, pages)

--- a/scripts/sort-keys-deep.mts
+++ b/scripts/sort-keys-deep.mts
@@ -1,0 +1,21 @@
+/**
+ * Re-sorts every object key to the repo's `json/sort-keys` convention,
+ * leaving values (and array order) exactly as they came — the vendored
+ * capability definitions must stay homey-lib's own data, only laid out
+ * the way the linter expects.
+ * @param value - Any parsed JSON value.
+ * @returns The same value with its object keys sorted, depth-first.
+ */
+export const sortKeysDeep = (value: unknown): unknown => {
+  if (Array.isArray(value)) {
+    return value.map((entry: unknown) => sortKeysDeep(entry))
+  }
+  if (value !== null && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value)
+        .toSorted(([left], [right]) => left.localeCompare(right, 'en'))
+        .map(([key, entry]) => [key, sortKeysDeep(entry)]),
+    )
+  }
+  return value
+}

--- a/scripts/sync-capability-definitions.mts
+++ b/scripts/sync-capability-definitions.mts
@@ -4,6 +4,8 @@
 // exactly homey-lib's, pinned by tests/unit/capability-definitions.test.ts.
 import { readFile, writeFile } from 'node:fs/promises'
 
+import { sortKeysDeep } from './sort-keys-deep.mts'
+
 const CAPABILITIES = [
   'fan_speed',
   'onoff',
@@ -12,20 +14,6 @@ const CAPABILITIES = [
 ]
 
 const JSON_INDENT = 2
-
-const sortKeysDeep = (value: unknown): unknown => {
-  if (Array.isArray(value)) {
-    return value.map((entry: unknown) => sortKeysDeep(entry))
-  }
-  if (value !== null && typeof value === 'object') {
-    return Object.fromEntries(
-      Object.entries(value)
-        .toSorted(([left], [right]) => left.localeCompare(right, 'en'))
-        .map(([key, entry]) => [key, sortKeysDeep(entry)]),
-    )
-  }
-  return value
-}
 
 await Promise.all(
   CAPABILITIES.map(async (capability) => {

--- a/scripts/webview-stamp.mts
+++ b/scripts/webview-stamp.mts
@@ -1,0 +1,159 @@
+// Cache-busting for the PACKAGED pages: phone webviews cache assets
+// across app versions, so a content hash per file (`?v=`) forces a
+// refetch exactly when a file changes, and the join of a page's stamps
+// is the identity its own freshness handshake compares against
+// (`GET /webview-hashes`). The committed source HTML stays unstamped —
+// this is a package-time transform of the `.homeybuild` copy, which
+// exists in the CLI flow (its pre-process copy runs before
+// `npm run build`) and is absent in a standalone suite run, which only
+// proves the bundles compile.
+import { createHash } from 'node:crypto'
+import { readFile, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+
+const HASH_LENGTH = 8
+
+// A local asset reference — an href/src attribute value, with an
+// optional existing stamp.
+const REFERENCE =
+  /(?<prefix>href="|src=")(?<file>[^"':?\/][^"':?]*)(?:\?v=[0-9a-f]+)?(?<suffix>")/gv
+
+// A reference's parts, exactly as the pattern captures them.
+interface Reference {
+  readonly file: string
+  readonly prefix: string
+  readonly suffix: string
+}
+
+/**
+ * One packaged page and the manifest key its bundle hash is served
+ * under.
+ */
+export interface WebviewPage {
+  readonly entry: string
+  readonly page: string
+}
+
+const hashOf = async (filePath: string): Promise<string> => {
+  const content = await readFile(filePath)
+  return createHash('sha256')
+    .update(content)
+    .digest('hex')
+    .slice(0, HASH_LENGTH)
+}
+
+// One parse for both passes, reading the captures POSITIONALLY: a
+// replacer's parameters are plain strings the pattern always fills,
+// where `matchAll` hands back `groups` typed as possibly-absent and so
+// demands fallbacks no input can ever reach.
+const rewriteReferences = (
+  html: string,
+  rewrite: (reference: Reference) => string,
+): string =>
+  html.replaceAll(REFERENCE, (...captures: string[]): string => {
+    // The platform hands the replacer the whole match followed by each
+    // capture; the pattern guarantees all three.
+    const [, prefix = '', file = '', suffix = ''] = captures
+    return rewrite({ file, prefix, suffix })
+  })
+
+const collectFiles = (html: string): ReadonlySet<string> => {
+  const files = new Set<string>()
+  rewriteReferences(html, ({ file, prefix, suffix }) => {
+    files.add(file)
+    return `${prefix}${file}${suffix}`
+  })
+  return files
+}
+
+const collectHashes = async (
+  html: string,
+  directory: string,
+): Promise<ReadonlyMap<string, string>> =>
+  new Map(
+    await Promise.all(
+      [...collectFiles(html)].map(async (file): Promise<[string, string]> => [
+        file,
+        await hashOf(path.join(directory, file)),
+      ]),
+    ),
+  )
+
+/**
+ * Stamps only within a reference context, so the same filename written
+ * elsewhere (e.g. a comment) is never rewritten.
+ * @param html - The page to rewrite.
+ * @param hashes - Content hash per referenced file.
+ * @returns The page with every local reference stamped.
+ */
+export const stampReferences = (
+  html: string,
+  hashes: ReadonlyMap<string, string>,
+): string =>
+  rewriteReferences(
+    html,
+    ({ file, prefix, suffix }) =>
+      `${prefix}${file}?v=${hashes.get(file) ?? ''}${suffix}`,
+  )
+
+/**
+ * Stamps one packaged page in place and returns the identity it now
+ * carries.
+ * @param htmlPath - The packaged page copy.
+ * @returns The page identity, or `null` when there is nothing to stamp.
+ */
+export const stampHtml = async (htmlPath: string): Promise<string | null> => {
+  let html: string
+  try {
+    html = await readFile(htmlPath, 'utf8')
+  } catch {
+    // The page copy only exists in the CLI flow; a standalone suite run
+    // has nothing to stamp.
+    return null
+  }
+  const hashes = await collectHashes(html, path.dirname(htmlPath))
+  const stamped = stampReferences(html, hashes)
+  if (stamped !== html) {
+    await writeFile(htmlPath, stamped)
+  }
+  // The page's identity is the join of every stamp it carries, in
+  // DOCUMENT order (the match order of `REFERENCE`, which the page's
+  // own collection mirrors): a change to any packaged asset (bundle,
+  // stylesheet) moves the identity, so CSS-only or markup-only ships
+  // self-heal too. Deduplicated by HASH, exactly as the page does it
+  // (the kit's `webview-freshness` joins a `Set` of stamp VALUES): two
+  // assets with identical bytes carry one stamp on the page, so
+  // counting them twice here would mint an identity no page can ever
+  // match — an endless refetch handshake.
+  const identity = [...new Set(hashes.values())].join('.')
+  return identity === '' ? null : identity
+}
+
+/**
+ * Stamps every packaged page and emits the live-hash manifest the app
+ * serves (`GET /webview-hashes`) — only in the CLI flow, where every
+ * page copy exists: a standalone suite run stamps nothing and must not
+ * leave a partial manifest.
+ * @param outRoot - The packaging target directory.
+ * @param pages - The packaged pages and their manifest keys.
+ * @returns Whether the manifest was written.
+ */
+export const stampPackagedPages = async (
+  outRoot: string,
+  pages: readonly WebviewPage[],
+): Promise<boolean> => {
+  const stampedEntries = await Promise.all(
+    pages.map(async ({ entry, page }): Promise<[string, string | null]> => [
+      entry,
+      await stampHtml(path.join(outRoot, page)),
+    ]),
+  )
+  if (stampedEntries.some(([, hash]) => hash === null)) {
+    return false
+  }
+  await writeFile(
+    path.join(outRoot, 'webview-hashes.json'),
+    JSON.stringify(Object.fromEntries(stampedEntries)),
+  )
+  return true
+}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,5 +3,5 @@ sonar.organization=olivierzal
 sonar.sourceEncoding=UTF-8
 sonar.javascript.lcov.reportPaths=./coverage/lcov.info
 sonar.exclusions=**/*.jpg,**/*.png,coverage/**
-sonar.coverage.exclusions=tests/**,**/*.config.*,widgets/charts/public/**,scripts/**
+sonar.coverage.exclusions=tests/**,**/*.config.*,widgets/charts/public/**,scripts/bundle.mts,scripts/sync-capability-definitions.mts
 sonar.cpd.exclusions=**/*.config.*,settings/index.html,widgets/*/public/index.html

--- a/tests/unit/sort-keys-deep.test.ts
+++ b/tests/unit/sort-keys-deep.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+
+import { sortKeysDeep } from '../../scripts/sort-keys-deep.mts'
+
+describe(sortKeysDeep, () => {
+  it('should sort object keys depth-first', () => {
+    const sorted = sortKeysDeep({ area: 3, zone: { getable: 2, max: 1 } })
+
+    expect(sorted).toStrictEqual({ area: 3, zone: { getable: 2, max: 1 } })
+    expect(Object.keys(sorted as object)).toStrictEqual(['area', 'zone'])
+  })
+
+  it('should keep array order and sort the entries inside', () => {
+    expect(sortKeysDeep([{ area: 2, zone: 1 }, 'zulu', 'alpha'])).toStrictEqual(
+      [{ area: 2, zone: 1 }, 'zulu', 'alpha'],
+    )
+  })
+
+  it('should pass primitives and null through untouched', () => {
+    expect([
+      sortKeysDeep('text'),
+      sortKeysDeep(7),
+      sortKeysDeep(true),
+      sortKeysDeep(null),
+    ]).toStrictEqual(['text', 7, true, null])
+  })
+})

--- a/tests/unit/webview-stamp.test.ts
+++ b/tests/unit/webview-stamp.test.ts
@@ -1,0 +1,211 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  type WebviewPage,
+  stampHtml,
+  stampPackagedPages,
+  stampReferences,
+} from '../../scripts/webview-stamp.mts'
+
+// One temp packaging tree per test, so a stamped page never leaks into
+// the next; boxed because the hooks refill it.
+const tree = { outRoot: '' }
+
+const PAGES: readonly WebviewPage[] = [
+  { entry: 'settings', page: 'settings/index.html' },
+  { entry: 'charts', page: 'widgets/charts/public/index.html' },
+]
+
+const writePage = async (
+  page: string,
+  html: string,
+  assets: Readonly<Record<string, string>> = {},
+): Promise<string> => {
+  const htmlPath = path.join(tree.outRoot, page)
+  const directory = path.dirname(htmlPath)
+  await mkdir(directory, { recursive: true })
+  await writeFile(htmlPath, html)
+  for (const [file, content] of Object.entries(assets)) {
+    const assetPath = path.join(directory, file)
+    // eslint-disable-next-line no-await-in-loop -- sequential by design: each asset's directory must exist before the next write
+    await mkdir(path.dirname(assetPath), { recursive: true })
+    // eslint-disable-next-line no-await-in-loop -- sequential by design: written in declaration order alongside its directory
+    await writeFile(assetPath, content)
+  }
+  return htmlPath
+}
+
+const readPage = async (htmlPath: string): Promise<string> =>
+  readFile(htmlPath, 'utf8')
+
+const stampsOf = (html: string): string[] =>
+  html
+    .matchAll(/\?v=(?<hash>[0-9a-f]+)/gv)
+    .map(({ groups }) => groups?.hash ?? '')
+    .toArray()
+
+describe('webview stamping', () => {
+  beforeEach(async () => {
+    tree.outRoot = await mkdtemp(path.join(tmpdir(), 'melcloud-stamp-'))
+  })
+
+  afterEach(async () => {
+    await rm(tree.outRoot, { force: true, recursive: true })
+  })
+
+  it('should stamp every local reference with its content hash', async () => {
+    const htmlPath = await writePage(
+      'settings/index.html',
+      '<link href="index.css" rel="stylesheet"><script defer src="index.js"></script>',
+      { 'index.css': 'body{}', 'index.js': 'console.log(1)' },
+    )
+
+    const identity = await stampHtml(htmlPath)
+    const html = await readPage(htmlPath)
+    const stamps = stampsOf(html)
+
+    expect(stamps).toHaveLength(2)
+    expect(identity).toBe(stamps.join('.'))
+  })
+
+  it('should join the identity over unique hashes, as the page does', async () => {
+    // Two DIFFERENT files with identical bytes carry the same stamp: the
+    // page joins a Set of stamp VALUES, so counting both here would mint
+    // an identity no page could ever match — an endless refetch.
+    const htmlPath = await writePage(
+      'settings/index.html',
+      '<link href="a.css" rel="stylesheet"><link href="b.css" rel="stylesheet"><script defer src="index.js"></script>',
+      { 'a.css': 'body{}', 'b.css': 'body{}', 'index.js': 'console.log(1)' },
+    )
+
+    const identity = await stampHtml(htmlPath)
+    const stamps = stampsOf(await readPage(htmlPath))
+
+    // Three references, two distinct hashes.
+    expect(stamps).toHaveLength(3)
+    expect(identity).toBe([...new Set(stamps)].join('.'))
+  })
+
+  it('should move the identity when any asset changes', async () => {
+    const html =
+      '<link href="index.css" rel="stylesheet"><script defer src="index.js"></script>'
+    const first = await writePage('settings/index.html', html, {
+      'index.css': 'body{}',
+      'index.js': 'console.log(1)',
+    })
+    const before = await stampHtml(first)
+    const second = await writePage('widgets/charts/public/index.html', html, {
+      // A CSS-only ship still moves the page identity.
+      'index.css': 'body{color:red}',
+      'index.js': 'console.log(1)',
+    })
+
+    const after = await stampHtml(second)
+
+    expect(after).not.toBe(before)
+  })
+
+  it('should re-stamp a page that already carries stamps', async () => {
+    const htmlPath = await writePage(
+      'settings/index.html',
+      '<script defer src="index.js?v=deadbeef"></script>',
+      { 'index.js': 'console.log(1)' },
+    )
+
+    await stampHtml(htmlPath)
+
+    expect(stampsOf(await readPage(htmlPath))).not.toContain('deadbeef')
+  })
+
+  it('should stamp only inside a reference context', async () => {
+    const htmlPath = await writePage(
+      'settings/index.html',
+      '<!-- index.js is the bundle --><script defer src="index.js"></script>',
+      { 'index.js': 'console.log(1)' },
+    )
+
+    await stampHtml(htmlPath)
+    const html = await readPage(htmlPath)
+
+    expect(html).toContain('<!-- index.js is the bundle -->')
+    expect(stampsOf(html)).toHaveLength(1)
+  })
+
+  it('should leave remote and rooted references alone', async () => {
+    const htmlPath = await writePage(
+      'settings/index.html',
+      '<link href="https://cdn.invalid/x.css" rel="stylesheet"><img src="/logo.png" alt=""><script defer src="index.js"></script>',
+      { 'index.js': 'console.log(1)' },
+    )
+
+    await stampHtml(htmlPath)
+    const html = await readPage(htmlPath)
+
+    expect(html).toContain('href="https://cdn.invalid/x.css"')
+    expect(html).toContain('src="/logo.png"')
+    expect(stampsOf(html)).toHaveLength(1)
+  })
+
+  it('should stamp an unknown file blank rather than drop it', () => {
+    // A reference whose asset never hashed keeps its shape, so the page
+    // still loads and its identity simply cannot match — the handshake's
+    // fail-open side.
+    expect(stampReferences('<script src="ghost.js"></script>', new Map())).toBe(
+      '<script src="ghost.js?v="></script>',
+    )
+  })
+
+  it('should report no identity for an unstamped page', async () => {
+    const htmlPath = await writePage(
+      'settings/index.html',
+      '<p>Nothing to stamp</p>',
+    )
+
+    await expect(stampHtml(htmlPath)).resolves.toBeNull()
+  })
+
+  it('should report no identity for an absent page copy', async () => {
+    await expect(
+      stampHtml(path.join(tree.outRoot, 'settings/index.html')),
+    ).resolves.toBeNull()
+  })
+
+  it('should emit the manifest once every page is stamped', async () => {
+    for (const { page } of PAGES) {
+      // eslint-disable-next-line no-await-in-loop -- sequential by design: one page tree written at a time
+      await writePage(page, '<script defer src="index.js"></script>', {
+        'index.js': `console.log('${page}')`,
+      })
+    }
+
+    await expect(stampPackagedPages(tree.outRoot, PAGES)).resolves.toBe(true)
+
+    const manifest: unknown = JSON.parse(
+      await readFile(path.join(tree.outRoot, 'webview-hashes.json'), 'utf8'),
+    )
+
+    expect(Object.keys(manifest as object)).toStrictEqual([
+      'settings',
+      'charts',
+    ])
+  })
+
+  it('should write no partial manifest outside the CLI flow', async () => {
+    // Only one page copy exists: a standalone suite run stamps nothing
+    // and must not leave a half-filled manifest behind.
+    await writePage(
+      PAGES[0]?.page ?? '',
+      '<script defer src="index.js"></script>',
+      { 'index.js': 'console.log(1)' },
+    )
+
+    await expect(stampPackagedPages(tree.outRoot, PAGES)).resolves.toBe(false)
+    await expect(
+      readFile(path.join(tree.outRoot, 'webview-hashes.json'), 'utf8'),
+    ).rejects.toThrow('ENOENT')
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,11 +4,18 @@ import { type ViteUserConfig, defineConfig } from 'vitest/config'
 const config: ViteUserConfig = defineConfig({
   test: {
     coverage: {
-      // The remaining webview exclusion shrinks as the real-coverage
-      // campaign lands zone by zone; never widen it.
+      // Named, file-scoped residue — never a directory sweep. The two
+      // packaging orchestrators hold no logic left to unit-test: table
+      // constants plus the esbuild and fs calls that consume them, every
+      // one of which `npm run build` and the vendored-definitions drift
+      // test already exercise end to end. Their logic lives in
+      // `webview-stamp.mts` and `sort-keys-deep.mts`, both covered. The
+      // charts exclusion shrinks to nothing as the campaign lands;
+      // never widen either.
       exclude: [
         '.homeybuild/**',
-        'scripts/**/*.mts',
+        'scripts/bundle.mts',
+        'scripts/sync-capability-definitions.mts',
         'widgets/charts/public/**/*.mts',
       ],
       include: ['**/*.mts'],


### PR DESCRIPTION
### The bug

The freshness handshake compares two joins that must agree by construction — and they didn't.

- **Page side** (the kit's `webview-freshness`): joins a `Set` of stamp **values**, so two assets with identical bytes contribute **one** stamp.
- **Bundler side** (`bundle.mts`): joined `hashes.values()` of a map keyed by **file**, so the same pair contributed **two**.

A page carrying two byte-identical assets would therefore advertise an identity the page can never produce: mismatch on every boot → one refetch through `?fresh=` → still a mismatch → `POST /boot-error`, for a page that was current all along.

No shipped page carries such a pair today — the byte-identical `zone-select.css` twins live in *different* pages, and the emitted manifest confirms the shared hash never repeats within one entry:

```
{"settings":"acbae477.f9c1e15f",
 "ata-group-setting":"9fcf30a8.8c64f5e4.…",
 "charts":"a916435e.8c64f5e4.ed73cc19"}
```

So this lands as the latent bug it is: fixed, and pinned by a test that fails the moment the dedup drifts back (verified by reintroducing the old join — `should join the identity over unique hashes, as the page does` goes red, alone).

Same defect found and fixed in the sibling extension app; this is its twin here.

### Structure and coverage

The stamping pass moves into `scripts/webview-stamp.mts` and the vendored-JSON key sort into `scripts/sort-keys-deep.mts` — both unit-tested against a temp packaging tree (13 tests: stamping only inside a reference context, remote/rooted references left alone, re-stamping an already-stamped page, identity movement on a CSS-only change, the manifest emitted only when every page copy exists). The orchestrators keep their tables and the esbuild/fs calls consuming them.

The coverage exclusion narrows from all of `scripts/**` to exactly `scripts/bundle.mts` and `scripts/sync-capability-definitions.mts` — named and file-scoped, in `vitest.config.ts` and `sonar-project.properties` together, with the reason in the config itself. Suite: 803 → 817 tests, 100% statements/branches/functions.

### Two smaller corrections

- **Positional captures.** Reading the reference groups off the replacer's parameters instead of `match.groups` drops four fallbacks no input could reach (`?? {}` plus a default per group) — TypeScript demanded them, the pattern made them dead.
- **`absWorkingDir`.** esbuild builds in a service process with its own working directory while the stamping reads through `node:fs` (the launcher's); both now anchor on an explicit repo root so they cannot disagree about where the packaged app lives.

CLAUDE.md records the by-value dedup rule on both sides, the new module split, the named exclusions, and one harness rule learned next door: a suite that simulates the clock must stub `Temporal.Now`, never `Date` — `temporal-polyfill` delegates to `globalThis.Temporal` where the runtime ships one (Node 26, the CI's "Node latest" leg), so a faked `Date` passes locally and fails only there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3