### PR TITLE
test(widget): pin the rolling-window default in the charts picker

### DIFF
--- a/tests/unit/charts.test.ts
+++ b/tests/unit/charts.test.ts
@@ -425,6 +425,22 @@ describe('charts widget', () => {
     expect(optionValues(getSelect('days')).at(0)).not.toBe('0')
   })
 
+  it('should open on the rolling window when it is the stored default', async () => {
+    await boot({ settings: { days: 0 } })
+
+    expect(getSelect('days').value).toBe('0')
+  })
+
+  it('should fall back to a real day count when the rolling window is gone', async () => {
+    await boot({ settings: { chart: 'report', days: 0 } })
+    commit(getSelect('zones'), 'devices_12')
+    await settleDetached()
+
+    // A default no option can express must not empty the picker: the
+    // guarded write leaves the first real day count selected.
+    expect(getSelect('days').value).toBe('1')
+  })
+
   it('should keep the day choices within the published bounds', async () => {
     await boot({ settings: { days: 9999 } })
 


### PR DESCRIPTION
Lowering the `days` minimum to 0 made "last 24 hours" reachable as a stored default, and nothing pinned what the picker does with it. Two tests close that:

- `days: 0` at widget open selects the rolling-window option.
- On a Classic ATW report — the one chart whose wire never buckets energy under a day, so the option is not built — the picker falls back to the first real day count instead of going blank.

Both fail when `applySelectValue`'s existence guard is removed (mutation-checked), so they bite on the guard rather than on incidental ordering. Coverage stays at 100 % on all four axes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3