### PR TITLE
build: adopt @olivierzal/configs 4.0.0 and derive the webview floor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
       packages: read
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/reusable-ci.yml@802b7e1bd61d37420efa982eb471356711b46251 # v3.2.0
+    uses: OlivierZal/configs/.github/workflows/reusable-ci.yml@dd5ebe19d5b7f3381c34aa25ccba6ce7f324116f # v4.0.0
     with:
       check-node-version: '22'
       # The coverage/Sonar leg carries its own flag, and it runs on the

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -8,7 +8,7 @@ jobs:
       pull-requests: write
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/claude-code-review.yml@802b7e1bd61d37420efa982eb471356711b46251 # v3.2.0
+    uses: OlivierZal/configs/.github/workflows/claude-code-review.yml@dd5ebe19d5b7f3381c34aa25ccba6ce7f324116f # v4.0.0
 name: claude-code-review
 on:
   pull_request:

--- a/.github/workflows/claude-dependabot-fix.yml
+++ b/.github/workflows/claude-dependabot-fix.yml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: read
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/reusable-claude-dependabot-fix.yml@802b7e1bd61d37420efa982eb471356711b46251 # v3.2.0
+    uses: OlivierZal/configs/.github/workflows/reusable-claude-dependabot-fix.yml@dd5ebe19d5b7f3381c34aa25ccba6ce7f324116f # v4.0.0
     with:
       repo-guidance: 'API bugs surfacing through @olivierzal/melcloud-api are fixed in that library, never worked around in this app. When the bump is @olivierzal/configs, realign every `uses: OlivierZal/configs/...` ref in .github/workflows to the tag matching the new npm pin, comment included — one version covers both channels. Stop and leave the pull request failing for human review when that release changes lint policy: adopting it needs per-repository judgement no automated fix can make.'
       verify-commands: '`npm run format`, `npm run lint`, `npm run typecheck`, `npm test`, and `npm run build`'

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -6,7 +6,7 @@ jobs:
       issues: write
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/claude-issue-triage.yml@802b7e1bd61d37420efa982eb471356711b46251 # v3.2.0
+    uses: OlivierZal/configs/.github/workflows/claude-issue-triage.yml@dd5ebe19d5b7f3381c34aa25ccba6ce7f324116f # v4.0.0
 name: claude-issue-triage
 on:
   issues:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -11,7 +11,7 @@ jobs:
       pull-requests: read
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/claude.yml@802b7e1bd61d37420efa982eb471356711b46251 # v3.2.0
+    uses: OlivierZal/configs/.github/workflows/claude.yml@dd5ebe19d5b7f3381c34aa25ccba6ce7f324116f # v4.0.0
 name: claude
 on:
   # No pull_request_review(_comment): Copilot auto-review fires them as a

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -4,7 +4,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: OlivierZal/configs/.github/workflows/dependabot.yml@802b7e1bd61d37420efa982eb471356711b46251 # v3.2.0
+    uses: OlivierZal/configs/.github/workflows/dependabot.yml@dd5ebe19d5b7f3381c34aa25ccba6ce7f324116f # v4.0.0
 name: dependabot
 on:
   pull_request: {}

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -3,7 +3,7 @@ jobs:
   dependency-review:
     permissions:
       contents: read
-    uses: OlivierZal/configs/.github/workflows/dependency-review.yml@802b7e1bd61d37420efa982eb471356711b46251 # v3.2.0
+    uses: OlivierZal/configs/.github/workflows/dependency-review.yml@dd5ebe19d5b7f3381c34aa25ccba6ce7f324116f # v4.0.0
 name: Dependency review
 on:
   pull_request: {}

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -3,7 +3,7 @@ jobs:
   pr_title:
     permissions:
       pull-requests: read
-    uses: OlivierZal/configs/.github/workflows/pr-title.yml@802b7e1bd61d37420efa982eb471356711b46251 # v3.2.0
+    uses: OlivierZal/configs/.github/workflows/pr-title.yml@dd5ebe19d5b7f3381c34aa25ccba6ce7f324116f # v4.0.0
 name: pr-title
 on:
   pull_request:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -5,7 +5,7 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    uses: OlivierZal/configs/.github/workflows/zizmor.yml@802b7e1bd61d37420efa982eb471356711b46251 # v3.2.0
+    uses: OlivierZal/configs/.github/workflows/zizmor.yml@dd5ebe19d5b7f3381c34aa25ccba6ce7f324116f # v4.0.0
 name: zizmor
 on:
   pull_request: {}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -349,8 +349,8 @@ coverage.
   methods are accepted (`toSorted`/`toReversed` — the lint mandates
   them and they ship today), but nothing newer — no iterator helpers
   (`.entries().map()`, 2025-era), no `Object.groupBy` & co.: esbuild
-  lowers syntax only, and old iOS engines are real. Never load the
-  bundle as a STATIC
+  lowers syntax only, and the floor derives from the mobile app's
+  iOS 16.4 minimum (below). Never load the bundle as a STATIC
   `<script type="module">`: 45.2.5 shipped that and every webview spun
   forever on a cold open (proven with breadcrumbs over `homey app run`;
   reverted). Dynamic `import()` is merely unnecessary, not broken — its
@@ -443,22 +443,33 @@ coverage.
   even where no rule captures it.
 - The webview runtime floor (es2023: no `Object.groupBy`, no iterator
   helpers, no `v` regex flag) is enforced by a scoped lint block over
-  `public/`, `settings/` and `widgets/*/public/` — the tsconfig cannot
-  express two runtimes in one project, and the floor has already
-  caused a production incident once. A `tsconfig.webview.json`
-  (target/lib ES2023) would be the stronger form, but was probed and
-  refused (2026-08-06): `include` does not bound the project — tsc
-  checks the import CLOSURE, and the webview-facing types import the
-  drivers' type barrel, reaching node-side es2024/2025 code. Revisit
-  only if webview-facing types get decoupled from driver classes
-  (pure DTOs).
+  `public/`, `settings/`, `types/widgets.mts` and `widgets/*/public/`
+  — the tsconfig cannot express two runtimes in one project. It is
+  DERIVED, not preventive: the Homey mobile app requires iOS 16.4 or
+  later (App Store, read 2026-08-11), and a Homey app only ever gets
+  the system WebKit, so the worst legitimate engine is iOS 16.4's —
+  es2023-complete, short of every es2024 gain (`Object.groupBy` and
+  `Promise.withResolvers` need Safari 17.4, the `v` flag 17). es2024
+  becomes derivable the day that App Store minimum reaches 17.4;
+  Android never binds the floor, its System WebView being evergreen. A
+  `tsconfig.webview.json` (target/lib ES2023) would be the stronger
+  form, but was probed and refused (2026-08-06): `include` does not
+  bound the project — tsc checks the import CLOSURE, and the
+  webview-facing types import the drivers' type barrel, reaching
+  node-side es2024/2025 code. Revisit only if webview-facing types get
+  decoupled from driver classes (pure DTOs).
 - TWO floors coexist, on UNRELATED engines — never let one move the
-  other. The **webview** floor is es2023, set by the phone's WebKit,
-  which no Homey firmware can rejuvenate: it stays enforced by the
-  scoped lint block above, and the danger there is APIs, because
-  esbuild lowers syntax but NEVER polyfills. The **node-side** floor is
-  the Homey's own Node, held by the manifest's `compatibility`
-  declaration, NOT by a check.
+  other. The **webview** floor is es2023, held by the system WebKit
+  that iOS 16.4 minimum implies and no Homey firmware can rejuvenate:
+  it stays enforced by the scoped lint block above, and the danger
+  there is APIs, because esbuild lowers syntax but NEVER polyfills.
+  Severity differs by channel: under a sub-es2024 target esbuild
+  defers a `v` literal to a `new RegExp` call, so a webview escapee
+  throws at RUNTIME inside the feature that runs it, not at parse — a
+  narrower blast radius than the node-side tsc path, which emits the
+  literal verbatim; the ban is the same either way. The **node-side**
+  floor is the Homey's own Node, held by the manifest's
+  `compatibility` declaration, NOT by a check.
 - A floor is declared from WHERE THE CODE RUNS, never from what a
   dependency happens to require. `compatibility: ">=12.9.0"` is
   Athom's own documented Node 22 boundary ("as of Homey v12.9.0, all

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "temporal-polyfill": "^1.0.1"
       },
       "devDependencies": {
-        "@olivierzal/configs": "3.2.0",
+        "@olivierzal/configs": "4.0.0",
         "@types/homey": "npm:homey-apps-sdk-v3-types@^0.3.12",
         "@types/node": "^26.1.2",
         "@typescript/native": "npm:typescript@^7.0.2",
@@ -1071,9 +1071,9 @@
       }
     },
     "node_modules/@olivierzal/configs": {
-      "version": "3.2.0",
-      "resolved": "https://npm.pkg.github.com/download/@olivierzal/configs/3.2.0/4957ec5e3676ec5fcce1ff51f6d4d324f77193ff",
-      "integrity": "sha512-QLtgFcGvYNafsi/O059ZRDPNlluD0RZde95ewAMIw+Yy4Yd+sFBRf1AW8bfjH+sQgrSJNTIKMuf3W3giX0xG5w==",
+      "version": "4.0.0",
+      "resolved": "https://npm.pkg.github.com/download/@olivierzal/configs/4.0.0/e9c57bdad07904b2daa123538bf5408db87d430e",
+      "integrity": "sha512-ERblKVcsjHmoOWvo97q3U7Qk3IrzgzCkwgW4pfe53RETUb+f0Xh+2Woqubr3jmdi7I9aBw36FeE/IRMyTyD+Lw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "temporal-polyfill": "^1.0.1"
   },
   "devDependencies": {
-    "@olivierzal/configs": "3.2.0",
+    "@olivierzal/configs": "4.0.0",
     "@types/homey": "npm:homey-apps-sdk-v3-types@^0.3.12",
     "@types/node": "^26.1.2",
     "@typescript/native": "npm:typescript@^7.0.2",


### PR DESCRIPTION
Pins `@olivierzal/configs` to **4.0.0** on both channels: the npm pin and all nine workflow refs move to `dd5ebe19 # v4.0.0`.

The major retires `check-sonar-bar.sh` from the shipped package: the scanner now carries `-Dsonar.qualitygate.wait=true` and fails the coverage leg itself when the **Olivierzal way** organization gate rejects, while `check-sonar-gate.sh` shrinks to the skipped-scan guards (Dependabot authorship, token presence, coherence). No caller-side YAML shape changes.

The same release rewrites the floor's rationale, so `CLAUDE.md` follows: the es2023 webview floor is **DERIVED**, not preventive. The Homey mobile app requires iOS 16.4 or later (App Store, read 2026-08-11) and a Homey app only ever gets the system WebKit, so the worst legitimate engine is iOS 16.4's — es2023-complete, short of every es2024 gain (`Object.groupBy` and `Promise.withResolvers` need Safari 17.4, the `v` flag 17). es2024 becomes derivable the day that App Store minimum reaches 17.4; Android never binds the floor, its System WebView being evergreen. The undated "old iOS engines are real" justification goes with it.

Severity is corrected too: under a sub-es2024 esbuild target a `v` literal ships as a `new RegExp` call, so a webview escapee throws at RUNTIME inside the feature that runs it, not at parse — the parse crash belongs to the node-side tsc path, which emits the literal verbatim. The ban is unchanged either way.

Local suite: format, lint, typecheck, 953 tests across 51 files, 100 % on all four axes, `homey:validate` at publish level with no rewrite, `check-pins.sh` 14 refs across 12 files with both channels agreeing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)