### PR TITLE
fix: read the JSON files with syntax every firmware can parse

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -451,8 +451,8 @@ coverage.
   firmware's engine**. Older Homey Pro (2016-2019) firmwares before
   13.4 run a pre-Node-20 engine (established from a crash report's
   stack naming `ESMLoader`, a class Node renamed in 18.19.0), so the
-  language floor is es2022 — es2023 added no syntax, es2024 added the
-  regex `v` flag, es2025 added import attributes. A module the engine
+  language floor is es2022 — es2023 added only library methods, es2024
+  added the regex `v` flag, es2025 added import attributes. A module the engine
   cannot parse fails BEFORE a line of it runs: the app does not boot,
   and no try/catch anywhere can recover it. Two shipped incidents, same
   class: the `v` flag (2026-08 report), then

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -445,11 +445,39 @@ coverage.
   checks the import CLOSURE, and the webview-facing types import the
   drivers' type barrel, reaching node-side es2024/2025 code. Revisit
   only if webview-facing types get decoupled from driver classes
-  (pure DTOs). Node-side code may use the newer APIs
-  freely — with ONE carve-out: shipped regexes stay on the `u` flag.
-  Older Homey Pro (2016-2019) firmwares run a pre-Node-20 runtime
-  where the es2024 `v` flag is a parse-time SyntaxError — it killed
-  the app at boot there (2026-08 crash report).
+  (pure DTOs).
+- The device's own floor is a SEPARATE invariant, and it is about
+  SYNTAX, not APIs: **every shipped module must PARSE on the oldest
+  firmware's engine**. Older Homey Pro (2016-2019) firmwares before
+  13.4 run a pre-Node-20 engine (established from a crash report's
+  stack naming `ESMLoader`, a class Node renamed in 18.19.0), so the
+  language floor is es2022 — es2023 added no syntax, es2024 added the
+  regex `v` flag, es2025 added import attributes. A module the engine
+  cannot parse fails BEFORE a line of it runs: the app does not boot,
+  and no try/catch anywhere can recover it. Two shipped incidents, same
+  class: the `v` flag (2026-08 report), then
+  `import … with { type: 'json' }` (2026-08 report, app 46.2.1) — the
+  second a REGRESSION of an explicit fix, `files.mts` having been
+  created in 2024 precisely to avoid it (`e84cf041`, "Make json import
+  compatible for Homey 2016") before a 2025-10 `simplify` commit
+  deleted its `createRequire` fallback and promoted the import-attribute
+  form. That is why the guard is mechanical and not a convention:
+  `tests/unit/node-floor.test.ts` emits the real build and parses every
+  module at the floor, so it is exhaustive BY CONSTRUCTION — it catches
+  syntax nobody thought to look for, not a list of known offenders.
+  Never re-add an import attribute to shipped code: `files.mts` reads
+  its JSON through `createRequire`, with type-only imports keeping tsc's
+  inference.
+- Runtime APIs are the OTHER family and the parser cannot see them:
+  they parse fine and throw on use. `Object.groupBy` (Node 21),
+  `toSorted`/`toReversed` (Node 20) and `Promise.withResolvers`
+  (Node 22) all postdate the floor. Shipped node-side code still calls
+  `toSorted` (6 sites) and `Object.groupBy` (1 site, `getDriverSettings`)
+  — they degrade a feature on use rather than killing the boot, and they
+  cannot be removed here because `unicorn/no-array-sort` MANDATES
+  `toSorted`: the rule lives in `@olivierzal/configs`, so resolving it
+  is a family decision, not a local edit. The boot-path occurrence was
+  removed (`ClassicDriver#onInit` now filters twice instead of grouping).
 
 ## Tooling boundary (@olivierzal/configs)
 

--- a/drivers/classic-driver.mts
+++ b/drivers/classic-driver.mts
@@ -79,11 +79,12 @@ export abstract class ClassicMELCloudDriver<
       string & keyof EnergyCapabilityTagMapping<T>,
       EnergyCapabilityTagMapping<T>[keyof EnergyCapabilityTagMapping<T>]
     >(this.tagMappings.energy)) {
-      const { consumed = [], produced = [] } = Object.groupBy(tags, (tag) =>
-        tag.endsWith('Consumed') ? 'consumed' : 'produced',
+      this.consumedTagMapping[capability] = tags.filter((tag) =>
+        tag.endsWith('Consumed'),
       )
-      this.consumedTagMapping[capability] = consumed
-      this.producedTagMapping[capability] = produced
+      this.producedTagMapping[capability] = tags.filter(
+        (tag) => !tag.endsWith('Consumed'),
+      )
     }
   }
 }

--- a/files.mts
+++ b/files.mts
@@ -1,7 +1,58 @@
-export { default as changelog } from './.homeychangelog.json' with { type: 'json' }
-export { default as horizontal } from './.homeycompose/capabilities/horizontal.json' with { type: 'json' }
-export { default as vertical } from './.homeycompose/capabilities/vertical.json' with { type: 'json' }
-export { default as fanSpeed } from './vendor/capabilities/fan_speed.json' with { type: 'json' }
-export { default as power } from './vendor/capabilities/onoff.json' with { type: 'json' }
-export { default as targetTemperature } from './vendor/capabilities/target_temperature.json' with { type: 'json' }
-export { default as thermostatMode } from './vendor/capabilities/thermostat_mode.json' with { type: 'json' }
+// `app.mts` loads this module at boot, so the device parses it before
+// running anything: import attributes (`with { type: 'json' }`) are a
+// parse-time SyntaxError on the pre-Node-20 engine of the oldest
+// firmware the manifest supports, and no try/catch can recover a module
+// that never parsed. `createRequire` reads the same files with syntax
+// every engine accepts, while the type-only imports keep tsc's
+// inference and erase at emit. `tests/unit/node-floor.test.ts` holds
+// the invariant for every shipped module, not just this one.
+import { createRequire } from 'node:module'
+
+import type ChangelogJson from './.homeychangelog.json'
+import type HorizontalJson from './.homeycompose/capabilities/horizontal.json'
+import type VerticalJson from './.homeycompose/capabilities/vertical.json'
+import type FanSpeedJson from './vendor/capabilities/fan_speed.json'
+import type PowerJson from './vendor/capabilities/onoff.json'
+import type TargetTemperatureJson from './vendor/capabilities/target_temperature.json'
+import type ThermostatModeJson from './vendor/capabilities/thermostat_mode.json'
+
+// Binds every readable path to the shape tsc inferred for it, so a
+// mistyped path is a compile error rather than a runtime one.
+interface JsonFiles {
+  './.homeychangelog.json': typeof ChangelogJson
+  './.homeycompose/capabilities/horizontal.json': typeof HorizontalJson
+  './.homeycompose/capabilities/vertical.json': typeof VerticalJson
+  './vendor/capabilities/fan_speed.json': typeof FanSpeedJson
+  './vendor/capabilities/onoff.json': typeof PowerJson
+  './vendor/capabilities/target_temperature.json': typeof TargetTemperatureJson
+  './vendor/capabilities/thermostat_mode.json': typeof ThermostatModeJson
+}
+
+const requireJson = createRequire(import.meta.url)
+
+const loadJson = <TPath extends keyof JsonFiles>(
+  path: TPath,
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- the module system types every read as `any`; the mapping above restores the shape tsc inferred
+): JsonFiles[TPath] => requireJson(path) as JsonFiles[TPath]
+
+export const changelog: typeof ChangelogJson = loadJson(
+  './.homeychangelog.json',
+)
+export const horizontal: typeof HorizontalJson = loadJson(
+  './.homeycompose/capabilities/horizontal.json',
+)
+export const vertical: typeof VerticalJson = loadJson(
+  './.homeycompose/capabilities/vertical.json',
+)
+export const fanSpeed: typeof FanSpeedJson = loadJson(
+  './vendor/capabilities/fan_speed.json',
+)
+export const power: typeof PowerJson = loadJson(
+  './vendor/capabilities/onoff.json',
+)
+export const targetTemperature: typeof TargetTemperatureJson = loadJson(
+  './vendor/capabilities/target_temperature.json',
+)
+export const thermostatMode: typeof ThermostatModeJson = loadJson(
+  './vendor/capabilities/thermostat_mode.json',
+)

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@types/node": "^26.1.2",
         "@typescript/native": "npm:typescript@^7.0.2",
         "@vitest/coverage-v8": "^4.1.10",
+        "acorn": "^8.18.0",
         "chart.js": "^4.5.1",
         "esbuild": "^0.28.1",
         "eslint": "^10.8.0",
@@ -3129,9 +3130,9 @@
       "license": "MIT"
     },
     "node_modules/acorn": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@types/node": "^26.1.2",
     "@typescript/native": "npm:typescript@^7.0.2",
     "@vitest/coverage-v8": "^4.1.10",
+    "acorn": "^8.18.0",
     "chart.js": "^4.5.1",
     "esbuild": "^0.28.1",
     "eslint": "^10.8.0",

--- a/tests/unit/node-floor.test.ts
+++ b/tests/unit/node-floor.test.ts
@@ -18,8 +18,8 @@ import { describe, expect, it } from 'vitest'
 // Pro (2016-2019) firmwares before 13.4 run a pre-Node-20 engine —
 // established from a crash report's own stack, which names `ESMLoader`,
 // a class Node renamed in 18.19.0. es2022 is the last language level
-// that engine parses whole: es2023 added no syntax, es2024 added the `v`
-// flag, es2025 added import attributes.
+// that engine parses whole: es2023 added only library methods, es2024
+// added the `v` flag, es2025 added import attributes.
 //
 // This guard is exhaustive BY CONSTRUCTION rather than by a list: it
 // parses the real emitted output at the floor, so any future syntax the

--- a/tests/unit/node-floor.test.ts
+++ b/tests/unit/node-floor.test.ts
@@ -1,0 +1,110 @@
+import { execFileSync } from 'node:child_process'
+import { mkdtemp, readdir, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+import { getErrorMessage } from '@olivierzal/homey-kit'
+import { parse } from 'acorn'
+import { describe, expect, it } from 'vitest'
+
+// The device parses every shipped module before running a line of it, so
+// syntax the firmware's engine does not know is a boot-time
+// `SyntaxError`, not a degraded feature. Two such crashes reached users:
+// the es2024 regex `v` flag, then import attributes
+// (`with { type: 'json' }`) — the second a regression of an explicit
+// 2024 fix that a refactor had quietly undone.
+//
+// The floor follows the firmware the manifest claims to support. Homey
+// Pro (2016-2019) firmwares before 13.4 run a pre-Node-20 engine —
+// established from a crash report's own stack, which names `ESMLoader`,
+// a class Node renamed in 18.19.0. es2022 is the last language level
+// that engine parses whole: es2023 added no syntax, es2024 added the `v`
+// flag, es2025 added import attributes.
+//
+// This guard is exhaustive BY CONSTRUCTION rather than by a list: it
+// parses the real emitted output at the floor, so any future syntax the
+// engine cannot read fails here, including forms nobody has thought to
+// look for. Runtime APIs are a different family — they parse fine and
+// throw on use — and no parser can see them.
+const LANGUAGE_FLOOR = 2022
+
+const TIMEOUT_MS = 120_000
+
+const emitShippedCode = (outDirectory: string): void => {
+  execFileSync(process.execPath, [
+    path.join('node_modules', '@typescript', 'native', 'bin', 'tsc'),
+    '--project',
+    'tsconfig.build.json',
+    '--outDir',
+    outDirectory,
+  ])
+}
+
+const collectModules = async (directory: string): Promise<string[]> => {
+  const entries = await readdir(directory, { withFileTypes: true })
+  const nested = await Promise.all(
+    entries.map(async (entry) => {
+      const full = path.join(directory, entry.name)
+
+      if (entry.isDirectory()) {
+        return collectModules(full)
+      }
+      return entry.name.endsWith('.mjs') ? [full] : []
+    }),
+  )
+
+  return nested.flat()
+}
+
+const parseFailure = (source: string): string | null => {
+  try {
+    parse(source, { ecmaVersion: LANGUAGE_FLOOR, sourceType: 'module' })
+
+    return null
+  } catch (error) {
+    return getErrorMessage(error)
+  }
+}
+
+describe('shipped syntax stays within the oldest supported engine', () => {
+  it(
+    `parses every emitted module at es${String(LANGUAGE_FLOOR)}`,
+    { timeout: TIMEOUT_MS },
+    async () => {
+      const outDirectory = await mkdtemp(path.join(tmpdir(), 'node-floor-'))
+
+      try {
+        emitShippedCode(outDirectory)
+
+        const modules = await collectModules(outDirectory)
+
+        // A guard that silently measures nothing is worse than none.
+        expect(modules.length).toBeGreaterThan(0)
+
+        const results = await Promise.all(
+          modules.map(async (file) => {
+            const message = parseFailure(await readFile(file, 'utf8'))
+
+            return message === null
+              ? null
+              : `${path.relative(outDirectory, file)}: ${message}`
+          }),
+        )
+
+        expect(results.filter((result) => result !== null)).toStrictEqual([])
+      } finally {
+        await rm(outDirectory, { force: true, recursive: true })
+      }
+    },
+  )
+
+  it('rejects the two syntaxes that took the app down on device', () => {
+    expect(
+      parseFailure("import x from './a.json' with { type: 'json' }"),
+    ).toMatch(/Unexpected token/v)
+    expect(parseFailure('const pattern = /a/v')).toMatch(
+      /Invalid regular expression flag/v,
+    )
+    expect(parseFailure('const pattern = /a/u')).toBeNull()
+  })
+})


### PR DESCRIPTION
## The crash

App 46.2.1 on Homey Pro (Early 2019), firmware 13.2.4:

```
Unable to initialize app SyntaxError: Unexpected token 'with'
    at ESMLoader.moduleStrategy (node:internal/modules/esm/translators:115:18)
```

`app.mts` loads `files.mts` at boot, and its seven `with { type: 'json' }` import attributes need Node ≥ 20.10. The failure is at **module parse**, before a line runs — no `try`/`catch` anywhere can recover it, so the app simply never starts.

This is the **second** shipped instance of one class. The es2024 regex `v` flag was the first; 46.2.1 fixed it, and these users hit this one immediately. They have not had a working app since **v42.1.0 (2025-10-13)**.

It is also a **regression of an explicit fix**: `files.mts` was created in 2024 as *"Make json import compatible for Homey 2016"* (`e84cf041`) with a `createRequire` fallback for exactly this. A 2025-10 `simplify` commit deleted the fallback and promoted the import-attribute form.

## The floor, established rather than assumed

The crash stack names `ESMLoader` — a class Node **renamed in 18.19.0**, so that firmware runs Node ≤ 18.18. Two independent parse failures agree (`v` flag needs Node 20, import attributes need 18.20/20.10). **es2022** is the last language level that engine parses whole: es2023 added no syntax, es2024 added the `v` flag, es2025 added import attributes.

## The mechanism

`tests/unit/node-floor.test.ts` emits the real build (`tsconfig.build.json` to a temp dir) and parses **every** emitted module at es2022. It is exhaustive **by construction**, not by a list of known offenders — future syntax nobody thought to look for fails here too.

Proven by mutation, both shipped incidents, each with tsc passing so only the guard can catch them:

| mutation | guard output |
| --- | --- |
| `with { type: 'json' }` restored | `files.mjs: Unexpected token (1:62)` |
| `export const PROBE: RegExp = /[a-z]/v` | `lib/constants.mjs: Invalid regular expression flag (4:22)` |

## The fix

`createRequire` reads the same files with syntax every engine accepts. Type-only imports keep tsc's inference, and a path→type mapping makes a mistyped path a compile error. Verified: tsc still emits the JSON to `.homeybuild`, the module loads under Node, and the data is byte-identical to the JSON.

`ClassicDriver#onInit` also called `Object.groupBy` (Node 21) — it would have thrown at driver init on the same engine, so the app still would not have started. It now filters twice.

## Reported, not fixed here

Runtime APIs are the other family: they parse fine and throw on use, so no parser sees them. Shipped code still calls `toSorted` (6 sites) and `Object.groupBy` (1 site, `getDriverSettings`). They degrade a feature rather than killing the boot, and they **cannot** be removed locally — `unicorn/no-array-sort` *mandates* `toSorted`, and that rule lives in `@olivierzal/configs`. Resolving it is a family decision. Recorded in CLAUDE.md.

## Gates

Format, lint (zero disables added beyond one documented boundary cast, mirroring `typed-object.mts`), typecheck, 951 tests, 100 % on all four axes, `homey:validate` at publish level with no rewrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3