### PR TITLE
build: adopt @olivierzal/configs 4.0.1 and derive the contributing floor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
       packages: read
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/reusable-ci.yml@dd5ebe19d5b7f3381c34aa25ccba6ce7f324116f # v4.0.0
+    uses: OlivierZal/configs/.github/workflows/reusable-ci.yml@1fbb744f0684e5ead7f5e919d6f6ad1e973e54b4 # v4.0.1
     with:
       check-node-version: '22'
       # The coverage/Sonar leg carries its own flag, and it runs on the

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -8,7 +8,7 @@ jobs:
       pull-requests: write
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/claude-code-review.yml@dd5ebe19d5b7f3381c34aa25ccba6ce7f324116f # v4.0.0
+    uses: OlivierZal/configs/.github/workflows/claude-code-review.yml@1fbb744f0684e5ead7f5e919d6f6ad1e973e54b4 # v4.0.1
 name: claude-code-review
 on:
   pull_request:

--- a/.github/workflows/claude-dependabot-fix.yml
+++ b/.github/workflows/claude-dependabot-fix.yml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: read
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/reusable-claude-dependabot-fix.yml@dd5ebe19d5b7f3381c34aa25ccba6ce7f324116f # v4.0.0
+    uses: OlivierZal/configs/.github/workflows/reusable-claude-dependabot-fix.yml@1fbb744f0684e5ead7f5e919d6f6ad1e973e54b4 # v4.0.1
     with:
       repo-guidance: 'API bugs surfacing through @olivierzal/melcloud-api are fixed in that library, never worked around in this app. When the bump is @olivierzal/configs, realign every `uses: OlivierZal/configs/...` ref in .github/workflows to the tag matching the new npm pin, comment included — one version covers both channels. Stop and leave the pull request failing for human review when that release changes lint policy: adopting it needs per-repository judgement no automated fix can make.'
       verify-commands: '`npm run format`, `npm run lint`, `npm run typecheck`, `npm test`, and `npm run build`'

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -6,7 +6,7 @@ jobs:
       issues: write
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/claude-issue-triage.yml@dd5ebe19d5b7f3381c34aa25ccba6ce7f324116f # v4.0.0
+    uses: OlivierZal/configs/.github/workflows/claude-issue-triage.yml@1fbb744f0684e5ead7f5e919d6f6ad1e973e54b4 # v4.0.1
 name: claude-issue-triage
 on:
   issues:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -11,7 +11,7 @@ jobs:
       pull-requests: read
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/claude.yml@dd5ebe19d5b7f3381c34aa25ccba6ce7f324116f # v4.0.0
+    uses: OlivierZal/configs/.github/workflows/claude.yml@1fbb744f0684e5ead7f5e919d6f6ad1e973e54b4 # v4.0.1
 name: claude
 on:
   # No pull_request_review(_comment): Copilot auto-review fires them as a

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -4,7 +4,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: OlivierZal/configs/.github/workflows/dependabot.yml@dd5ebe19d5b7f3381c34aa25ccba6ce7f324116f # v4.0.0
+    uses: OlivierZal/configs/.github/workflows/dependabot.yml@1fbb744f0684e5ead7f5e919d6f6ad1e973e54b4 # v4.0.1
 name: dependabot
 on:
   pull_request: {}

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -3,7 +3,7 @@ jobs:
   dependency-review:
     permissions:
       contents: read
-    uses: OlivierZal/configs/.github/workflows/dependency-review.yml@dd5ebe19d5b7f3381c34aa25ccba6ce7f324116f # v4.0.0
+    uses: OlivierZal/configs/.github/workflows/dependency-review.yml@1fbb744f0684e5ead7f5e919d6f6ad1e973e54b4 # v4.0.1
 name: Dependency review
 on:
   pull_request: {}

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -3,7 +3,7 @@ jobs:
   pr_title:
     permissions:
       pull-requests: read
-    uses: OlivierZal/configs/.github/workflows/pr-title.yml@dd5ebe19d5b7f3381c34aa25ccba6ce7f324116f # v4.0.0
+    uses: OlivierZal/configs/.github/workflows/pr-title.yml@1fbb744f0684e5ead7f5e919d6f6ad1e973e54b4 # v4.0.1
 name: pr-title
 on:
   pull_request:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -5,7 +5,7 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    uses: OlivierZal/configs/.github/workflows/zizmor.yml@dd5ebe19d5b7f3381c34aa25ccba6ce7f324116f # v4.0.0
+    uses: OlivierZal/configs/.github/workflows/zizmor.yml@1fbb744f0684e5ead7f5e919d6f6ad1e973e54b4 # v4.0.1
 name: zizmor
 on:
   pull_request: {}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,13 +62,17 @@ add the missing `l`, in the manifest, the code or the docs.
 
 Node-side code follows `engines.node` and may use modern APIs freely.
 
-Webview code — [`settings/`](settings), [`public/`](public) and
-`widgets/*/public/` — runs on **phone browser engines**, not on the
-Homey. Those stall at **es2023**, a separate and lower ceiling the lint
-enforces on exactly those paths. esbuild lowers syntax but never
-polyfills APIs, so a too-recent API passes both the lint and the compile
-and fails only on a user's phone. Raising one floor never raises the
-other; conflating them has already caused a production incident.
+Webview code — [`settings/`](settings), [`public/`](public),
+`widgets/*/public/` and [`types/widgets.mts`](types/widgets.mts),
+which ships into the charts bundle — runs on **phone browser engines**,
+not on the Homey. Its ceiling is **es2023**, derived from the Homey
+mobile app's own iOS 16.4 minimum (App Store, 2026-08-11): an app only
+ever gets the system WebKit, and iOS 16.4's has none of es2024. The
+lint enforces that ceiling on exactly those paths. esbuild lowers
+syntax but never polyfills APIs, so a too-recent API passes both the
+lint and the compile and fails only on a user's phone. Raising one
+floor never raises the other; conflating them has already caused a
+production incident.
 
 The floor the device runs is a third, distinct declaration:
 `compatibility` in [`.homeycompose/app.json`](.homeycompose/app.json).

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "temporal-polyfill": "^1.0.1"
       },
       "devDependencies": {
-        "@olivierzal/configs": "4.0.0",
+        "@olivierzal/configs": "4.0.1",
         "@types/homey": "npm:homey-apps-sdk-v3-types@^0.3.12",
         "@types/node": "^26.1.2",
         "@typescript/native": "npm:typescript@^7.0.2",
@@ -1071,9 +1071,9 @@
       }
     },
     "node_modules/@olivierzal/configs": {
-      "version": "4.0.0",
-      "resolved": "https://npm.pkg.github.com/download/@olivierzal/configs/4.0.0/e9c57bdad07904b2daa123538bf5408db87d430e",
-      "integrity": "sha512-ERblKVcsjHmoOWvo97q3U7Qk3IrzgzCkwgW4pfe53RETUb+f0Xh+2Woqubr3jmdi7I9aBw36FeE/IRMyTyD+Lw==",
+      "version": "4.0.1",
+      "resolved": "https://npm.pkg.github.com/download/@olivierzal/configs/4.0.1/baaf00059f15b95f4f339311beb52db55658bf4a",
+      "integrity": "sha512-gz7mQl4K2OA9H3qMrzt5Y2dOCMG9UhIorxQoK8G12+KYzSuG2PxhBiqakDGsIVtxdfCPpLiW/6hC3juTeUG5Dg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "temporal-polyfill": "^1.0.1"
   },
   "devDependencies": {
-    "@olivierzal/configs": "4.0.0",
+    "@olivierzal/configs": "4.0.1",
     "@types/homey": "npm:homey-apps-sdk-v3-types@^0.3.12",
     "@types/node": "^26.1.2",
     "@typescript/native": "npm:typescript@^7.0.2",


### PR DESCRIPTION
Adopts configs 4.0.1 — the release that carries OlivierZal/configs#57's corrected webview-floor doctrine into the installed artifact. Both channels move together: the npm pin to `4.0.1`, every workflow ref to `1fbb744f0684e5ead7f5e919d6f6ad1e973e54b4 # v4.0.1`.

Iso-behavior: `eslint --print-config` on `settings/index.mts` and `app.mts` differs from 4.0.0 only in `message` strings (4 lines, all in the webview-floor file; `app.mts` is byte-identical) — selectors, globs and severities untouched. Not a policy change.

This PR also brings CONTRIBUTING.md up to the derivation #1584 landed everywhere else in the repo: the floor is now stated as derived from the Homey mobile app's iOS 16.4 App Store minimum rather than as an undated "old engines" claim, and the glob list now names `types/widgets.mts` — the fourth glob the lint already enforces, which ships into the charts bundle — matching `eslint.config.ts` and CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
