### PR TITLE
docs: settle whether the settings cascade fixes should be shared

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -185,6 +185,27 @@ coverage.
   (a class list silently missed renamed buttons).
   The kit's own suite locks the behavior — a change to the gate is a kit
   release, adopted here by an exact-pin bump.
+- Settings-CSS sharing — VERDICT (2026-08, after the `./dom` adoption):
+  the cascade fixes STAY LOCAL, in all three apps. Two independent
+  reasons, either sufficient. (1) The kit ships no stylesheet and
+  exports no CSS entry (`.`, `./dom`, `./manifest`, `./node`,
+  `./settings`, `./testing`, `./types`, `./webview`, `./widget` — all
+  JS): sharing them would mean inventing a CSS delivery path, and since
+  webviews load plain `<link>` tags from the packaged app, each app's
+  `bundle.mts` would have to copy the file into `.homeybuild` at
+  package time. That is a new packaging contract, not a 15-line move.
+  (2) Only about a third of the file is generic by construction — the
+  rules encoding a kit or SDK contract rather than app design:
+  `body fieldset[hidden]`, the `.homey-form-group` checkbox-set restack
+  and its sibling margin, `[class*='homey-button']:disabled`, the
+  `busy-scope` pair and the `fieldset[disabled]` pair (the dirty-gate
+  freeze contract), plus the `:indeterminate` checkmark. The rest is
+  this app's own: the zone select, the error-log table, the
+  `datetime-local` holiday inputs, the credentials summary and its
+  reset button. A shared file would therefore carry a minority of the
+  lines while adding a delivery mechanism to three apps. Revisit only
+  if the kit gains a stylesheet export for other reasons — never as a
+  standalone refactor.
 - The injected sheet resets `fieldset.homey-form-checkbox-set` /
   `-radio-set` with `all: unset`, which leaves `display: inline` — and
   WebKit renders inline fieldsets atomically, so SIBLING sets tile side


### PR DESCRIPTION
The measurement promised after the `./dom` adoption: are `settings/index.css`'s cascade fixes now identical by construction across the three apps, and should they move somewhere shared?

**Verdict: they stay local.** Two independent reasons, either sufficient on its own.

**1. There is nowhere to move them to.** `@olivierzal/homey-kit` ships no stylesheet and exports no CSS entry — its `exports` map is `.`, `./dom`, `./manifest`, `./node`, `./settings`, `./testing`, `./types`, `./webview`, `./widget`, all JavaScript. Webviews load plain `<link>` tags from the packaged app, so a shared stylesheet would additionally need each app's `bundle.mts` to copy it into `.homeybuild` at package time (and stamp it, since the page identity is the join of its `?v=` stamps). That is a new packaging contract across three apps, not a fifteen-line move.

**2. Only about a third of the file is generic anyway.** Rules encoding a kit or SDK contract rather than this app's design:

- `body fieldset[hidden]`
- `.homey-form-group fieldset.homey-form-checkbox-set` and its sibling margin
- `[class*='homey-button']:disabled`
- `body fieldset.busy-scope` + `fieldset.busy-scope:not([hidden])`
- `body fieldset[disabled]` + `fieldset[disabled] [class*='homey-button']:disabled`
- the `:indeterminate` checkmark

Everything else is this app's own: the zone select, the error-log table, the `datetime-local` holiday inputs, the credentials summary and its reset button. A shared file would carry a minority of the lines while adding a delivery mechanism to three apps.

One caveat I could not close inside this mandate's scope (com.melcloud only): I did not diff the three stylesheets byte for byte, so "identical by construction" is an argument from what each rule encodes, not a measured equality. It does not change the verdict — reason 1 stands regardless.

Revisit only if the kit gains a stylesheet export for other reasons; never as a standalone refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3