### PR TITLE
test(scripts): measure the two build scripts, closing the last coverage exclusions

### DIFF
--- a/scripts/bundle.mts
+++ b/scripts/bundle.mts
@@ -15,15 +15,9 @@ import { stampPackagedPages } from './webview-stamp.mts'
 // The IIFE global each page's inline `onHomeyReady` reads `start` from.
 const GLOBAL_NAME = 'MELCloudWebview'
 
-// esbuild runs its build in a service process with its own working
-// directory, while the stamping pass reads and writes through `node:fs`
-// (the launcher's cwd): both are anchored at the repo root so they
-// cannot disagree about where the packaged app lives.
-const ROOT = path.resolve(import.meta.dirname, '..')
-
 // The Homey CLI's packaging target: `tsc` already emits here (its
 // validated `outDir`), and the CLI packs exactly this directory.
-const OUT_ROOT = path.join(ROOT, '.homeybuild')
+const OUT_ROOT = '.homeybuild'
 
 const entryPoints = [
   'widgets/ata-group-setting/public/index.mts',
@@ -45,7 +39,12 @@ const pages = [
 ]
 
 const sharedOptions: BuildOptions = {
-  absWorkingDir: ROOT,
+  // Pinned at load: esbuild's service process outlives this module and
+  // keeps its own working directory, so relative entries must be
+  // anchored to the app root explicitly. The stamping pass reads and
+  // writes through `node:fs` (the launcher's cwd), so both halves land
+  // in the same packaged app.
+  absWorkingDir: process.cwd(),
   bundle: true,
   legalComments: 'none',
   logLevel: 'info',

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,5 +3,5 @@ sonar.organization=olivierzal
 sonar.sourceEncoding=UTF-8
 sonar.javascript.lcov.reportPaths=./coverage/lcov.info
 sonar.exclusions=**/*.jpg,**/*.png,coverage/**
-sonar.coverage.exclusions=tests/**,**/*.config.*,scripts/bundle.mts,scripts/sync-capability-definitions.mts
+sonar.coverage.exclusions=tests/**,**/*.config.*
 sonar.cpd.exclusions=**/*.config.*,settings/index.html,widgets/*/public/index.html

--- a/tests/unit/bundle.test.ts
+++ b/tests/unit/bundle.test.ts
@@ -1,0 +1,121 @@
+import { createHash } from 'node:crypto'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// The bundler is a top-level-await script working against the current
+// directory (the Homey CLI runs it from the packaged app's root), so
+// each test materializes a miniature app in a temp directory, moves
+// there, and imports the script afresh. The stamping semantics it calls
+// into are pinned separately, in tests/unit/webview-stamp.test.ts: what
+// belongs here is the bundler's own wiring — a compat pair per entry,
+// and the manifest key each packaged page is served under.
+const HASH_LENGTH = 8
+
+const initialDirectory = process.cwd()
+
+// One source per entry, each with its own body: byte-distinct bundles
+// give byte-distinct identities, so the manifest proves it maps every
+// key to the right page rather than to a coincidence.
+const entrySource = (name: string): string =>
+  `export const start = (value?: string): string => value ?? '${name}'\n`
+
+const pageHtml =
+  '<html><head><script defer src="index.js"></script></head></html>'
+
+// The entries the bundler declares, with the manifest key each page is
+// served under (`GET /webview-hashes`).
+const ENTRIES = [
+  { directory: 'settings', entry: 'settings' },
+  { directory: 'widgets/ata-group-setting/public', entry: 'ata-group-setting' },
+  { directory: 'widgets/charts/public', entry: 'charts' },
+]
+
+const hashOf = (content: string | Buffer): string =>
+  createHash('sha256').update(content).digest('hex').slice(0, HASH_LENGTH)
+
+// Cwd-relative on purpose: every test runs from inside its own temp
+// app, exactly where the Homey CLI runs the script from.
+const seedApp = async (): Promise<void> => {
+  await Promise.all(
+    ENTRIES.map(async ({ directory, entry }) => {
+      await mkdir(directory, { recursive: true })
+      await writeFile(path.join(directory, 'index.mts'), entrySource(entry))
+    }),
+  )
+}
+
+const seedPackagedPages = async (): Promise<void> => {
+  await Promise.all(
+    ENTRIES.map(async ({ directory }) => {
+      const packaged = path.join('.homeybuild', directory)
+      await mkdir(packaged, { recursive: true })
+      await writeFile(path.join(packaged, 'index.html'), pageHtml)
+    }),
+  )
+}
+
+const runBundler = async (): Promise<void> => {
+  vi.resetModules()
+  await import('../../scripts/bundle.mts')
+}
+
+const packagedFile = async (relativePath: string): Promise<string> =>
+  readFile(path.join('.homeybuild', relativePath), 'utf8')
+
+describe('bundle script', () => {
+  let workDirectory = ''
+
+  beforeEach(async () => {
+    workDirectory = await mkdtemp(path.join(tmpdir(), 'bundle-'))
+    process.chdir(workDirectory)
+    await seedApp()
+  })
+
+  afterEach(async () => {
+    process.chdir(initialDirectory)
+    await rm(workDirectory, { force: true, recursive: true })
+  })
+
+  it.each(ENTRIES)(
+    'should emit the compat pair of $entry into the packaged app',
+    async ({ directory }) => {
+      await runBundler()
+
+      const iife = await packagedFile(path.join(directory, 'index.js'))
+      const esm = await packagedFile(path.join(directory, 'index.mjs'))
+
+      expect(iife).toContain('var MELCloudWebview')
+      expect(iife).not.toContain('export')
+      expect(esm).toContain('export')
+      // es2020 target: nullish coalescing ships as-is, unlowered
+      expect(iife).toContain('??')
+    },
+  )
+
+  it('should serve every packaged page under its own manifest key', async () => {
+    await seedPackagedPages()
+
+    await runBundler()
+
+    const identities = await Promise.all(
+      ENTRIES.map(async ({ directory, entry }): Promise<[string, string]> => [
+        entry,
+        hashOf(await packagedFile(path.join(directory, 'index.js'))),
+      ]),
+    )
+    const manifest: unknown = JSON.parse(
+      await packagedFile('webview-hashes.json'),
+    )
+
+    expect(manifest).toStrictEqual(Object.fromEntries(identities))
+  })
+
+  it('should stamp nothing in a standalone suite run', async () => {
+    await runBundler()
+
+    await expect(packagedFile('webview-hashes.json')).rejects.toThrow('ENOENT')
+  })
+})

--- a/tests/unit/sync-capability-definitions.test.ts
+++ b/tests/unit/sync-capability-definitions.test.ts
@@ -1,0 +1,102 @@
+import {
+  mkdir,
+  mkdtemp,
+  readdir,
+  readFile,
+  rm,
+  writeFile,
+} from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// The sync script is a top-level-await script reading and writing
+// through the current directory, so each test materializes a miniature
+// app — a stand-in homey-lib plus an empty vendor directory — moves
+// there, and imports the script afresh. The key ordering it applies is
+// pinned separately, in tests/unit/sort-keys-deep.test.ts: what belongs
+// here is the script's own wiring — which capabilities it vendors, from
+// where, and in what on-disk form.
+const initialDirectory = process.cwd()
+
+const LIB_ROOT = 'node_modules/homey-lib/assets/capability/capabilities'
+
+const VENDOR_ROOT = 'vendor/capabilities'
+
+const VENDORED = ['fan_speed', 'onoff', 'target_temperature', 'thermostat_mode']
+
+// Raw JSON bytes rather than an object literal, and deliberately
+// unsorted: what the script contracts on is the LAYOUT of the file it
+// writes, so the fixture has to be an on-disk order — one an object
+// literal could not hold, since the repo's own key sorting applies to
+// source too.
+const definitionOf = (capability: string): string =>
+  `{"type":"number","getable":true,"id":"${capability}","$flow":{"actions":[{"args":[{"step":0.5}]}]}}`
+
+const seedApp = async (capabilities: readonly string[]): Promise<void> => {
+  await mkdir(LIB_ROOT, { recursive: true })
+  await mkdir(VENDOR_ROOT, { recursive: true })
+  await Promise.all(
+    capabilities.map(async (capability) =>
+      writeFile(
+        path.join(LIB_ROOT, `${capability}.json`),
+        definitionOf(capability),
+      ),
+    ),
+  )
+}
+
+const runSync = async (): Promise<void> => {
+  vi.resetModules()
+  await import('../../scripts/sync-capability-definitions.mts')
+}
+
+describe('capability definition sync', () => {
+  let workDirectory = ''
+
+  beforeEach(async () => {
+    workDirectory = await mkdtemp(path.join(tmpdir(), 'sync-'))
+    process.chdir(workDirectory)
+  })
+
+  afterEach(async () => {
+    process.chdir(initialDirectory)
+    await rm(workDirectory, { force: true, recursive: true })
+  })
+
+  it('should vendor exactly the capabilities the drivers consume', async () => {
+    // A capability homey-lib ships but no driver consumes must not be
+    // vendored: the copies are what reaches the device.
+    await seedApp([...VENDORED, 'dim'])
+
+    await runSync()
+
+    const vendored = await readdir(VENDOR_ROOT)
+
+    expect(
+      vendored.toSorted((left, right) => left.localeCompare(right, 'en')),
+    ).toStrictEqual(VENDORED.map((capability) => `${capability}.json`))
+  })
+
+  it('should write homey-lib values, sorted and newline-terminated', async () => {
+    await seedApp(VENDORED)
+
+    await runSync()
+
+    const written = await readFile(path.join(VENDOR_ROOT, 'onoff.json'), 'utf8')
+
+    expect(written).toBe(
+      `${JSON.stringify(
+        {
+          $flow: { actions: [{ args: [{ step: 0.5 }] }] },
+          getable: true,
+          id: 'onoff',
+          type: 'number',
+        },
+        undefined,
+        2,
+      )}\n`,
+    )
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -16,11 +16,7 @@ const config: ViteUserConfig = defineConfig({
       // the template for closing these two.
       //
       // Every webview surface of this app is at a real 100 %.
-      exclude: [
-        '.homeybuild/**',
-        'scripts/bundle.mts',
-        'scripts/sync-capability-definitions.mts',
-      ],
+      exclude: ['.homeybuild/**'],
       include: ['**/*.mts'],
       reporter: ['text', 'lcov'],
       thresholds: {


### PR DESCRIPTION
The bundler and the capability-definition sync were the last two coverage exclusions outside build output. Both run on every package, and neither had a single assertion behind it.

## Bundler anchoring

`scripts/bundle.mts` was the only one of the three apps resolving its paths through `import.meta.dirname`; com.heatzy and com.melcloud.extension both anchor at the launcher's cwd. That divergence is what made the proven temp-app test model inapplicable here, so the bundler now matches its siblings.

Production behaviour is unchanged — the Homey CLI runs `npm run build` from the app root. Verified on the real CLI flow rather than by reasoning: `homey:validate` stamps all three packaged pages and emits the complete manifest.

```
{"settings":"acbae477.7b5ec8c5","ata-group-setting":"9fcf30a8.…","charts":"a916435e.…"}
```

## What the tests pin

The stamping semantics are already pinned at unit level in `webview-stamp.test.ts` (12 cases), so `bundle.test.ts` covers only the bundler's own wiring: a compat pair per entry, `es2020` shipping `??` unlowered, and the manifest key each packaged page is served under — proven with byte-distinct sources so the mapping cannot pass by coincidence.

`sync-capability-definitions.test.ts` covers the sync's wiring the same way, key sorting being pinned in `sort-keys-deep.test.ts`: which capabilities are vendored (a capability homey-lib ships but no driver consumes must stay out), from where, and in what on-disk form.

## Coverage

100 % of statements (2675), branches (1047), functions (933) and lines (2646), with `.homeybuild/**` as the only exclusion left in `vitest.config.ts` — and `sonar.coverage.exclusions` down to tests and configs. No app in the family now excludes anything but its build output.

**No ignore directive was introduced**, here or anywhere: `v8 ignore` / `c8 ignore` / `istanbul ignore` are at zero across all seven repos. The one lint conflict — a deliberately unsorted fixture against `perfectionist/sort-objects` — was resolved by restructuring rather than suppressing: the fixture is now raw JSON bytes, which is the truer form anyway, since what the script contracts on is the layout of the file it writes.

Full suite green: format, lint, typecheck, 936 tests, build, `homey:validate` at publish level (which rewrote nothing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3