### PR TITLE
docs: use the platform's straight apostrophe in the French strings

### DIFF
--- a/.homeycompose/locales/fr.json
+++ b/.homeycompose/locales/fr.json
@@ -1,7 +1,7 @@
 {
   "errors": {
     "deviceNotFound": "Appareil introuvable.",
-    "energyReportsFailing": "Les rapports d’énergie ont échoué plusieurs fois de suite — les valeurs d’énergie peuvent être obsolètes.",
+    "energyReportsFailing": "Les rapports d'énergie ont échoué plusieurs fois de suite — les valeurs d'énergie peuvent être obsolètes.",
     "invalidDuration": "La durée doit être un nombre entier de jours entre 0 et 365.",
     "invalidHolidayModeEnd": "La fin du mode vacances doit être dans le futur.",
     "invalidTime": "L'heure de fin n'est pas valide.",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -3,7 +3,7 @@
     "deviceNotFound": "Appareil introuvable.",
     "zoneNotFound": "Zone introuvable.",
     "invalidDuration": "La durée doit être un nombre entier de jours entre 0 et 365.",
-    "energyReportsFailing": "Les rapports d’énergie ont échoué plusieurs fois de suite — les valeurs d’énergie peuvent être obsolètes.",
+    "energyReportsFailing": "Les rapports d'énergie ont échoué plusieurs fois de suite — les valeurs d'énergie peuvent être obsolètes.",
     "invalidTime": "L'heure de fin n'est pas valide.",
     "invalidHolidayModeEnd": "La fin du mode vacances doit être dans le futur.",
     "unitOffline": "MELCloud signale cette unité hors ligne — vérifiez sa connexion Wi-Fi.",


### PR DESCRIPTION
Audit of every localized string in the three apps against homey-lib's corpus (936 French strings across capability titles, descriptions and flow hints).

homey-lib writes the apostrophe straight — 274 occurrences against 2 typographic. This app matched it in 60 strings and diverged in one, which also made the app internally inconsistent with itself. Two apostrophes in `errors.energyReportsFailing`.

Everything else measured as already aligned: the device term (`appareil`, as homey-lib), Russian guillemets, and no percent or quotation conflicts anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3