### PR TITLE
feat: keep in-progress widget edits across real-time syncs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -400,6 +400,21 @@ coverage.
   write API-side (the Classic ATA facade clamps against its reported
   `MinTempCoolDry`/`MaxTempHeat` and friends). Never duplicate that
   clamp widget-side.
+- The ATA group widget's real-time path (`deviceupdate`, debounced)
+  resyncs only PRISTINE controls: one still showing what the zone held
+  follows the stream, one the user moved keeps the edit, and no
+  baseline moves — the gate runs in predicate mode, so the body builder
+  re-judges the kept edits against the zone's NEW state: Update greys
+  exactly when every edit was caught up (a button that would send
+  nothing must not arm) and re-arms the moment one diverges again. A
+  caught-up control has, by the same value judgment, rejoined the
+  stream. `SetTemperature` resyncs LAST so its grid rebuild reads the
+  mode the same sync settled, and a kept edit the new floor no longer
+  offers blanks to "no instruction" — the form never displays a value
+  no request could carry. Full resyncs stay full: initial load, zone
+  switch (an edit is a zone-scoped statement, not a portable one) and
+  Refresh, which remains the deliberate way back to the zone's current
+  state.
 - Widgets ship separately; they cannot share files at runtime. The zone
   selector's ghost styling is deliberately duplicated as byte-identical
   `styles/zone-select.css` twins, pinned by `tests/unit/widget-styles.test.ts`

--- a/tests/unit/ata-group-setting.test.ts
+++ b/tests/unit/ata-group-setting.test.ts
@@ -193,6 +193,24 @@ describe('ata group setting widget', () => {
     expect(stateFetches()).toBe(before + 1)
   })
 
+  it('should keep an in-progress edit across a device update', async () => {
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
+    const routes = widgetRoutes()
+    const harness = await bootWidget({ routes })
+    commit(getSelect('SetTemperature'), '25')
+    routes['GET /classic/zones/buildings/1/ata'] = {
+      ...groupStateFixture(),
+      Power: false,
+    }
+    harness.emit('deviceupdate')
+    await vi.advanceTimersByTimeAsync(1000)
+    await settleDetached()
+
+    expect(getSelect('Power').value).toBe('false')
+    expect(getSelect('SetTemperature').value).toBe('25')
+    expect(getButton('apply_values_melcloud').disabled).toBe(false)
+  })
+
   it('should recover a load that outlives the overlay timeout', async () => {
     vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
     const targets = Promise.withResolvers<unknown>()

--- a/tests/unit/ata-values.test.ts
+++ b/tests/unit/ata-values.test.ts
@@ -357,6 +357,69 @@ describe('ata value manager', () => {
     expect(getSelect('SetTemperature').value).toBe('22')
   })
 
+  it('should keep an in-progress edit across a real-time sync', async () => {
+    const routes = widgetRoutes()
+    const { manager } = await createManager({ routes })
+    await manager.fetchValues()
+    commit(getSelect('SetTemperature'), '25')
+    routes['GET /classic/zones/buildings/1/ata'] = {
+      ...groupStateFixture(),
+      Power: false,
+    }
+    await manager.fetchValuesKeepingEdits()
+
+    // The untouched control follows the stream; the edit stays the
+    // user's, so pressing Update would still carry it.
+    expect(getSelect('Power').value).toBe('false')
+    expect(getSelect('SetTemperature').value).toBe('25')
+    expect(getButtonDisabled('apply_values_melcloud')).toBe(false)
+  })
+
+  it('should grey Update when the zone catches up with the edit', async () => {
+    const routes = widgetRoutes()
+    const { manager } = await createManager({ routes })
+    await manager.fetchValues()
+    commit(getSelect('SetTemperature'), '25')
+    routes['GET /classic/zones/buildings/1/ata'] = {
+      ...groupStateFixture(),
+      SetTemperature: 25,
+    }
+    await manager.fetchValuesKeepingEdits()
+
+    // The edit became a no-op: nothing to send, so the gate cannot arm.
+    expect(getSelect('SetTemperature').value).toBe('25')
+    expect(getButtonDisabled('apply_values_melcloud')).toBe(true)
+
+    // Caught up means released: the control follows the stream again.
+    routes['GET /classic/zones/buildings/1/ata'] = {
+      ...groupStateFixture(),
+      SetTemperature: 23,
+    }
+    await manager.fetchValuesKeepingEdits()
+
+    expect(getSelect('SetTemperature').value).toBe('23')
+  })
+
+  it('should blank an edit the incoming mode pushed off the grid', async () => {
+    const routes = widgetRoutes()
+    const { manager } = await createManager({ routes })
+    await manager.fetchValues()
+    commit(getSelect('SetTemperature'), '12')
+    routes['GET /classic/zones/buildings/1/ata'] = {
+      ...groupStateFixture(),
+      OperationMode: 3,
+    }
+    await manager.fetchValuesKeepingEdits()
+
+    // The synced cooling mode raised the floor past the edit: a value
+    // no request could carry blanks to "no instruction", and an empty
+    // body cannot arm.
+    expect(getSelect('OperationMode').value).toBe('3')
+    expect(getSelect('SetTemperature').value).toBe('')
+    expect(optionValues(getSelect('SetTemperature'))).not.toContain('12')
+    expect(getButtonDisabled('apply_values_melcloud')).toBe(true)
+  })
+
   it('should skip a value slot without a control', async () => {
     const { manager } = await createManager()
     // A rogue non-control carrying a capability id must not take the

--- a/widgets/ata-group-setting/public/ata-values.mts
+++ b/widgets/ata-group-setting/public/ata-values.mts
@@ -226,6 +226,10 @@ export class AtaValueManager {
     )
   }
 
+  // The FULL sync: initial load, zone switch and Refresh all mean "show
+  // me the zone as it stands", so every control takes the server state,
+  // edits included — an edit is a zone-scoped statement, not a portable
+  // one. The real-time path is `fetchValuesKeepingEdits`.
   public async fetchValues(): Promise<Classic.GroupState> {
     const values = await homeyApiGet<Classic.GroupState>(
       this.#homey,
@@ -233,10 +237,27 @@ export class AtaValueManager {
     )
     this.#updateZoneMapping({ ...this.#defaultAtaValues, ...values })
     this.#syncAtaValues()
-    // The incoming server state becomes the new baseline (a background
-    // re-fetch mid-edit re-snapshots here); `runBusy`'s generation guard
-    // keeps this from releasing a save that a live PUT still owns.
+    // `runBusy`'s generation guard keeps this from releasing a save
+    // that a live PUT still owns.
     this.#dirtyGate.markSaved()
+    return values
+  }
+
+  // The real-time sync (`deviceupdate`): a control still showing what
+  // the zone held follows the stream; one the user moved keeps the
+  // edit. No baseline moves — the gate runs in predicate mode, so
+  // `recompute` re-judges the kept edits against the zone's NEW state:
+  // Update greys exactly when every edit was caught up (a no-op button
+  // must not arm) and re-arms the moment one diverges again.
+  public async fetchValuesKeepingEdits(): Promise<Classic.GroupState> {
+    const previous = { ...this.#zoneMapping[this.#zone.value] }
+    const values = await homeyApiGet<Classic.GroupState>(
+      this.#homey,
+      getAtaStatePath(this.#zone.value),
+    )
+    this.#updateZoneMapping({ ...this.#defaultAtaValues, ...values })
+    this.#syncPristineAtaValues(previous)
+    this.#dirtyGate.recompute()
     return values
   }
 
@@ -332,6 +353,35 @@ export class AtaValueManager {
   #syncAtaValues(): void {
     for (const [ataKey] of this.#ataCapabilities) {
       this.#updateAtaValue(ataKey)
+    }
+  }
+
+  // `SetTemperature` runs LAST so its grid rebuild reads the mode this
+  // same sync settled (a programmatic mode write fires no `change`
+  // event for the rebuild wiring to catch). A kept edit the new floor
+  // no longer offers blanks to "no instruction": the form never
+  // displays a value no request could carry.
+  #syncPristineAtaValues(previous: Partial<Classic.GroupState>): void {
+    const ataKeys = this.#ataCapabilities
+      .map(([ataKey]) => ataKey)
+      .toSorted(
+        (first, second) =>
+          Number(first === 'SetTemperature') -
+          Number(second === 'SetTemperature'),
+      )
+    for (const ataKey of ataKeys) {
+      const control = this.#ataValues.querySelector(`#${CSS.escape(ataKey)}`)
+      if (
+        !(control instanceof HTMLInputElement) &&
+        !(control instanceof HTMLSelectElement)
+      ) {
+        continue
+      }
+      if (control.value === (previous[ataKey]?.toString() ?? '')) {
+        this.#updateAtaValue(ataKey)
+      } else if (ataKey === 'SetTemperature') {
+        this.#refreshTemperatureOptions(control.value)
+      }
     }
   }
 

--- a/widgets/ata-group-setting/public/index.mts
+++ b/widgets/ata-group-setting/public/index.mts
@@ -93,11 +93,14 @@ class WidgetApp {
         clearTimeout(this.#debounceTimeout)
       }
       this.#debounceTimeout = setTimeout(() => {
-        fireAndForget(this.#fetchAndAnimate())
+        fireAndForget(this.#refreshKeepingEdits())
       }, AnimationDelay.debounce)
     })
   }
 
+  // Zone switch and initial load take the full sync ("show me the zone
+  // as it stands"); the real-time stream must not clobber an edit in
+  // progress, so it goes through the edit-keeping sync instead.
   async #fetchAndAnimate(): Promise<void> {
     const values = await this.#ataValueManager.fetchValues()
     await this.#animationController.applyAnimation(values)
@@ -125,6 +128,11 @@ class WidgetApp {
       this.#ataValueManager.applyDefaultZone(defaultZone)
       await this.#fetchAndAnimate()
     }
+  }
+
+  async #refreshKeepingEdits(): Promise<void> {
+    const values = await this.#ataValueManager.fetchValuesKeepingEdits()
+    await this.#animationController.applyAnimation(values)
   }
 
   async #run(): Promise<void> {


### PR DESCRIPTION
The ATA group widget's real-time path (`deviceupdate`, debounced) used to resync every control and re-grey Update, clobbering whatever the user was editing. It now resyncs only PRISTINE controls: one still showing what the zone held follows the stream, one the user moved keeps the edit — and no baseline moves, so the predicate-mode gate re-judges the kept edits against the zone's NEW state through the existing body builder. Update greys exactly when every edit was caught up (a button that would send nothing must not arm) and re-arms the moment one diverges again; a caught-up control has, by the same value judgment, rejoined the stream.

Two deliberate verdicts, recorded in CLAUDE.md:
- dirty is judged by VALUE, not by touch — an edit the stream caught up is a no-op, and preserving a no-op would only arm a lying button;
- `SetTemperature` resyncs LAST so its grid rebuild reads the mode the same sync settled, and a kept edit the new floor no longer offers blanks to "no instruction" — the form never displays a value no request could carry.

Full resyncs stay full: initial load, zone switch and Refresh. No homey-kit change: the gate already exposes `recompute` for programmatic writes.

Tests: three manager-level cases (edit kept + pristine synced + armed; caught-up greys then rejoins the stream; off-grid edit blanked with an empty body) and one wiring case (edit survives a `deviceupdate` burst). 957 tests, lint and typecheck green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)