### PR TITLE
refactor(settings): read the protection bounds from the library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "GPL-3.0-only",
       "dependencies": {
         "@olivierzal/homey-kit": "5.0.0",
-        "@olivierzal/melcloud-api": "48.0.0",
+        "@olivierzal/melcloud-api": "48.1.0",
         "source-map-support": "^0.5.21",
         "temporal-polyfill": "^1.0.1"
       },
@@ -32,7 +32,7 @@
         "vitest": "^4.1.2"
       },
       "engines": {
-        "node": ">=22.19.0"
+        "node": "^22.22.2 || >=24.15.0"
       }
     },
     "node_modules/@altano/repository-tools": {
@@ -1117,9 +1117,9 @@
       }
     },
     "node_modules/@olivierzal/melcloud-api": {
-      "version": "48.0.0",
-      "resolved": "https://npm.pkg.github.com/download/@olivierzal/melcloud-api/48.0.0/c174b8b14ebd87f6354ad862a725b90d83ab60df",
-      "integrity": "sha512-BJmJ4kx/Puzto0CkVe1Dca7qYZNF6EuD2lMOu4Ths/ztKBOzxSXL7U84znCe4mX7CHO72J9m57ltBMK3AvoPRg==",
+      "version": "48.1.0",
+      "resolved": "https://npm.pkg.github.com/download/@olivierzal/melcloud-api/48.1.0/f0be274e553d3b8dbcc333b43d9086142dd3c7aa",
+      "integrity": "sha512-LN6q7n4ywMKIPgIJ+wWk0HxdfMVM5TAf04AkSb/BwbXppv0heQ+SzD0lBS6OHHDAhwJbzD5uSTzNau/7AewZeQ==",
       "license": "MIT",
       "dependencies": {
         "temporal-polyfill": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "prettier": "@olivierzal/configs/prettier",
   "dependencies": {
     "@olivierzal/homey-kit": "5.0.0",
-    "@olivierzal/melcloud-api": "48.0.0",
+    "@olivierzal/melcloud-api": "48.1.0",
     "source-map-support": "^0.5.21",
     "temporal-polyfill": "^1.0.1"
   },

--- a/settings/index.mts
+++ b/settings/index.mts
@@ -3,8 +3,6 @@ import type {
   HolidayModeState,
   HolidayModeUpdate,
   LoginCredentials,
-  ProtectionState,
-  ProtectionUpdate,
 } from '@olivierzal/melcloud-api'
 import type * as Classic from '@olivierzal/melcloud-api/classic'
 import type Homey from 'homey/lib/HomeySettings'
@@ -39,6 +37,13 @@ import {
   runWebview,
   watchWebviewFreshness,
 } from '@olivierzal/homey-kit/webview'
+import {
+  type ProtectionState,
+  type ProtectionUpdate,
+  FROST_PROTECTION_RANGE,
+  OVERHEAT_PROTECTION_RANGE,
+  PROTECTION_GAP,
+} from '@olivierzal/melcloud-api/protection'
 import { Temporal } from 'temporal-polyfill'
 
 import type { Api } from '../types/api.mts'
@@ -126,10 +131,6 @@ const Modulo = { base10: 10, base100: 100 } as const
 // form, except 12-14 which use the regular plural
 const PLURAL_THRESHOLD = 2
 const slavicPaucal = { maxEnding: 4, minEnding: 2, teenMax: 14, teenMin: 12 }
-
-const frostProtectionTemperatureRange = { max: 16, min: 4 }
-const overheatProtectionTemperatureRange = { max: 40, min: 31 }
-const PROTECTION_TEMPERATURE_GAP = 2
 
 const commonElementTypes = new Set(['checkbox', 'dropdown'])
 
@@ -338,7 +339,7 @@ const initProtectionMin = (
 ): HTMLInputElement => {
   const element = getInput(id)
   element.min = String(range.min)
-  element.max = String(range.max - PROTECTION_TEMPERATURE_GAP)
+  element.max = String(range.max - PROTECTION_GAP)
   return element
 }
 
@@ -347,7 +348,7 @@ const initProtectionMax = (
   range: { max: number; min: number },
 ): HTMLInputElement => {
   const element = getInput(id)
-  element.min = String(range.min + PROTECTION_TEMPERATURE_GAP)
+  element.min = String(range.min + PROTECTION_GAP)
   element.max = String(range.max)
   return element
 }
@@ -1239,12 +1240,12 @@ class ZoneSettingsManager {
 
   readonly #frostProtectionMaxTemperature = initProtectionMax(
     'max',
-    frostProtectionTemperatureRange,
+    FROST_PROTECTION_RANGE,
   )
 
   readonly #frostProtectionMinTemperature = initProtectionMin(
     'min',
-    frostProtectionTemperatureRange,
+    FROST_PROTECTION_RANGE,
   )
 
   readonly #holidayModeDirtyGate: DirtyGate
@@ -1269,12 +1270,12 @@ class ZoneSettingsManager {
 
   readonly #overheatProtectionMaxTemperature = initProtectionMax(
     'overheat_max',
-    overheatProtectionTemperatureRange,
+    OVERHEAT_PROTECTION_RANGE,
   )
 
   readonly #overheatProtectionMinTemperature = initProtectionMin(
     'overheat_min',
-    overheatProtectionTemperatureRange,
+    OVERHEAT_PROTECTION_RANGE,
   )
 
   readonly #overheatScope = getSpan('overheat_protection_scope')
@@ -1685,7 +1686,7 @@ class ZoneSettingsManager {
     if (max < min) {
       ;[min, max] = [max, min]
     }
-    return { max: Math.max(max, min + PROTECTION_TEMPERATURE_GAP), min }
+    return { max: Math.max(max, min + PROTECTION_GAP), min }
   }
 
   // Read one panel's settings for the selected target. Every target kind


### PR DESCRIPTION
The settings page spelled out three values `@olivierzal/melcloud-api` already publishes:

```ts
const frostProtectionTemperatureRange = { max: 16, min: 4 }
const overheatProtectionTemperatureRange = { max: 40, min: 31 }
const PROTECTION_TEMPERATURE_GAP = 2
```

They now come from `@olivierzal/melcloud-api/protection` — the subpath 48.1.0 opened for exactly this. The values are identical, so **nothing changes for a user today**; what closes is the divergence the day MELCloud moves a bound and the library follows.

`PROTECTION_GAP` carried the most risk of the three: it derives the fields' own `min`/`max` attributes at `initProtectionMin`/`initProtectionMax` and forces the spread on read, so a drift would have produced a form that accepts what the API rejects — invisible in tests, visible to the user.

### Only the constants travel

`clampFrostProtection` / `clampOverheatProtection` stay unused on purpose. The library **clamps silently** into the interval; the page **raises a visible error** naming the field and its limits (`parseNumericInput` → `settings.intError`). Substituting would swallow an out-of-range entry instead of reporting it.

### The bundle, measured

The settings page is a webview, so the import has to survive bundling — importing a value from the library's **root** fails with 118 errors (`undici` pulling `node:buffer`, `node:net`). The subpath is a zero-import leaf:

| | |
|---|---|
| `main` | 87 706 bytes |
| this branch | **87 702 bytes** (−4) |

Both ranges inline (`max:16,min:4`, `max:40,min:31`), zero occurrence of `melcloud-api`, `undici` or `node:buffer` in the output, and the clamps are tree-shaken away.

Statements drop 2716 → 2713, exactly the three deleted declarations. No test moved.

`ProtectionState` / `ProtectionUpdate` move to the same subpath they belong to, rather than reaching the module through the root barrel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3