### PR TITLE
chore: drop the expired node-side u-flag verdict

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -472,7 +472,9 @@ coverage.
   `toSorted` anyway, and a hand-rolled replacement is a readability
   regression for nothing. The same holds for syntax: `files.mts`
   reads its JSON through import attributes, the statically analysable
-  form.
+  form, and node-side regexes take the family's `v` flag — only the
+  webview globs step down to `u`, and that step-down is the scoped
+  block's job, never a second overlay.
 
 ## Tooling boundary (@olivierzal/configs)
 

--- a/app.mts
+++ b/app.mts
@@ -1334,7 +1334,7 @@ export default class MELCloudApp extends App {
   #holidayModeEndTime(time: unknown): Temporal.PlainTime {
     if (
       typeof time !== 'string' ||
-      !/^(?:[01]\d|2[0-3]):[0-5]\d$/u.test(time)
+      !/^(?:[01]\d|2[0-3]):[0-5]\d$/v.test(time)
     ) {
       throw new RangeError(this.homey.__('errors.invalidTime'))
     }

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -74,14 +74,6 @@ const config: Config[] = defineConfig([
       'max-classes-per-file': 'off',
     },
   },
-  {
-    // Shipped node-side regexes stay on the `u` flag: older Homey
-    // Pro (2016-2019) firmwares run a pre-Node-20 runtime where the
-    // es2024 `v` flag is a parse-time SyntaxError — the 2026-08
-    // boot-crash root cause.
-    files: ['*.mts', 'drivers/**/*.mts', 'lib/**/*.mts'],
-    rules: { 'require-unicode-regexp': ['error', { requireFlag: 'u' }] },
-  },
 ])
 
 export default config


### PR DESCRIPTION
The eslint overlay pinned `require-unicode-regexp` to `u` over `*.mts`, `drivers/**/*.mts` and `lib/**/*.mts`, with this reason: the es2024 `v` flag is a parse-time `SyntaxError` on the pre-Node-20 runtime of older Homey Pro (2016-2019) firmware.

**Those globs are node-side only.** The real webview sources — `public/`, `settings/`, `widgets/*/public/` — are covered by the preset's own scoped floor block, which still steps the requirement down to `u`. Verified rather than assumed: the only relative imports reaching into `lib/` come from `widgets/*/api.mts`, which is the widget's **node-side** API handler, not its webview; the webview entries import solely from `public/`.

The node-side floor is the Homey's own Node, declared by `compatibility: ">=12.9.0"` — Athom's documented Node 22 boundary — where `v` parses fine. The pin has nothing left to encode, so it goes: a rule that cannot apply to the project should not be included.

## Measured, not assumed

Removing the block makes the family default (`v`) fire on **exactly one** regex, `app.mts:1337`:

```
/^(?:[01]\d|2[0-3]):[0-5]\d$/u
```

Its character classes hold only digits and range hyphens — none of the double punctuators or unescaped syntax characters `v` treats more strictly — so `u` and `v` are equivalent for it. It now carries `v`.

## Doctrine

The "TWO floors coexist" section already stated the split correctly and needed no correction. One clause is added where node-side es2022+ APIs are listed as legitimate, so the regex flag is named alongside them: the step-down to `u` is the scoped webview block's job, never a second overlay.

## Gates

format · lint (zero disable) · typecheck · 949 tests · **100 % on all four axes** (2716/1074/944/2686) · `homey:validate` at publish level, no rewrite