### PR TITLE
chore: adopt @olivierzal/configs 1.8.0 and let Prettier format HTML

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -4,7 +4,7 @@ jobs:
     permissions:
       contents: read
       packages: read
-    uses: OlivierZal/configs/.github/workflows/reusable-audit.yml@262b014bfa89bca8ff1bf8799b50a95f8552b3f2 # v1.6.0
+    uses: OlivierZal/configs/.github/workflows/reusable-audit.yml@91cfb98049d20d3c62d1f21b34a4769672040d95 # v1.8.0
 name: Audit
 on:
   push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,12 +6,18 @@ jobs:
       packages: read
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/reusable-ci.yml@262b014bfa89bca8ff1bf8799b50a95f8552b3f2 # v1.6.0
+    uses: OlivierZal/configs/.github/workflows/reusable-ci.yml@91cfb98049d20d3c62d1f21b34a4769672040d95 # v1.8.0
     with:
       check-node-version: '22'
-      # The fleet's Node major — measured 22.20/22.23 on-device
-      # (2026-08); the coverage/Sonar leg tracks it, not lts/*.
-      coverage-node-version: '22'
+      # The coverage/Sonar leg runs on the fleet's FLOOR, not lts/*:
+      # 22.20 (Pro 2019, firmware 13.4.1-rc) against 22.23 (Pro 2023),
+      # both measured on-device (2026-08). A bare '22' resolves to the
+      # head of the line and drifts off that floor at every release.
+      # Quoting is load-bearing: unquoted, JSON reads 22.20 as the
+      # number 22.2 — a three-year-old release, and a leg name that
+      # never matches. The reusable workflow's guard rejects both.
+      coverage-node-version: '22.20'
+      node-versions: '["22", "22.20", "latest", "lts/*"]'
 name: CI
 on:
   merge_group: {}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -8,7 +8,7 @@ jobs:
       pull-requests: write
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/claude-code-review.yml@262b014bfa89bca8ff1bf8799b50a95f8552b3f2 # v1.6.0
+    uses: OlivierZal/configs/.github/workflows/claude-code-review.yml@91cfb98049d20d3c62d1f21b34a4769672040d95 # v1.8.0
 name: claude-code-review
 on:
   pull_request:

--- a/.github/workflows/claude-dependabot-fix.yml
+++ b/.github/workflows/claude-dependabot-fix.yml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: read
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/reusable-claude-dependabot-fix.yml@262b014bfa89bca8ff1bf8799b50a95f8552b3f2 # v1.6.0
+    uses: OlivierZal/configs/.github/workflows/reusable-claude-dependabot-fix.yml@91cfb98049d20d3c62d1f21b34a4769672040d95 # v1.8.0
     with:
       repo-guidance: 'API bugs surfacing through @olivierzal/melcloud-api are fixed in that library, never worked around in this app. When the bump is @olivierzal/configs, realign every `uses: OlivierZal/configs/...` ref in .github/workflows to the tag matching the new npm pin, comment included — one version covers both channels. Stop and leave the pull request failing for human review when that release changes lint policy: adopting it needs per-repository judgement no automated fix can make.'
       verify-commands: '`npm run format`, `npm run lint`, `npm run typecheck`, `npm test`, and `npm run build`'

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -6,7 +6,7 @@ jobs:
       issues: write
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/claude-issue-triage.yml@262b014bfa89bca8ff1bf8799b50a95f8552b3f2 # v1.6.0
+    uses: OlivierZal/configs/.github/workflows/claude-issue-triage.yml@91cfb98049d20d3c62d1f21b34a4769672040d95 # v1.8.0
 name: claude-issue-triage
 on:
   issues:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -11,7 +11,7 @@ jobs:
       pull-requests: read
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/claude.yml@262b014bfa89bca8ff1bf8799b50a95f8552b3f2 # v1.6.0
+    uses: OlivierZal/configs/.github/workflows/claude.yml@91cfb98049d20d3c62d1f21b34a4769672040d95 # v1.8.0
 name: claude
 on:
   # No pull_request_review(_comment): Copilot auto-review fires them as a

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -4,7 +4,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: OlivierZal/configs/.github/workflows/dependabot.yml@262b014bfa89bca8ff1bf8799b50a95f8552b3f2 # v1.6.0
+    uses: OlivierZal/configs/.github/workflows/dependabot.yml@91cfb98049d20d3c62d1f21b34a4769672040d95 # v1.8.0
 name: dependabot
 on:
   pull_request: {}

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -3,7 +3,7 @@ jobs:
   pr_title:
     permissions:
       pull-requests: read
-    uses: OlivierZal/configs/.github/workflows/pr-title.yml@262b014bfa89bca8ff1bf8799b50a95f8552b3f2 # v1.6.0
+    uses: OlivierZal/configs/.github/workflows/pr-title.yml@91cfb98049d20d3c62d1f21b34a4769672040d95 # v1.8.0
 name: pr-title
 on:
   pull_request:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -5,7 +5,7 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    uses: OlivierZal/configs/.github/workflows/zizmor.yml@262b014bfa89bca8ff1bf8799b50a95f8552b3f2 # v1.6.0
+    uses: OlivierZal/configs/.github/workflows/zizmor.yml@91cfb98049d20d3c62d1f21b34a4769672040d95 # v1.8.0
 name: zizmor
 on:
   merge_group: {}

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,3 @@
-*.html
 # Written by the Homey CLI on every preprocess, without a trailing
 # newline, and committed in that exact form: Prettier would add the
 # newline back and put the tree out of step with the next CLI run.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,9 +11,17 @@ Run the FULL suite before any push — CI runs all of it and each step has
 caught real failures that the others miss:
 
 - `npm run format` / `npm run format:fix` — prettier (eslint does NOT
-  cover formatting).
+  cover formatting). It owns `.html` layout too: indentation, attribute
+  wrapping and the ` />` on void elements are its call, and the
+  `html/` rules that contradicted that output are off in the preset.
+  Only `coverage/` and `.homeybuild/` escape it, through `.gitignore` —
+  the pages under them are generated.
 - `npm run lint` / `npm run lint:fix` — ESLint (needs its 8 GB heap; also
-  lints CSS and HTML via the css/html plugins).
+  lints CSS and HTML via the css/html plugins). What the html plugin
+  keeps is what prettier does NOT do: `head-order`, `sort-attrs` (`id`
+  before `class`, then alphabetical — the pages already comply, so its
+  silence means conformance, not absence) and
+  `no-whitespace-only-children`, plus the quality rules.
 - `npm run typecheck` — `tsc` from `@typescript/native` (TypeScript 7).
 - `npm test` / `npm run test:coverage` — vitest; branches are at 100%,
   keep them there.
@@ -33,6 +41,9 @@ caught real failures that the others miss:
   every local asset reference of the `.homeybuild` page copies with a
   content hash (`?v=<hash>`), so phone webviews (which cache assets
   across app versions) refetch an asset exactly when its bytes change.
+  The pattern anchors on `href="` / `src="` as one unit, so a reference
+  survives prettier splitting a long tag across lines; a leading `/`
+  is barred, which is what keeps the SDK's `/homey.js` unstamped.
   The committed source HTML carries NO stamps — never hand-add a `?v=`
   there, and nothing needs re-committing when a webview source changes
   (the old re-stamp-and-commit dance is gone). Stamps exist only in the

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "temporal-polyfill": "^1.0.1"
       },
       "devDependencies": {
-        "@olivierzal/configs": "1.6.0",
+        "@olivierzal/configs": "1.8.0",
         "@types/homey": "npm:homey-apps-sdk-v3-types@^0.3.12",
         "@types/node": "^26.1.2",
         "@typescript/native": "npm:typescript@^7.0.2",
@@ -1071,9 +1071,9 @@
       }
     },
     "node_modules/@olivierzal/configs": {
-      "version": "1.6.0",
-      "resolved": "https://npm.pkg.github.com/download/@olivierzal/configs/1.6.0/474d9fe4cb9ff56cee39a9e62660cb26f9fd71ed",
-      "integrity": "sha512-l+JqAg4eXdPjQFxRKqK1jZg86ki67MAVqJq6wesx5ZrKULic+NDMG0UNT+zf3dC0He+6Jh/rpvZPdxYWlpO6nw==",
+      "version": "1.8.0",
+      "resolved": "https://npm.pkg.github.com/download/@olivierzal/configs/1.8.0/d708e6a3522b167c2f6151a8cd95113813a87ffb",
+      "integrity": "sha512-GfpGEX1SouX/o4gzDvM4oYmDNObCFKgLCPdM0f/Qa/LqZ7Ra0TQzrthM3NDsey6ru9R9BryVlZ+qgJTwzG6KmA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "temporal-polyfill": "^1.0.1"
   },
   "devDependencies": {
-    "@olivierzal/configs": "1.6.0",
+    "@olivierzal/configs": "1.8.0",
     "@types/homey": "npm:homey-apps-sdk-v3-types@^0.3.12",
     "@types/node": "^26.1.2",
     "@typescript/native": "npm:typescript@^7.0.2",

--- a/settings/index.html
+++ b/settings/index.html
@@ -1,374 +1,410 @@
 <!doctype html>
 <html lang="en">
-    <head>
-        <meta charset="utf-8">
-        <meta content="width=device-width, initial-scale=1.0" name="viewport">
-        <title>MELCloud Settings</title>
-        <script>
-            // The page bundle loads as a classic defer script, not an ES
-            // module: a static module script stalls the whole boot on a
-            // cold webview open (a stalled module fetch also blocks
-            // onHomeyReady — proven on-device), while classic scripts,
-            // like the stylesheet, load cold. The poll keeps the boot
-            // bounded: it hands the instance to the bundle's start once
-            // it is up, or reports why and ends the overlay if it never
-            // arrives.
-            function onHomeyReady(homey) {
-                const deadline = Date.now() + 10000
-                const waitForBundle = () => {
-                    if (globalThis.MELCloudWebview) {
-                        globalThis.MELCloudWebview.start(homey)
-                    } else if (Date.now() > deadline) {
-                        // Boot beacon: the bundle never booted — report WHY
-                        // before degrading. A 200 probe with no global means
-                        // the script fetched but failed to parse/run (old
-                        // engine); a probe error means the fetch itself
-                        // fails on this device.
-                        const script = document.querySelector('script[src*="index.js"]')
-                        const report = (probe) => {
-                            homey.api('POST', '/boot-error', { message: 'The settings bundle did not boot within 10s', name: 'BootTimeout', probe, userAgent: navigator.userAgent }, () => {})
-                            homey.ready()
-                            homey.alert(homey.__('settings.loadFailed')).catch(() => {})
-                        }
-                        fetch(script ? script.src : 'index.js')
-                            .then((response) => { report('fetch ' + String(response.status)) })
-                            .catch((error) => { report('fetch failed: ' + String(error)) })
-                    } else {
-                        setTimeout(waitForBundle, 50)
-                    }
-                }
-                waitForBundle()
+  <head>
+    <meta charset="utf-8" />
+    <meta content="width=device-width, initial-scale=1.0" name="viewport" />
+    <title>MELCloud Settings</title>
+    <script>
+      // The page bundle loads as a classic defer script, not an ES
+      // module: a static module script stalls the whole boot on a
+      // cold webview open (a stalled module fetch also blocks
+      // onHomeyReady — proven on-device), while classic scripts,
+      // like the stylesheet, load cold. The poll keeps the boot
+      // bounded: it hands the instance to the bundle's start once
+      // it is up, or reports why and ends the overlay if it never
+      // arrives.
+      function onHomeyReady(homey) {
+        const deadline = Date.now() + 10000
+        const waitForBundle = () => {
+          if (globalThis.MELCloudWebview) {
+            globalThis.MELCloudWebview.start(homey)
+          } else if (Date.now() > deadline) {
+            // Boot beacon: the bundle never booted — report WHY
+            // before degrading. A 200 probe with no global means
+            // the script fetched but failed to parse/run (old
+            // engine); a probe error means the fetch itself
+            // fails on this device.
+            const script = document.querySelector('script[src*="index.js"]')
+            const report = (probe) => {
+              homey.api(
+                'POST',
+                '/boot-error',
+                {
+                  message: 'The settings bundle did not boot within 10s',
+                  name: 'BootTimeout',
+                  probe,
+                  userAgent: navigator.userAgent,
+                },
+                () => {},
+              )
+              homey.ready()
+              homey.alert(homey.__('settings.loadFailed')).catch(() => {})
             }
-        </script>
-        <link href="index.css" rel="stylesheet">
-        <script defer src="index.js"></script>
-        <script data-origin="settings" defer src="/homey.js"></script>
-        <meta content="MELCloud settings" name="description">
-    </head>
-    <body>
-        <header class="homey-header">
-            <h1
-                class="homey-title"
-                data-i18n="settings.title"
-            >MELCloud settings</h1>
-        </header>
-        <!-- Collapsible: folded when both APIs are signed in (the
+            fetch(script ? script.src : 'index.js')
+              .then((response) => {
+                report('fetch ' + String(response.status))
+              })
+              .catch((error) => {
+                report('fetch failed: ' + String(error))
+              })
+          } else {
+            setTimeout(waitForBundle, 50)
+          }
+        }
+        waitForBundle()
+      }
+    </script>
+    <link href="index.css" rel="stylesheet" />
+    <script defer src="index.js"></script>
+    <script data-origin="settings" defer src="/homey.js"></script>
+    <meta content="MELCloud settings" name="description" />
+  </head>
+  <body>
+    <header class="homey-header">
+      <h1 class="homey-title" data-i18n="settings.title">MELCloud settings</h1>
+    </header>
+    <!-- Collapsible: folded when both APIs are signed in (the
             credentials are settled), expanded while at least one is not. -->
-        <details id="authentication" class="homey-form-fieldset">
-            <summary class="homey-form-legend" data-i18n="settings.authenticate.legend">Credentials</summary>
-            <!-- One fieldset so a single `disabled` flip freezes every
+    <details id="authentication" class="homey-form-fieldset">
+      <summary
+        class="homey-form-legend"
+        data-i18n="settings.authenticate.legend"
+      >
+        Credentials
+      </summary>
+      <!-- One fieldset so a single `disabled` flip freezes every
                 region the credentials snapshot reads (API choice
                 included) while a request is in flight. -->
-            <fieldset id="login_panel" class="busy-scope">
-                <div class="homey-form-group">
-                    <!-- The accessible name "API" is language-neutral (reads
+      <fieldset id="login_panel" class="busy-scope">
+        <div class="homey-form-group">
+          <!-- The accessible name "API" is language-neutral (reads
                         identically in all 13 locales), so it deliberately
                         carries no data-i18n-aria-label. -->
-                    <select
-                        id="api"
-                        class="homey-form-select"
-                        aria-label="API"
-                    >
-                        <option value="classic">Classic</option>
-                        <option value="home">Home</option>
-                    </select>
-                </div>
-                <div id="login"></div>
-                <div class="homey-form-group container">
-                    <button
-                        id="reset_credentials"
-                        type="button"
-                        class="homey-button-primary-full"
-                        data-i18n="settings.authenticate.reset"
-                    >Reset</button>
-                    <button
-                        id="authenticate"
-                        type="button"
-                        class="homey-button-primary-full"
-                        data-i18n="settings.authenticate.button"
-                    >Log in</button>
-                </div>
-            </fieldset>
-        </details>
-        <!-- Shown when at least one API is authenticated — hidden by default to prevent flash -->
-        <div id="content" hidden>
-            <fieldset class="homey-form-fieldset">
-                <legend class="homey-form-legend" data-i18n="settings.errorLog.legend">Error history</legend>
-                <div class="homey-form-group container">
-                    <button
-                        id="see"
-                        type="button"
-                        class="homey-button-secondary-shadow"
-                        data-i18n="settings.errorLog.see"
-                    >See all errors</button>
-                    <div class="container-inline-end">
-                        <label
-                            class="homey-form-label unset-margin"
-                            data-i18n="settings.errorLog.since"
-                            for="since"
-                        >since</label>
-                        <input
-                            id="since"
-                            type="date"
-                        >
-                    </div>
-                </div>
-                <div id="error_log" class="homey-form-group">
-                    <div class="container-inline-end">
-                        <span
-                            id="period"
-                            class="homey-form-label unset-margin bolded"
-                        ></span>
-                        <span
-                            id="error_count"
-                            class="homey-form-label unset-margin"
-                            aria-live="polite"
-                        ></span>
-                    </div>
-                </div>
-            </fieldset>
-            <fieldset id="settings_common_section" class="homey-form-fieldset">
-                <legend class="homey-form-legend" data-i18n="settings.devices.legend">All device settings</legend>
-                <div id="settings_common"></div>
-                <div class="homey-form-group container">
-                    <button
-                        id="refresh_settings_common"
-                        type="button"
-                        class="homey-button-secondary-shadow"
-                        data-i18n="settings.refresh"
-                    >Refresh</button>
-                    <button
-                        id="apply_settings_common"
-                        type="button"
-                        class="homey-button-danger-shadow"
-                        data-i18n="settings.update"
-                    >Update</button>
-                </div>
-            </fieldset>
-            <!-- Air-to-air temperature auto-adjust: a link to the
+          <select id="api" class="homey-form-select" aria-label="API">
+            <option value="classic">Classic</option>
+            <option value="home">Home</option>
+          </select>
+        </div>
+        <div id="login"></div>
+        <div class="homey-form-group container">
+          <button
+            id="reset_credentials"
+            type="button"
+            class="homey-button-primary-full"
+            data-i18n="settings.authenticate.reset"
+          >
+            Reset
+          </button>
+          <button
+            id="authenticate"
+            type="button"
+            class="homey-button-primary-full"
+            data-i18n="settings.authenticate.button"
+          >
+            Log in
+          </button>
+        </div>
+      </fieldset>
+    </details>
+    <!-- Shown when at least one API is authenticated — hidden by default to prevent flash -->
+    <div id="content" hidden>
+      <fieldset class="homey-form-fieldset">
+        <legend class="homey-form-legend" data-i18n="settings.errorLog.legend">
+          Error history
+        </legend>
+        <div class="homey-form-group container">
+          <button
+            id="see"
+            type="button"
+            class="homey-button-secondary-shadow"
+            data-i18n="settings.errorLog.see"
+          >
+            See all errors
+          </button>
+          <div class="container-inline-end">
+            <label
+              class="homey-form-label unset-margin"
+              data-i18n="settings.errorLog.since"
+              for="since"
+              >since</label
+            >
+            <input id="since" type="date" />
+          </div>
+        </div>
+        <div id="error_log" class="homey-form-group">
+          <div class="container-inline-end">
+            <span
+              id="period"
+              class="homey-form-label unset-margin bolded"
+            ></span>
+            <span
+              id="error_count"
+              class="homey-form-label unset-margin"
+              aria-live="polite"
+            ></span>
+          </div>
+        </div>
+      </fieldset>
+      <fieldset id="settings_common_section" class="homey-form-fieldset">
+        <legend class="homey-form-legend" data-i18n="settings.devices.legend">
+          All device settings
+        </legend>
+        <div id="settings_common"></div>
+        <div class="homey-form-group container">
+          <button
+            id="refresh_settings_common"
+            type="button"
+            class="homey-button-secondary-shadow"
+            data-i18n="settings.refresh"
+          >
+            Refresh
+          </button>
+          <button
+            id="apply_settings_common"
+            type="button"
+            class="homey-button-danger-shadow"
+            data-i18n="settings.update"
+          >
+            Update
+          </button>
+        </div>
+      </fieldset>
+      <!-- Air-to-air temperature auto-adjust: a link to the
                 companion extension app, shown when devices of either
                 air-to-air driver (Classic or Home) exist. Not part of
                 the generated per-driver sections. -->
-            <div id="auto_adjust_section" hidden>
-                <fieldset class="homey-form-fieldset">
-                    <legend class="homey-form-legend" data-i18n="settings.devicesAta.legend">All air-to-air device settings</legend>
-                    <div class="homey-form-group">
-                        <label
-                            class="homey-form-label"
-                            data-i18n="settings.devicesAta.autoAdjust"
-                            for="auto_adjust"
-                        >Auto-adjust air conditioning temperature</label>
-                    </div>
-                    <div class="homey-form-group">
-                        <button
-                            id="auto_adjust"
-                            type="button"
-                            class="homey-button-secondary-shadow-full"
-                            data-i18n="settings.devicesAta.configure"
-                        >Configure</button>
-                    </div>
-                </fieldset>
-            </div>
-            <!-- One section per driver that has devices is generated here at
+      <div id="auto_adjust_section" hidden>
+        <fieldset class="homey-form-fieldset">
+          <legend
+            class="homey-form-legend"
+            data-i18n="settings.devicesAta.legend"
+          >
+            All air-to-air device settings
+          </legend>
+          <div class="homey-form-group">
+            <label
+              class="homey-form-label"
+              data-i18n="settings.devicesAta.autoAdjust"
+              for="auto_adjust"
+              >Auto-adjust air conditioning temperature</label
+            >
+          </div>
+          <div class="homey-form-group">
+            <button
+              id="auto_adjust"
+              type="button"
+              class="homey-button-secondary-shadow-full"
+              data-i18n="settings.devicesAta.configure"
+            >
+              Configure
+            </button>
+          </div>
+        </fieldset>
+      </div>
+      <!-- One section per driver that has devices is generated here at
                 runtime (legend = the driver's own name); no markup is
                 duplicated per driver, so a new driver needs nothing added. -->
-            <div id="device_settings"></div>
-            <fieldset class="homey-form-fieldset zone-device-settings">
-                <legend class="homey-form-legend" data-i18n="settings.zones.legend">Zone and device settings</legend>
-                <div class="homey-form-group">
-                    <select
-                        id="zones"
-                        class="homey-form-select"
-                        aria-label="Zones"
-                        data-i18n-aria-label="widgets.zones"
-                    ></select>
-                </div>
-                <fieldset id="holiday_mode_panel" class="busy-scope">
-                    <div class="homey-form-group">
-                        <label
-                            class="homey-form-label"
-                            data-i18n="settings.holidayMode.enabled"
-                            for="enabled_holiday_mode"
-                        >Enable holiday mode</label>
-                        <select id="enabled_holiday_mode" class="homey-form-select">
-                            <option
-                                data-i18n="settings.boolean.false"
-                                value="false"
-                            >No</option>
-                            <option
-                                data-i18n="settings.boolean.true"
-                                value="true"
-                            >Yes</option>
-                        </select>
-                    </div>
-                    <div class="homey-form-group">
-                        <label
-                            class="homey-form-label"
-                            data-i18n="settings.holidayMode.startDate"
-                            for="start_date"
-                        >Start date</label>
-                        <input
-                            id="start_date"
-                            type="datetime-local"
-                        >
-                    </div>
-                    <div class="homey-form-group">
-                        <label
-                            class="homey-form-label"
-                            data-i18n="settings.holidayMode.endDate"
-                            for="end_date"
-                        >End date</label>
-                        <input
-                            id="end_date"
-                            type="datetime-local"
-                        >
-                    </div>
-                    <div class="homey-form-group container">
-                        <button
-                            id="refresh_holiday_mode"
-                            type="button"
-                            class="homey-button-secondary-shadow"
-                            data-i18n="settings.refresh"
-                        >Refresh</button>
-                        <button
-                            id="apply_holiday_mode"
-                            type="button"
-                            class="homey-button-danger-shadow"
-                            data-i18n="settings.update"
-                        >Update</button>
-                    </div>
-                </fieldset>
-                <fieldset id="frost_protection_panel" class="busy-scope">
-                    <div class="homey-form-group">
-                        <label
-                            class="homey-form-label"
-                            data-i18n="settings.frostProtection.enabled"
-                            for="enabled_frost_protection"
-                        >Enable frost protection</label>
-                        <select id="enabled_frost_protection" class="homey-form-select">
-                            <option
-                                data-i18n="settings.boolean.false"
-                                value="false"
-                            >No</option>
-                            <option
-                                data-i18n="settings.boolean.true"
-                                value="true"
-                            >Yes</option>
-                        </select>
-                    </div>
-                    <div class="homey-form-group">
-                        <label
-                            class="homey-form-label"
-                            data-i18n="settings.frostProtection.min"
-                            for="min"
-                        >Minimum temperature</label>
-                        <input
-                            id="min"
-                            type="number"
-                            class="homey-form-input"
-                            inputmode="numeric"
-                        >
-                    </div>
-                    <div class="homey-form-group">
-                        <label
-                            class="homey-form-label"
-                            data-i18n="settings.frostProtection.max"
-                            for="max"
-                        >Maximum temperature</label>
-                        <input
-                            id="max"
-                            type="number"
-                            class="homey-form-input"
-                            inputmode="numeric"
-                        >
-                    </div>
-                    <div class="homey-form-group container">
-                        <button
-                            id="refresh_frost_protection"
-                            type="button"
-                            class="homey-button-secondary-shadow"
-                            data-i18n="settings.refresh"
-                        >Refresh</button>
-                        <button
-                            id="apply_frost_protection"
-                            type="button"
-                            class="homey-button-danger-shadow"
-                            data-i18n="settings.update"
-                        >Update</button>
-                    </div>
-                </fieldset>
-                <fieldset
-                    id="overheat_protection_panel"
-                    class="busy-scope"
-                    hidden
-                >
-                    <div class="homey-form-group">
-                        <label
-                            class="homey-form-label"
-                            for="enabled_overheat_protection"
-                        >
-                            <span
-                                data-i18n="settings.overheatProtection.enabled"
-                            >Enable overheat protection</span>
-                            <span
-                                id="overheat_protection_scope"
-                                data-i18n="settings.overheatProtection.airToAir"
-                                hidden
-                            >(air-to-air)</span>
-                        </label>
-                        <select id="enabled_overheat_protection" class="homey-form-select">
-                            <option
-                                data-i18n="settings.boolean.false"
-                                value="false"
-                            >No</option>
-                            <option
-                                data-i18n="settings.boolean.true"
-                                value="true"
-                            >Yes</option>
-                        </select>
-                    </div>
-                    <div class="homey-form-group">
-                        <label
-                            class="homey-form-label"
-                            data-i18n="settings.overheatProtection.min"
-                            for="overheat_min"
-                        >Minimum temperature</label>
-                        <input
-                            id="overheat_min"
-                            type="number"
-                            class="homey-form-input"
-                            inputmode="numeric"
-                        >
-                    </div>
-                    <div class="homey-form-group">
-                        <label
-                            class="homey-form-label"
-                            data-i18n="settings.overheatProtection.max"
-                            for="overheat_max"
-                        >Maximum temperature</label>
-                        <input
-                            id="overheat_max"
-                            type="number"
-                            class="homey-form-input"
-                            inputmode="numeric"
-                        >
-                    </div>
-                    <div class="homey-form-group container">
-                        <button
-                            id="refresh_overheat_protection"
-                            type="button"
-                            class="homey-button-secondary-shadow"
-                            data-i18n="settings.refresh"
-                        >Refresh</button>
-                        <button
-                            id="apply_overheat_protection"
-                            type="button"
-                            class="homey-button-danger-shadow"
-                            data-i18n="settings.update"
-                        >Update</button>
-                    </div>
-                </fieldset>
-            </fieldset>
+      <div id="device_settings"></div>
+      <fieldset class="homey-form-fieldset zone-device-settings">
+        <legend class="homey-form-legend" data-i18n="settings.zones.legend">
+          Zone and device settings
+        </legend>
+        <div class="homey-form-group">
+          <select
+            id="zones"
+            class="homey-form-select"
+            aria-label="Zones"
+            data-i18n-aria-label="widgets.zones"
+          ></select>
         </div>
-    </body>
+        <fieldset id="holiday_mode_panel" class="busy-scope">
+          <div class="homey-form-group">
+            <label
+              class="homey-form-label"
+              data-i18n="settings.holidayMode.enabled"
+              for="enabled_holiday_mode"
+              >Enable holiday mode</label
+            >
+            <select id="enabled_holiday_mode" class="homey-form-select">
+              <option data-i18n="settings.boolean.false" value="false">
+                No
+              </option>
+              <option data-i18n="settings.boolean.true" value="true">
+                Yes
+              </option>
+            </select>
+          </div>
+          <div class="homey-form-group">
+            <label
+              class="homey-form-label"
+              data-i18n="settings.holidayMode.startDate"
+              for="start_date"
+              >Start date</label
+            >
+            <input id="start_date" type="datetime-local" />
+          </div>
+          <div class="homey-form-group">
+            <label
+              class="homey-form-label"
+              data-i18n="settings.holidayMode.endDate"
+              for="end_date"
+              >End date</label
+            >
+            <input id="end_date" type="datetime-local" />
+          </div>
+          <div class="homey-form-group container">
+            <button
+              id="refresh_holiday_mode"
+              type="button"
+              class="homey-button-secondary-shadow"
+              data-i18n="settings.refresh"
+            >
+              Refresh
+            </button>
+            <button
+              id="apply_holiday_mode"
+              type="button"
+              class="homey-button-danger-shadow"
+              data-i18n="settings.update"
+            >
+              Update
+            </button>
+          </div>
+        </fieldset>
+        <fieldset id="frost_protection_panel" class="busy-scope">
+          <div class="homey-form-group">
+            <label
+              class="homey-form-label"
+              data-i18n="settings.frostProtection.enabled"
+              for="enabled_frost_protection"
+              >Enable frost protection</label
+            >
+            <select id="enabled_frost_protection" class="homey-form-select">
+              <option data-i18n="settings.boolean.false" value="false">
+                No
+              </option>
+              <option data-i18n="settings.boolean.true" value="true">
+                Yes
+              </option>
+            </select>
+          </div>
+          <div class="homey-form-group">
+            <label
+              class="homey-form-label"
+              data-i18n="settings.frostProtection.min"
+              for="min"
+              >Minimum temperature</label
+            >
+            <input
+              id="min"
+              type="number"
+              class="homey-form-input"
+              inputmode="numeric"
+            />
+          </div>
+          <div class="homey-form-group">
+            <label
+              class="homey-form-label"
+              data-i18n="settings.frostProtection.max"
+              for="max"
+              >Maximum temperature</label
+            >
+            <input
+              id="max"
+              type="number"
+              class="homey-form-input"
+              inputmode="numeric"
+            />
+          </div>
+          <div class="homey-form-group container">
+            <button
+              id="refresh_frost_protection"
+              type="button"
+              class="homey-button-secondary-shadow"
+              data-i18n="settings.refresh"
+            >
+              Refresh
+            </button>
+            <button
+              id="apply_frost_protection"
+              type="button"
+              class="homey-button-danger-shadow"
+              data-i18n="settings.update"
+            >
+              Update
+            </button>
+          </div>
+        </fieldset>
+        <fieldset id="overheat_protection_panel" class="busy-scope" hidden>
+          <div class="homey-form-group">
+            <label class="homey-form-label" for="enabled_overheat_protection">
+              <span data-i18n="settings.overheatProtection.enabled"
+                >Enable overheat protection</span
+              >
+              <span
+                id="overheat_protection_scope"
+                data-i18n="settings.overheatProtection.airToAir"
+                hidden
+                >(air-to-air)</span
+              >
+            </label>
+            <select id="enabled_overheat_protection" class="homey-form-select">
+              <option data-i18n="settings.boolean.false" value="false">
+                No
+              </option>
+              <option data-i18n="settings.boolean.true" value="true">
+                Yes
+              </option>
+            </select>
+          </div>
+          <div class="homey-form-group">
+            <label
+              class="homey-form-label"
+              data-i18n="settings.overheatProtection.min"
+              for="overheat_min"
+              >Minimum temperature</label
+            >
+            <input
+              id="overheat_min"
+              type="number"
+              class="homey-form-input"
+              inputmode="numeric"
+            />
+          </div>
+          <div class="homey-form-group">
+            <label
+              class="homey-form-label"
+              data-i18n="settings.overheatProtection.max"
+              for="overheat_max"
+              >Maximum temperature</label
+            >
+            <input
+              id="overheat_max"
+              type="number"
+              class="homey-form-input"
+              inputmode="numeric"
+            />
+          </div>
+          <div class="homey-form-group container">
+            <button
+              id="refresh_overheat_protection"
+              type="button"
+              class="homey-button-secondary-shadow"
+              data-i18n="settings.refresh"
+            >
+              Refresh
+            </button>
+            <button
+              id="apply_overheat_protection"
+              type="button"
+              class="homey-button-danger-shadow"
+              data-i18n="settings.update"
+            >
+              Update
+            </button>
+          </div>
+        </fieldset>
+      </fieldset>
+    </div>
+  </body>
 </html>

--- a/widgets/ata-group-setting/public/index.html
+++ b/widgets/ata-group-setting/public/index.html
@@ -1,89 +1,100 @@
 <!doctype html>
 <html lang="en">
-    <head>
-        <meta charset="utf-8">
-        <meta content="width=device-width, initial-scale=1.0" name="viewport">
-        <title>Air-to-air device values</title>
-        <script>
-            // Classic defer bundle, not an ES module: a static module
-            // script stalls the whole boot on a cold webview open (a
-            // stalled module fetch also blocks onHomeyReady — proven
-            // on-device), while classic scripts, like the stylesheets,
-            // load cold. The poll keeps the boot bounded: it hands the
-            // instance to the bundle's start once it is up, or reports
-            // why, shows the inline error and ends the overlay if it
-            // never arrives.
-            function onHomeyReady(homey) {
-                const deadline = Date.now() + 10000
-                const waitForBundle = () => {
-                    if (globalThis.MELCloudWebview) {
-                        globalThis.MELCloudWebview.start(homey)
-                    } else if (Date.now() > deadline) {
-                        // Boot beacon: the bundle never booted — report WHY
-                        // before degrading. A 200 probe with no global means
-                        // the script fetched but failed to parse/run (old
-                        // engine); a probe error means the fetch itself
-                        // fails on this device.
-                        const script = document.querySelector('script[src*="index.js"]')
-                        const report = (probe) => {
-                            homey
-                                .api('POST', '/boot-error', { message: 'The widget bundle did not boot within 10s', name: 'BootTimeout', probe, userAgent: navigator.userAgent })
-                                .catch(() => {})
-                            const message = document.querySelector('#init_error')
-                            if (message) {
-                                message.hidden = false
-                                message.textContent = homey.__('widgets.loadFailed')
-                            }
-                            homey.ready()
-                        }
-                        fetch(script ? script.src : 'index.js')
-                            .then((response) => { report('fetch ' + String(response.status)) })
-                            .catch((error) => { report('fetch failed: ' + String(error)) })
-                    } else {
-                        setTimeout(waitForBundle, 50)
-                    }
-                }
-                waitForBundle()
+  <head>
+    <meta charset="utf-8" />
+    <meta content="width=device-width, initial-scale=1.0" name="viewport" />
+    <title>Air-to-air device values</title>
+    <script>
+      // Classic defer bundle, not an ES module: a static module
+      // script stalls the whole boot on a cold webview open (a
+      // stalled module fetch also blocks onHomeyReady — proven
+      // on-device), while classic scripts, like the stylesheets,
+      // load cold. The poll keeps the boot bounded: it hands the
+      // instance to the bundle's start once it is up, or reports
+      // why, shows the inline error and ends the overlay if it
+      // never arrives.
+      function onHomeyReady(homey) {
+        const deadline = Date.now() + 10000
+        const waitForBundle = () => {
+          if (globalThis.MELCloudWebview) {
+            globalThis.MELCloudWebview.start(homey)
+          } else if (Date.now() > deadline) {
+            // Boot beacon: the bundle never booted — report WHY
+            // before degrading. A 200 probe with no global means
+            // the script fetched but failed to parse/run (old
+            // engine); a probe error means the fetch itself
+            // fails on this device.
+            const script = document.querySelector('script[src*="index.js"]')
+            const report = (probe) => {
+              homey
+                .api('POST', '/boot-error', {
+                  message: 'The widget bundle did not boot within 10s',
+                  name: 'BootTimeout',
+                  probe,
+                  userAgent: navigator.userAgent,
+                })
+                .catch(() => {})
+              const message = document.querySelector('#init_error')
+              if (message) {
+                message.hidden = false
+                message.textContent = homey.__('widgets.loadFailed')
+              }
+              homey.ready()
             }
-        </script>
-        <link href="styles/layout.css" rel="stylesheet">
-        <link href="styles/zone-select.css" rel="stylesheet">
-        <link href="styles/flame.css" rel="stylesheet">
-        <link href="styles/leaf.css" rel="stylesheet">
-        <link href="styles/smoke.css" rel="stylesheet">
-        <link href="styles/snowflake.css" rel="stylesheet">
-        <link href="styles/sun.css" rel="stylesheet">
-        <script defer src="index.js"></script>
-        <meta content="MELCloud air-to-air device setting" name="description">
-    </head>
-    <body class="homey-widget-full homey-text-align-center">
-        <p
-            id="init_error"
-            class="homey-text-small"
-            hidden
-            role="alert"
-        ></p>
-        <select
-            id="zones"
-            class="zone-select"
-            aria-label="Zones"
-            data-i18n-aria-label="widgets.zones"
-        ></select>
-        <div id="animation"></div>
-        <fieldset id="values_melcloud" class="busy-scope homey-text-align-left"></fieldset>
-        <div class="button-row">
-            <button
-                id="refresh_values_melcloud"
-                type="button"
-                class="ghost-button accent"
-                data-i18n="settings.refresh"
-            >Refresh</button>
-            <button
-                id="apply_values_melcloud"
-                type="button"
-                class="ghost-button danger"
-                data-i18n="settings.update"
-            >Update</button>
-        </div>
-    </body>
+            fetch(script ? script.src : 'index.js')
+              .then((response) => {
+                report('fetch ' + String(response.status))
+              })
+              .catch((error) => {
+                report('fetch failed: ' + String(error))
+              })
+          } else {
+            setTimeout(waitForBundle, 50)
+          }
+        }
+        waitForBundle()
+      }
+    </script>
+    <link href="styles/layout.css" rel="stylesheet" />
+    <link href="styles/zone-select.css" rel="stylesheet" />
+    <link href="styles/flame.css" rel="stylesheet" />
+    <link href="styles/leaf.css" rel="stylesheet" />
+    <link href="styles/smoke.css" rel="stylesheet" />
+    <link href="styles/snowflake.css" rel="stylesheet" />
+    <link href="styles/sun.css" rel="stylesheet" />
+    <script defer src="index.js"></script>
+    <meta content="MELCloud air-to-air device setting" name="description" />
+  </head>
+  <body class="homey-widget-full homey-text-align-center">
+    <p id="init_error" class="homey-text-small" hidden role="alert"></p>
+    <select
+      id="zones"
+      class="zone-select"
+      aria-label="Zones"
+      data-i18n-aria-label="widgets.zones"
+    ></select>
+    <div id="animation"></div>
+    <fieldset
+      id="values_melcloud"
+      class="busy-scope homey-text-align-left"
+    ></fieldset>
+    <div class="button-row">
+      <button
+        id="refresh_values_melcloud"
+        type="button"
+        class="ghost-button accent"
+        data-i18n="settings.refresh"
+      >
+        Refresh
+      </button>
+      <button
+        id="apply_values_melcloud"
+        type="button"
+        class="ghost-button danger"
+        data-i18n="settings.update"
+      >
+        Update
+      </button>
+    </div>
+  </body>
 </html>

--- a/widgets/charts/public/index.html
+++ b/widgets/charts/public/index.html
@@ -1,83 +1,87 @@
 <!doctype html>
 <html lang="en">
-    <head>
-        <meta charset="utf-8">
-        <meta content="width=device-width, initial-scale=1.0" name="viewport">
-        <title>MELCloud charts</title>
-        <script>
-            // Classic defer bundle, not an ES module: a static module
-            // script stalls the whole boot on a cold webview open (a
-            // stalled module fetch also blocks onHomeyReady — proven
-            // on-device), while classic scripts, like the stylesheets,
-            // load cold. The poll keeps the boot bounded: it hands the
-            // instance to the bundle's start once it is up, or reports
-            // why, shows the inline error and ends the overlay if it
-            // never arrives.
-            function onHomeyReady(homey) {
-                const deadline = Date.now() + 10000
-                const waitForBundle = () => {
-                    if (globalThis.MELCloudWebview) {
-                        globalThis.MELCloudWebview.start(homey)
-                    } else if (Date.now() > deadline) {
-                        // Boot beacon: the bundle never booted — report WHY
-                        // before degrading. A 200 probe with no global means
-                        // the script fetched but failed to parse/run (old
-                        // engine); a probe error means the fetch itself
-                        // fails on this device.
-                        const script = document.querySelector('script[src*="index.js"]')
-                        const report = (probe) => {
-                            homey
-                                .api('POST', '/boot-error', { message: 'The widget bundle did not boot within 10s', name: 'BootTimeout', probe, userAgent: navigator.userAgent })
-                                .catch(() => {})
-                            const message = document.querySelector('#init_error')
-                            if (message) {
-                                message.hidden = false
-                                message.textContent = homey.__('widgets.loadFailed')
-                            }
-                            homey.ready()
-                        }
-                        fetch(script ? script.src : 'index.js')
-                            .then((response) => { report('fetch ' + String(response.status)) })
-                            .catch((error) => { report('fetch failed: ' + String(error)) })
-                    } else {
-                        setTimeout(waitForBundle, 50)
-                    }
-                }
-                waitForBundle()
+  <head>
+    <meta charset="utf-8" />
+    <meta content="width=device-width, initial-scale=1.0" name="viewport" />
+    <title>MELCloud charts</title>
+    <script>
+      // Classic defer bundle, not an ES module: a static module
+      // script stalls the whole boot on a cold webview open (a
+      // stalled module fetch also blocks onHomeyReady — proven
+      // on-device), while classic scripts, like the stylesheets,
+      // load cold. The poll keeps the boot bounded: it hands the
+      // instance to the bundle's start once it is up, or reports
+      // why, shows the inline error and ends the overlay if it
+      // never arrives.
+      function onHomeyReady(homey) {
+        const deadline = Date.now() + 10000
+        const waitForBundle = () => {
+          if (globalThis.MELCloudWebview) {
+            globalThis.MELCloudWebview.start(homey)
+          } else if (Date.now() > deadline) {
+            // Boot beacon: the bundle never booted — report WHY
+            // before degrading. A 200 probe with no global means
+            // the script fetched but failed to parse/run (old
+            // engine); a probe error means the fetch itself
+            // fails on this device.
+            const script = document.querySelector('script[src*="index.js"]')
+            const report = (probe) => {
+              homey
+                .api('POST', '/boot-error', {
+                  message: 'The widget bundle did not boot within 10s',
+                  name: 'BootTimeout',
+                  probe,
+                  userAgent: navigator.userAgent,
+                })
+                .catch(() => {})
+              const message = document.querySelector('#init_error')
+              if (message) {
+                message.hidden = false
+                message.textContent = homey.__('widgets.loadFailed')
+              }
+              homey.ready()
             }
-        </script>
-        <link href="styles/layout.css" rel="stylesheet">
-        <link href="styles/zone-select.css" rel="stylesheet">
-        <script defer src="index.js"></script>
-        <meta content="MELCloud charts" name="description">
-    </head>
-    <body class="homey-widget-full homey-text-align-center">
-        <p
-            id="init_error"
-            class="homey-text-small"
-            hidden
-            role="alert"
-        ></p>
-        <select
-            id="charts"
-            class="zone-select"
-            aria-label="Chart"
-            data-i18n-aria-label="widgets.chart"
-        ></select>
-        <div class="picker-row">
-            <select
-                id="zones"
-                class="zone-select"
-                aria-label="Zones"
-                data-i18n-aria-label="widgets.zones"
-            ></select>
-            <select
-                id="days"
-                class="zone-select"
-                aria-label="Number of days"
-                data-i18n-aria-label="widgets.days"
-            ></select>
-        </div>
-        <div id="chart"></div>
-    </body>
+            fetch(script ? script.src : 'index.js')
+              .then((response) => {
+                report('fetch ' + String(response.status))
+              })
+              .catch((error) => {
+                report('fetch failed: ' + String(error))
+              })
+          } else {
+            setTimeout(waitForBundle, 50)
+          }
+        }
+        waitForBundle()
+      }
+    </script>
+    <link href="styles/layout.css" rel="stylesheet" />
+    <link href="styles/zone-select.css" rel="stylesheet" />
+    <script defer src="index.js"></script>
+    <meta content="MELCloud charts" name="description" />
+  </head>
+  <body class="homey-widget-full homey-text-align-center">
+    <p id="init_error" class="homey-text-small" hidden role="alert"></p>
+    <select
+      id="charts"
+      class="zone-select"
+      aria-label="Chart"
+      data-i18n-aria-label="widgets.chart"
+    ></select>
+    <div class="picker-row">
+      <select
+        id="zones"
+        class="zone-select"
+        aria-label="Zones"
+        data-i18n-aria-label="widgets.zones"
+      ></select>
+      <select
+        id="days"
+        class="zone-select"
+        aria-label="Number of days"
+        data-i18n-aria-label="widgets.days"
+      ></select>
+    </div>
+    <div id="chart"></div>
+  </body>
 </html>


### PR DESCRIPTION
Pin jumps `1.6.0` → `1.8.0`, so this carries two preset changes at once.

## 1.7.0 — Prettier owns `.html`

Four `html/` rules actively rejected Prettier's output (`indent`, `attrs-newline`, `no-extra-spacing-tags`, `require-closing-tags`). Removing `*.html` from `.prettierignore` without turning them off would have put the three pages permanently at odds with the linter — measured at 78 errors. The preset turns off 11 rules (4 conflicting, 7 redundant) and keeps the ~50 quality rules, plus the three formatting-looking ones Prettier does not do: `head-order`, `sort-attrs`, `no-whitespace-only-children`.

Result: 2-space indent, ` />` on void elements, `lint` at zero.

`coverage/` and `.homeybuild/` stay out of Prettier's reach through `.gitignore` (Prettier 3 reads it by default) — only the 3 authored pages reformat.

## 1.8.0 — the coverage leg is a declared matrix member

`coverage-node-version` was a string compared against a hard-coded matrix: a value absent from it silently ran neither coverage nor Sonar, while `Test (Node 22)` stayed green. It now names the fleet's floor — **22.20** (Pro 2019, firmware 13.4.1-rc) rather than a bare `'22'` that resolves to the head of the line and drifts. `22` stays in `node-versions`, so the required `Test (Node 22)` context keeps reporting and no ruleset has to move.

Quoting is load-bearing: unquoted, JSON reads `22.20` as the number `22.2`. The reusable workflow's guard rejects that.

All nine `uses:` refs move to `91cfb98` (verified: `v1.8.0` dereferences to it) alongside the npm pin, in one branch — `check-pins.sh` refuses divergence.

## Stamping — verified, not assumed

The `?v=` transform anchors on `href="` / `src="` as one unit, which Prettier never splits (confirmed against a deliberately over-long tag it does wrap).

End to end on the packaged tree:

- every local reference stamped on all three pages; `/homey.js` correctly bare
- `webview-hashes.json` matches an independent recomputation of each page's document-order join of unique-by-value stamps
- the three identities are **byte-identical to `main`'s** — no asset bytes, no document order moved, so no webview sees a spurious refetch

## Checks

`format`, `lint` (0), `typecheck`, 949 tests, 100 % on all four axes, `homey:validate` at publish level with no rewrite. The two `npm audit` advisories are pre-existing, identical on `main`, and dev-only (`--omit=dev` resolves empty).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3