### PR TITLE
test: floor the emitted webview closure and record the comment edges

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,8 +47,13 @@ caught real failures that the others miss:
   The committed source HTML carries NO stamps — never hand-add a `?v=`
   there, and nothing needs re-committing when a webview source changes
   (the old re-stamp-and-commit dance is gone). Stamps exist only in the
-  packaged app, and only within attribute/import reference contexts,
-  never comments. A second cache layer covers the HTML
+  packaged app, within attribute/import reference contexts
+  (`href="`/`src="`) — matched WHEREVER they appear, HTML comments
+  included: a commented reference to a missing file fails the packaging
+  pass, and one to a real file would be stamped by the builder yet
+  invisible to the page-side DOM query, splitting the two identities
+  into an endless refetch handshake. Delete a dead reference, never
+  comment it out. A second cache layer covers the HTML
   itself (phone webviews cache the page across app versions,
   force-close included): each bundle carries a freshness handshake —
   the page's identity is the document-order join of its UNIQUE `?v=`
@@ -336,8 +341,9 @@ coverage.
   timeout ends it if the bundle never loads (`#init_error` / post-ready
   alert), and `runWebview`/`withInitTimeout` end it if a DATA fetch hangs
   during init (`Homey.ready()` in a `finally`). `scripts/bundle.mts`
-  stamps the PACKAGED `.homeybuild` page copies — only inside an
-  attribute/import context, never a comment — with a content hash
+  stamps the PACKAGED `.homeybuild` page copies — full references
+  (`href="`/`src="`) wherever they appear, comments included; only a
+  bare filename in prose is safe — with a content hash
   (`?v=`): phone webviews cache assets across app versions; the source
   HTML stays unstamped. Webview runtime-API floor: es2023 array
   methods are accepted (`toSorted`/`toReversed` — the lint mandates

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -28,6 +28,10 @@ const config: Config[] = defineConfig([
     webviewFloorFiles: [
       'public/**/*.mts',
       'settings/**/*.mts',
+      // Cross-surface by contract: `DAYS_MAX` ships into the charts
+      // bundle, so the file holds the floor even though node-side code
+      // reads it too. `webview-floor.test.ts` recomputes the closure.
+      'types/widgets.mts',
       'widgets/*/public/**/*.mts',
     ],
     wireNamingEntries: [

--- a/scripts/webview-stamp.mts
+++ b/scripts/webview-stamp.mts
@@ -80,8 +80,14 @@ const collectHashes = async (
   )
 
 /**
- * Stamps only within a reference context, so the same filename written
- * elsewhere (e.g. a comment) is never rewritten.
+ * Stamps only within a reference context (`href="`/`src="`), so a bare
+ * filename written elsewhere (e.g. prose in a comment) is never
+ * rewritten. A FULL reference inside an HTML comment still matches:
+ * pointing at a missing file it fails the packaging pass (ENOENT);
+ * pointing at a real file it earns a stamp the page-side DOM query
+ * never sees, splitting the builder identity from the page identity —
+ * one refetch, then a boot-error on every open. No page carries a
+ * commented reference today; delete, never comment out.
  * @param html - The page to rewrite.
  * @param hashes - Content hash per referenced file.
  * @returns The page with every local reference stamped.

--- a/tests/unit/webview-floor.test.ts
+++ b/tests/unit/webview-floor.test.ts
@@ -1,0 +1,119 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import path from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+// The es2023 webview floor must cover every file a webview bundle can
+// emit: the bundler's entry points plus every module they reach through
+// a VALUE import — type imports erase at emit, so they pull nothing
+// into a bundle. A reached file outside the floor globs would ship API
+// the phone engines lack without any lint saying so; `types/widgets.mts`
+// already ships `DAYS_MAX` into the charts bundle, which is why the
+// floor names it. Inclusion is the invariant (globs cover whole
+// directories by design), unlike melcloud-api's exact-list twin.
+
+const ENTRY_POINT = /^ {2}'(?<file>[^']+\.mts)',$/gmv
+
+const FLOOR_LIST = /webviewFloorFiles: \[(?<entries>[^\]]*)\]/gv
+
+const FLOOR_ENTRY = /'(?<file>[^']+)'/gv
+
+// One statement spans from `import` to its single `from` clause; the
+// lazy quantifier stops at the first, so statements never bleed into
+// each other even without semicolons.
+const IMPORT_STATEMENT =
+  /^import(?<typeOnly> type)? (?<clause>[\s\S]*?)from '(?<specifier>[^']+)'/gmv
+
+const RELATIVE = /^\.\.?\//v
+
+const REPO_ROOT = fileURLToPath(new URL('../..', import.meta.url))
+
+const byName = (left: string, right: string): number =>
+  left.localeCompare(right)
+
+const readRepoFile = (relativePath: string): string =>
+  readFileSync(path.join(REPO_ROOT, relativePath), 'utf8')
+
+// Globs escape their dots, park `**/` on a placeholder no glob can
+// contain, expand `*`, then expand the parked `**/` — the order keeps
+// the two star forms from consuming each other.
+const toGlobRegex = (glob: string): RegExp =>
+  new RegExp(
+    `^${glob
+      .replaceAll('.', String.raw`\.`)
+      .replaceAll('**/', '\u{1}')
+      .replaceAll('*', String.raw`[^\/]*`)
+      .replaceAll('\u{1}', String.raw`(?:.*\/)?`)}$`,
+    'v',
+  )
+
+// The repo-relative files a source file pulls in through value imports.
+const getValueImports = (file: string): string[] =>
+  readRepoFile(file)
+    .matchAll(IMPORT_STATEMENT)
+    .filter((statement) => statement.groups?.typeOnly === undefined)
+    .map((statement) => statement.groups?.specifier)
+    .filter(
+      (specifier): specifier is string =>
+        specifier !== undefined && RELATIVE.test(specifier),
+    )
+    .map((specifier) =>
+      path
+        .relative(
+          REPO_ROOT,
+          path.resolve(REPO_ROOT, path.dirname(file), specifier),
+        )
+        .replaceAll(path.sep, '/'),
+    )
+    .toArray()
+
+const getEmittedClosure = (seed: readonly string[]): string[] => {
+  const closure = new Set<string>()
+  const pending = [...seed]
+  for (let file = pending.pop(); file !== undefined; file = pending.pop()) {
+    if (closure.has(file)) {
+      continue
+    }
+    closure.add(file)
+    pending.push(...getValueImports(file))
+  }
+  return [...closure].toSorted(byName)
+}
+
+describe.concurrent('webview floor closure', () => {
+  const entryPoints = [
+    ...new Set(
+      readRepoFile('scripts/bundle.mts')
+        .matchAll(ENTRY_POINT)
+        .map((match) => match.groups?.file),
+    ),
+  ].filter((file) => file !== undefined)
+  const floorRegexes = readRepoFile('eslint.config.ts')
+    .matchAll(FLOOR_LIST)
+    .flatMap((match) => (match.groups?.entries ?? '').matchAll(FLOOR_ENTRY))
+    .map((match) => match.groups?.file)
+    .filter((file) => file !== undefined)
+    .map(toGlobRegex)
+    .toArray()
+
+  // Guards the guard: broken extractors would equal two empty sets.
+  it('finds the entry points and the floor globs', () => {
+    expect(entryPoints.length).toBeGreaterThan(2)
+    expect(floorRegexes.length).toBeGreaterThan(2)
+  })
+
+  it('follows at least one value-import edge beyond the seed', () => {
+    expect(getEmittedClosure(entryPoints).length).toBeGreaterThan(
+      entryPoints.length,
+    )
+  })
+
+  it('floors every file a webview bundle can emit', () => {
+    const uncovered = getEmittedClosure(entryPoints).filter((file) =>
+      floorRegexes.every((regex) => !regex.test(file)),
+    )
+
+    expect(uncovered).toStrictEqual([])
+  })
+})


### PR DESCRIPTION
Two closures from the adversarial counter-review.

**`types/widgets.mts` was already an escape, not a future one**: it ships `DAYS_MAX` into the charts bundle through a value import, outside every webview-floor glob. The floor now names the file, and `tests/unit/webview-floor.test.ts` recomputes the value-import closure of the bundler's entry points and fails on any reached file the globs miss — proven red-first (it listed exactly `types/widgets.mts` before the glob landed), and the neutralised-extractor mutation drops two tests.

**The stamping docs claimed a comment is never rewritten** — true only for a bare filename. A full reference inside an HTML comment still matches: pointing at a missing file it fails the packaging pass (ENOENT); pointing at a real file it earns a stamp the page-side DOM query never sees, splitting the builder identity from the page identity — one refetch, then a boot-error on every open. CLAUDE.md and the stamping script docstring now state it, aligned on the extension's wording. Delete a dead reference, never comment it out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3