### PR TITLE
refactor: read the JSON files through import attributes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -447,40 +447,32 @@ coverage.
   only if webview-facing types get decoupled from driver classes
   (pure DTOs).
 - TWO floors coexist, on UNRELATED engines — never let one move the
-  other. The **webview** floor above is es2023 and is set by the
-  phone's WebKit, which no Homey firmware can rejuvenate: it stays
-  enforced by the scoped lint block, and the danger there is APIs,
-  because esbuild lowers syntax but NEVER polyfills. The **node-side**
-  floor is the Homey's own Node, and it is held by the manifest's
-  `compatibility` declaration, NOT by a check.
-- That node-side floor is a DECLARATION, deliberately. Two shipped
-  incidents crashed the app at PARSE time on Homey Pro (2016-2019)
-  firmwares before 13.4, which run a pre-Node-20 engine (established
-  from a crash report's stack naming `ESMLoader`, a class Node renamed
-  in 18.19.0): the regex `v` flag, then
-  `import … with { type: 'json' }` (app 46.2.1) — the second a
-  REGRESSION of an explicit fix, `files.mts` having been created in
-  2024 precisely to avoid it (`e84cf041`, "Make json import compatible
-  for Homey 2016") before a 2025-10 `simplify` commit deleted its
-  `createRequire` fallback. A parse-level guard over the emitted build
-  was built and then REFUSED (2026-08): no acorn `ecmaVersion`
-  corresponds to "what Node 22.19 accepts" — es2025 is only partly
-  implemented there (regex modifiers and duplicate named groups are
-  Node 23, `using` is Node 24) — so any calibration is either too lax
-  to catch anything or too strict, forcing rewrites of perfectly valid
-  code. A guard that cannot be calibrated honestly guards nothing. The
-  net is the declaration, kept aligned with the `engines` of the
-  shipped dependencies (`>=22.19.0`); supporting an engine older than
-  that is a product decision, not a code one, and the answer to a
-  report from such a firmware is a free update. `files.mts` still reads
-  its JSON through `createRequire` — not to satisfy a floor, but
-  because it is the robust form and costs nothing.
-- Node-side runtime APIs above the floor are therefore LEGITIMATE:
+  other. The **webview** floor is es2023, set by the phone's WebKit,
+  which no Homey firmware can rejuvenate: it stays enforced by the
+  scoped lint block above, and the danger there is APIs, because
+  esbuild lowers syntax but NEVER polyfills. The **node-side** floor is
+  the Homey's own Node, held by the manifest's `compatibility`
+  declaration, NOT by a check.
+- A floor is declared from WHERE THE CODE RUNS, never from what a
+  dependency happens to require. `compatibility: ">=12.9.0"` is
+  Athom's own documented Node 22 boundary ("as of Homey v12.9.0, all
+  Homey platforms run apps on Node.js v22"), and it already covers the
+  `engines` of every shipped dependency. Raising it
+  cannot express more than it already does: the two firmware lines are
+  numbered independently, so one semver range cannot say "has Node 22"
+  across both — and on Homey Pro (2016-2019) the Node 22 firmware is
+  still only a release candidate, so a raise would cut off that whole
+  stable install base rather than a few laggards.
+- Node-side runtime APIs above es2022 are therefore LEGITIMATE:
   `toSorted`/`toReversed` (Node 20), `Object.groupBy` (Node 21) and
-  `Promise.withResolvers` (Node 22) all predate the declared engine.
-  Never rewrite one away for compatibility — `unicorn/no-array-sort`
-  mandates `toSorted` anyway, and a hand-rolled replacement is a
-  readability regression for nothing.
+  `Promise.withResolvers` (Node 22) all predate the declared engine,
+  and `@olivierzal/homey-kit` already calls `toSorted` inside the
+  boot path every app runs. Never rewrite one away for an engine the
+  manifest does not claim — `unicorn/no-array-sort` mandates
+  `toSorted` anyway, and a hand-rolled replacement is a readability
+  regression for nothing. The same holds for syntax: `files.mts`
+  reads its JSON through import attributes, the statically analysable
+  form.
 
 ## Tooling boundary (@olivierzal/configs)
 

--- a/files.mts
+++ b/files.mts
@@ -1,58 +1,7 @@
-// `app.mts` loads this module at boot, so the device parses it before
-// running anything: import attributes (`with { type: 'json' }`) are a
-// parse-time SyntaxError on the pre-Node-20 engine of the oldest
-// firmware the manifest supports, and no try/catch can recover a module
-// that never parsed. `createRequire` reads the same files with syntax
-// every engine accepts, while the type-only imports keep tsc's
-// inference and erase at emit. `tests/unit/node-floor.test.ts` holds
-// the invariant for every shipped module, not just this one.
-import { createRequire } from 'node:module'
-
-import type ChangelogJson from './.homeychangelog.json'
-import type HorizontalJson from './.homeycompose/capabilities/horizontal.json'
-import type VerticalJson from './.homeycompose/capabilities/vertical.json'
-import type FanSpeedJson from './vendor/capabilities/fan_speed.json'
-import type PowerJson from './vendor/capabilities/onoff.json'
-import type TargetTemperatureJson from './vendor/capabilities/target_temperature.json'
-import type ThermostatModeJson from './vendor/capabilities/thermostat_mode.json'
-
-// Binds every readable path to the shape tsc inferred for it, so a
-// mistyped path is a compile error rather than a runtime one.
-interface JsonFiles {
-  './.homeychangelog.json': typeof ChangelogJson
-  './.homeycompose/capabilities/horizontal.json': typeof HorizontalJson
-  './.homeycompose/capabilities/vertical.json': typeof VerticalJson
-  './vendor/capabilities/fan_speed.json': typeof FanSpeedJson
-  './vendor/capabilities/onoff.json': typeof PowerJson
-  './vendor/capabilities/target_temperature.json': typeof TargetTemperatureJson
-  './vendor/capabilities/thermostat_mode.json': typeof ThermostatModeJson
-}
-
-const requireJson = createRequire(import.meta.url)
-
-const loadJson = <TPath extends keyof JsonFiles>(
-  path: TPath,
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- the module system types every read as `any`; the mapping above restores the shape tsc inferred
-): JsonFiles[TPath] => requireJson(path) as JsonFiles[TPath]
-
-export const changelog: typeof ChangelogJson = loadJson(
-  './.homeychangelog.json',
-)
-export const horizontal: typeof HorizontalJson = loadJson(
-  './.homeycompose/capabilities/horizontal.json',
-)
-export const vertical: typeof VerticalJson = loadJson(
-  './.homeycompose/capabilities/vertical.json',
-)
-export const fanSpeed: typeof FanSpeedJson = loadJson(
-  './vendor/capabilities/fan_speed.json',
-)
-export const power: typeof PowerJson = loadJson(
-  './vendor/capabilities/onoff.json',
-)
-export const targetTemperature: typeof TargetTemperatureJson = loadJson(
-  './vendor/capabilities/target_temperature.json',
-)
-export const thermostatMode: typeof ThermostatModeJson = loadJson(
-  './vendor/capabilities/thermostat_mode.json',
-)
+export { default as changelog } from './.homeychangelog.json' with { type: 'json' }
+export { default as horizontal } from './.homeycompose/capabilities/horizontal.json' with { type: 'json' }
+export { default as vertical } from './.homeycompose/capabilities/vertical.json' with { type: 'json' }
+export { default as fanSpeed } from './vendor/capabilities/fan_speed.json' with { type: 'json' }
+export { default as power } from './vendor/capabilities/onoff.json' with { type: 'json' }
+export { default as targetTemperature } from './vendor/capabilities/target_temperature.json' with { type: 'json' }
+export { default as thermostatMode } from './vendor/capabilities/thermostat_mode.json' with { type: 'json' }


### PR DESCRIPTION
`files.mts` goes back to `import … with { type: 'json' }`, and the doctrine states the two runtime floors as they now stand.

## Why the accommodation had no beneficiary

`createRequire` was introduced to survive a pre-Node-20 engine. It cannot achieve that:
`App#onInit` → `#createNotification` → `selectChangelogEntries` → `@olivierzal/homey-kit`'s
`changelog.js:63` `.toSorted(…)`, which needs **Node 20**. The parse it protected is followed,
on the same tick, by a `TypeError`. `Object.groupBy` (Node 21) is likewise back in
`ClassicDriver#onInit`.

So the accommodation cost a cast and the static analysability of the import graph, and bought
nothing.

## Why `compatibility` is not raised

`>=12.9.0` is already Athom's documented Node 22 boundary — *"as of Homey v12.9.0, all Homey
platforms run apps on Node.js v22"*. Raising it cannot express more:

- the two firmware lines are numbered **independently**, so one semver range cannot say
  "has Node 22" across both;
- on Homey Pro (2016-2019) the Node 22 firmware is still only a **release candidate**
  (v13.4.1-rc.1, 2026-08-10; latest stable v13.2.4, 2026-07-22), so a raise would cut off that
  entire stable install base rather than a few laggards.

## Doctrine

The floors section now states the final state: two floors on unrelated engines, the rule that a
floor is declared **from where the code runs, never from what a dependency requires**, and the
node-side APIs above es2022 that are legitimate. The **webview** es2023 floor is untouched — it
is set by the phone's WebKit, which no firmware can rejuvenate.

## Verification

format · lint (zero disables) · typecheck · 949 tests · **100 % on all four axes** ·
`homey:validate` at publish level with no rewrite.