### PR TITLE
chore: drop the merge_group trigger an org-only feature cannot fire

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,6 @@ jobs:
       node-versions: '[{"node-version": "22"}, {"node-version": "22.20", "coverage": true}, {"node-version": "latest"}, {"node-version": "lts/*"}]'
 name: CI
 on:
-  merge_group: {}
   pull_request: {}
   push:
     branches: [main]

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -22,7 +22,6 @@ jobs:
     timeout-minutes: 15
 name: Validate
 on:
-  merge_group: {}
   pull_request: {}
   push:
     branches: [main]

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -8,7 +8,6 @@ jobs:
     uses: OlivierZal/configs/.github/workflows/zizmor.yml@802b7e1bd61d37420efa982eb471356711b46251 # v3.2.0
 name: zizmor
 on:
-  merge_group: {}
   pull_request: {}
   push:
     branches: [main]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -600,9 +600,11 @@ reader fails open with an empty map).
   reviewed PR per release, and a caret is what silently held heatzy-api's
   published auth fix away from its app for six days (2026-08). The
   library's own Releasing doctrine mirrors this from the publisher side.
-- `main` is protected (PRs only, squash merges, 6 required contexts,
-  `strict=false`); merge queue is impossible (user-owned repo, org-only
-  feature).
+- `main` is protected (PRs only, squash merges, 8 required contexts,
+  `strict=false`); merge queue is impossible — GitHub gates it on
+  ORGANISATION ownership, and these repos are user-owned (verified
+  2026-08 against the docs source). The workflows therefore declare no
+  `merge_group` trigger: an event that cannot fire needs no handling.
 - The PR title IS the commit that lands: `squash_merge_commit_title` is
   `PR_TITLE` on all five repos, so the title is the single source (under
   the former `COMMIT_OR_PR_TITLE`, a one-commit PR silently took its


### PR DESCRIPTION
GitHub gates merge queues on **organisation ownership**. From the docs source ([`gated-features/merge-queue`](https://github.com/github/docs/blob/main/data/reusables/gated-features/merge-queue.md)):

> Pull request merge queues are available in any public repository **owned by an organization**, or in private repositories owned by organizations using GitHub Enterprise Cloud.

Every repo in this family is public but owned by a **personal account** (`owner.type = User`, checked on all seven). The `merge_group` event therefore cannot arrive, and the trigger was configuration for a need that cannot appear.

That is the same standard applied earlier today when an `allow-ghsas` input was kept out of the dependency review — *"no repo needs it; building for a need that has not appeared is precisely what we remove"*. A standard applied in one direction only is not a standard.

The doctrine is corrected where it claimed these triggers were "inert but harmless": inertness is not a reason to keep configuration.