### PR TITLE
build: adopt @olivierzal/configs 4.2.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
       packages: read
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/reusable-ci.yml@9a7c5901faa9f17cf82b67553434c80a21a1df36 # v4.2.0
+    uses: OlivierZal/configs/.github/workflows/reusable-ci.yml@dd730be20712cee23726f2f9da9403d9f79694e2 # v4.2.1
     with:
       check-node-version: '22'
       # The coverage/Sonar leg carries its own flag, and it runs on the

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -8,7 +8,7 @@ jobs:
       pull-requests: write
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/claude-code-review.yml@9a7c5901faa9f17cf82b67553434c80a21a1df36 # v4.2.0
+    uses: OlivierZal/configs/.github/workflows/claude-code-review.yml@dd730be20712cee23726f2f9da9403d9f79694e2 # v4.2.1
 name: claude-code-review
 on:
   pull_request:

--- a/.github/workflows/claude-dependabot-fix.yml
+++ b/.github/workflows/claude-dependabot-fix.yml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: read
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/reusable-claude-dependabot-fix.yml@9a7c5901faa9f17cf82b67553434c80a21a1df36 # v4.2.0
+    uses: OlivierZal/configs/.github/workflows/reusable-claude-dependabot-fix.yml@dd730be20712cee23726f2f9da9403d9f79694e2 # v4.2.1
     with:
       repo-guidance: 'API bugs surfacing through @olivierzal/melcloud-api are fixed in that library, never worked around in this app. When the bump is @olivierzal/configs, realign every `uses: OlivierZal/configs/...` ref in .github/workflows to the tag matching the new npm pin, comment included — one version covers both channels. Stop and leave the pull request failing for human review when that release changes lint policy: adopting it needs per-repository judgement no automated fix can make.'
       verify-commands: '`npm run format`, `npm run lint`, `npm run typecheck`, `npm test`, and `npm run build`'

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -6,7 +6,7 @@ jobs:
       issues: write
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/claude-issue-triage.yml@9a7c5901faa9f17cf82b67553434c80a21a1df36 # v4.2.0
+    uses: OlivierZal/configs/.github/workflows/claude-issue-triage.yml@dd730be20712cee23726f2f9da9403d9f79694e2 # v4.2.1
 name: claude-issue-triage
 on:
   issues:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -11,7 +11,7 @@ jobs:
       pull-requests: read
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/claude.yml@9a7c5901faa9f17cf82b67553434c80a21a1df36 # v4.2.0
+    uses: OlivierZal/configs/.github/workflows/claude.yml@dd730be20712cee23726f2f9da9403d9f79694e2 # v4.2.1
 name: claude
 on:
   # No pull_request_review(_comment): Copilot auto-review fires them as a

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -4,7 +4,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: OlivierZal/configs/.github/workflows/dependabot.yml@9a7c5901faa9f17cf82b67553434c80a21a1df36 # v4.2.0
+    uses: OlivierZal/configs/.github/workflows/dependabot.yml@dd730be20712cee23726f2f9da9403d9f79694e2 # v4.2.1
 name: dependabot
 on:
   pull_request: {}

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -3,7 +3,7 @@ jobs:
   dependency-review:
     permissions:
       contents: read
-    uses: OlivierZal/configs/.github/workflows/dependency-review.yml@9a7c5901faa9f17cf82b67553434c80a21a1df36 # v4.2.0
+    uses: OlivierZal/configs/.github/workflows/dependency-review.yml@dd730be20712cee23726f2f9da9403d9f79694e2 # v4.2.1
 name: Dependency review
 on:
   pull_request: {}

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -3,7 +3,7 @@ jobs:
   pr_title:
     permissions:
       pull-requests: read
-    uses: OlivierZal/configs/.github/workflows/pr-title.yml@9a7c5901faa9f17cf82b67553434c80a21a1df36 # v4.2.0
+    uses: OlivierZal/configs/.github/workflows/pr-title.yml@dd730be20712cee23726f2f9da9403d9f79694e2 # v4.2.1
 name: pr-title
 on:
   pull_request:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -5,7 +5,7 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    uses: OlivierZal/configs/.github/workflows/zizmor.yml@9a7c5901faa9f17cf82b67553434c80a21a1df36 # v4.2.0
+    uses: OlivierZal/configs/.github/workflows/zizmor.yml@dd730be20712cee23726f2f9da9403d9f79694e2 # v4.2.1
 name: zizmor
 on:
   pull_request: {}

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "temporal-polyfill": "^1.0.1"
       },
       "devDependencies": {
-        "@olivierzal/configs": "4.2.0",
+        "@olivierzal/configs": "4.2.1",
         "@types/homey": "npm:homey-apps-sdk-v3-types@^0.3.12",
         "@types/node": "^26.2.0",
         "@typescript/native": "npm:typescript@^7.0.2",
@@ -1071,9 +1071,9 @@
       }
     },
     "node_modules/@olivierzal/configs": {
-      "version": "4.2.0",
-      "resolved": "https://npm.pkg.github.com/download/@olivierzal/configs/4.2.0/84ca347824f442a050b658820d14e0220c592e61",
-      "integrity": "sha512-rwjg44aaHd+PZ6hAxDd8bJew7XIQrUd/sn3fSQwC5y31/hjk/xy6VYpWczYlWYVTNd0LKcZMqc0kTLE5osB9Pg==",
+      "version": "4.2.1",
+      "resolved": "https://npm.pkg.github.com/download/@olivierzal/configs/4.2.1/c2e5f003068c4ee1aa140e8fd60b9d4fea21f023",
+      "integrity": "sha512-Vw352O52Yl7od4jrogd7wiZcvFschVeXd8plvsC5Eg64au0mJJzTcHHok0sK7WVW3RFMOk1IAc35HlTZZQ9CPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "temporal-polyfill": "^1.0.1"
   },
   "devDependencies": {
-    "@olivierzal/configs": "4.2.0",
+    "@olivierzal/configs": "4.2.1",
     "@types/homey": "npm:homey-apps-sdk-v3-types@^0.3.12",
     "@types/node": "^26.2.0",
     "@typescript/native": "npm:typescript@^7.0.2",


### PR DESCRIPTION
Workflow-only release: the triage reusable's verdict moves from a fenced-JSON block to sentinel lines (TRIAGE LABELS: / TRIAGE COMMENT START/END) — the first live run failed loudly because a Markdown comment does not survive JSON string escaping. All nine OlivierZal/configs workflow refs move from 9a7c5901faa9f17cf82b67553434c80a21a1df36 (v4.2.0) to dd730be20712cee23726f2f9da9403d9f79694e2 (v4.2.1), and the npm pin follows so both channels stay on one version; the package content is identical.

No lint policy changes: npx eslint --print-config on drivers/base-device.mts is byte-identical before and after (empty diff). npm run typecheck passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKsbttD4wLTrZnZDwKK1Fn