### PR TITLE
test: cover the pristine-blank and kept-edit branches

### DIFF
--- a/tests/unit/ata-values.test.ts
+++ b/tests/unit/ata-values.test.ts
@@ -360,18 +360,30 @@ describe('ata value manager', () => {
   it('should keep an in-progress edit across a real-time sync', async () => {
     const routes = widgetRoutes()
     const { manager } = await createManager({ routes })
+    // The zone starts without a fan-speed reading: the control opens
+    // blank, and blank-vs-absent must read as pristine, not as an edit.
+    routes['GET /classic/zones/buildings/1/ata'] = {
+      OperationMode: 1,
+      Power: true,
+      SetTemperature: 22,
+    }
     await manager.fetchValues()
     commit(getSelect('SetTemperature'), '25')
+    const fanSpeed = getInput('FanSpeed')
+    fanSpeed.value = '5'
+    fanSpeed.dispatchEvent(new Event('change', { bubbles: true }))
     routes['GET /classic/zones/buildings/1/ata'] = {
       ...groupStateFixture(),
       Power: false,
     }
     await manager.fetchValuesKeepingEdits()
 
-    // The untouched control follows the stream; the edit stays the
-    // user's, so pressing Update would still carry it.
+    // The untouched control follows the stream; the edits — the picker
+    // and the free input alike — stay the user's, so pressing Update
+    // would still carry them.
     expect(getSelect('Power').value).toBe('false')
     expect(getSelect('SetTemperature').value).toBe('25')
+    expect(getInput('FanSpeed').value).toBe('5')
     expect(getButtonDisabled('apply_values_melcloud')).toBe(false)
   })
 


### PR DESCRIPTION
Repairs red `main`: #1587 auto-merged at 19:47:44Z on green *required* contexts while the flagged coverage leg — `ci / Test (Node 22.20)`, absent from the ruleset — was still failing (99.81% branches), so the squash landed without this commit and the `main` run failed with branch Sonar skipped. Two uncovered branches in the new real-time sync get their tests: the kept non-temperature edit (a FanSpeed edit now rides the first case) and the nullish arm for a zone opening without a reading (blank-vs-absent pinned as PRISTINE, not as an edit).

The ruleset gap itself is being closed separately: `ci / Test (Node 22.20)` joins the required contexts, which is what the reusable-ci's skipped-Sonar reasoning always assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)