### PR TITLE
fix: holiday-mode times in the user's timezone, one clock for "now" (46.4.2)

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -1813,5 +1813,20 @@
     "pl": "Edycja w widżecie powietrze-powietrze nie jest już przerywana przez aktualizacje na żywo: nietknięte pola nadal podążają za urządzeniami, a wprowadzone zmiany pozostają na miejscu, dopóki ich nie zastosujesz lub nie odświeżysz.",
     "ru": "Редактирование в виджете «воздух-воздух» больше не прерывается живыми обновлениями: нетронутые поля продолжают следовать за устройствами, а ваши изменения остаются на месте, пока вы их не примените или не обновите.",
     "sv": "Redigering i luft-till-luft-widgeten avbryts inte längre av liveuppdateringar: orörda fält fortsätter att följa dina enheter, och dina ändringar står kvar tills du tillämpar dem eller uppdaterar."
+  },
+  "46.4.2": {
+    "ar": "أصبحت أوقات وضع الإجازة تُحفظ وتُعرض الآن بتوقيتك المحلي الصحيح، ويستخدم وقت البدء التلقائي ساعة Homey.",
+    "da": "Ferietilstandens tidspunkter gemmes og vises nu korrekt i din egen tidszone, og det automatiske starttidspunkt følger din Homeys ur.",
+    "de": "Die Zeiten des Urlaubsmodus werden jetzt korrekt in Ihrer eigenen Zeitzone gespeichert und angezeigt, und die automatische Startzeit folgt der Uhr Ihres Homey.",
+    "en": "Holiday mode times are now stored and shown correctly in your own timezone, and the automatic start time follows your Homey’s clock.",
+    "es": "Las horas del modo vacaciones ahora se guardan y muestran correctamente en tu zona horaria, y la hora de inicio automática sigue el reloj de tu Homey.",
+    "fr": "Les horaires du mode vacances sont désormais enregistrés et affichés correctement dans votre fuseau horaire, et l’heure de début automatique suit l’horloge de votre Homey.",
+    "it": "Gli orari della modalità vacanza ora vengono salvati e mostrati correttamente nel tuo fuso orario, e l’ora di inizio automatica segue l’orologio del tuo Homey.",
+    "ko": "휴가 모드 시간이 이제 사용자의 시간대에 맞게 올바르게 저장되고 표시되며, 자동 시작 시간은 Homey의 시계를 따릅니다.",
+    "nl": "De tijden van de vakantiemodus worden nu correct in je eigen tijdzone opgeslagen en getoond, en de automatische starttijd volgt de klok van je Homey.",
+    "no": "Feriemodusens tidspunkter lagres og vises nå riktig i din egen tidssone, og den automatiske starttiden følger Homey-klokken din.",
+    "pl": "Godziny trybu wakacyjnego są teraz zapisywane i wyświetlane poprawnie w Twojej strefie czasowej, a automatyczny czas rozpoczęcia korzysta z zegara Homey.",
+    "ru": "Время режима отпуска теперь сохраняется и отображается корректно в вашем часовом поясе, а автоматическое время начала следует часам вашего Homey.",
+    "sv": "Semesterlägets tider sparas och visas nu korrekt i din egen tidszon, och den automatiska starttiden följer din Homeys klocka."
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -342,5 +342,5 @@
       "värmeåtervinning"
     ]
   },
-  "version": "46.4.1"
+  "version": "46.4.2"
 }

--- a/api.mts
+++ b/api.mts
@@ -5,7 +5,6 @@ import type { Homey } from 'homey/lib/Homey'
 import { getErrorMessage } from '@olivierzal/homey-kit'
 import {
   type HolidayModeState,
-  type HolidayModeUpdate,
   type LoginCredentials,
   type ProtectionState,
   type ProtectionUpdate,
@@ -13,6 +12,7 @@ import {
   AuthenticationThrottledError,
 } from '@olivierzal/melcloud-api'
 
+import type { HolidayModeSettings } from './types/api.mts'
 import type { DeviceSettings, Settings } from './types/device-settings.mts'
 import type {
   ErrorLogQueryParams,
@@ -297,7 +297,7 @@ const api = {
     homey: { app },
     params,
   }: {
-    body: HolidayModeUpdate
+    body: HolidayModeSettings
     homey: Homey
     params: DeviceOrZoneData
   }): Promise<void> =>
@@ -328,7 +328,7 @@ const api = {
     homey: { app },
     params: { buildingId },
   }: {
-    body: HolidayModeUpdate
+    body: HolidayModeSettings
     homey: Homey
     params: { buildingId: string }
   }): Promise<void> => app.updateHomeBuildingHolidayMode(buildingId, body),
@@ -356,7 +356,7 @@ const api = {
     homey: { app },
     params: { deviceId },
   }: {
-    body: HolidayModeUpdate
+    body: HolidayModeSettings
     homey: Homey
     params: { deviceId: string }
   }): Promise<void> => app.updateHomeHolidayMode([deviceId], body),

--- a/app.json
+++ b/app.json
@@ -343,7 +343,7 @@
       "värmeåtervinning"
     ]
   },
-  "version": "46.4.1",
+  "version": "46.4.2",
   "flow": {
     "triggers": [
       {

--- a/app.mts
+++ b/app.mts
@@ -32,7 +32,7 @@ import { Intl, Temporal } from 'temporal-polyfill'
 import * as Classic from '@olivierzal/melcloud-api/classic'
 import * as Home from '@olivierzal/melcloud-api/home'
 
-import type { Api } from './types/api.mts'
+import type { Api, HolidayModeSettings } from './types/api.mts'
 import type { HomeySettings } from './types/app-settings.mts'
 import type { GroupAtaStates } from './types/classic-ata.mts'
 import type { DeviceSettings, Settings } from './types/device-settings.mts'
@@ -901,8 +901,10 @@ export default class MELCloudApp extends App {
     settings,
     zoneId,
     zoneType,
-  }: DeviceOrZoneData & { settings: HolidayModeUpdate }): Promise<void> {
-    await this.getClassicFacade(zoneType, zoneId).updateHolidayMode(settings)
+  }: DeviceOrZoneData & { settings: HolidayModeSettings }): Promise<void> {
+    await this.getClassicFacade(zoneType, zoneId).updateHolidayMode(
+      this.#completeHolidayModeWindow(settings),
+    )
   }
 
   public async updateDeviceSettings({
@@ -973,7 +975,7 @@ export default class MELCloudApp extends App {
 
   public async updateHomeBuildingHolidayMode(
     buildingId: string,
-    settings: HolidayModeUpdate,
+    settings: HolidayModeSettings,
   ): Promise<void> {
     await this.updateHomeHolidayMode(
       this.#getHomeBuildingDeviceIds(buildingId),
@@ -1000,9 +1002,12 @@ export default class MELCloudApp extends App {
 
   public async updateHomeHolidayMode(
     deviceIds: readonly string[],
-    settings: HolidayModeUpdate,
+    settings: HolidayModeSettings,
   ): Promise<void> {
-    await this.#homeFacadeManager.updateHolidayMode(deviceIds, settings)
+    await this.#homeFacadeManager.updateHolidayMode(
+      deviceIds,
+      this.#completeHolidayModeWindow(settings),
+    )
   }
 
   public async updateHomeOverheatProtection(
@@ -1066,6 +1071,24 @@ export default class MELCloudApp extends App {
       if (result.status === 'rejected') {
         this.error('Device sync failed:', result.reason)
       }
+    }
+  }
+
+  // One clock for every entry point: the Homey's. An absent bound means
+  // "now" — the settings page no longer stamps the phone's clock, whose
+  // divergence from the flow cards' Homey clock was #1595.
+  #completeHolidayModeWindow({
+    endDate,
+    isEnabled,
+    startDate,
+  }: HolidayModeSettings): HolidayModeUpdate {
+    const nowAtHomey = Temporal.Now.plainDateTimeISO(
+      getTimeZone(this.homey),
+    ).toString()
+    return {
+      endDate: endDate ?? nowAtHomey,
+      isEnabled,
+      startDate: startDate ?? nowAtHomey,
     }
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "com.melcloud",
-  "version": "46.4.1",
+  "version": "46.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "com.melcloud",
-      "version": "46.4.1",
+      "version": "46.4.2",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@olivierzal/homey-kit": "5.0.0",
-        "@olivierzal/melcloud-api": "48.1.0",
+        "@olivierzal/melcloud-api": "49.0.0",
         "source-map-support": "^0.5.21",
         "temporal-polyfill": "^1.0.1"
       },
@@ -1117,9 +1117,9 @@
       }
     },
     "node_modules/@olivierzal/melcloud-api": {
-      "version": "48.1.0",
-      "resolved": "https://npm.pkg.github.com/download/@olivierzal/melcloud-api/48.1.0/f0be274e553d3b8dbcc333b43d9086142dd3c7aa",
-      "integrity": "sha512-LN6q7n4ywMKIPgIJ+wWk0HxdfMVM5TAf04AkSb/BwbXppv0heQ+SzD0lBS6OHHDAhwJbzD5uSTzNau/7AewZeQ==",
+      "version": "49.0.0",
+      "resolved": "https://npm.pkg.github.com/download/@olivierzal/melcloud-api/49.0.0/c5cd96f3c5ac702a45f49874811f519a5a75d0c5",
+      "integrity": "sha512-q1GezXrBp+m8bRRuJvZ58pHhTjjCBN1yYNo5ZNkJR0Va6mEKA1WpuWpNlKeZGAWTUSdfgmWfP0nek2V4jOOz8Q==",
       "license": "MIT",
       "dependencies": {
         "temporal-polyfill": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.melcloud",
-  "version": "46.4.1",
+  "version": "46.4.2",
   "description": "MELCloud for Homey",
   "homepage": "https://github.com/OlivierZal/com.melcloud/",
   "bugs": {
@@ -33,7 +33,7 @@
   "prettier": "@olivierzal/configs/prettier",
   "dependencies": {
     "@olivierzal/homey-kit": "5.0.0",
-    "@olivierzal/melcloud-api": "48.1.0",
+    "@olivierzal/melcloud-api": "49.0.0",
     "source-map-support": "^0.5.21",
     "temporal-polyfill": "^1.0.1"
   },

--- a/settings/index.mts
+++ b/settings/index.mts
@@ -1,7 +1,6 @@
 import type { DriverSetting } from '@olivierzal/homey-kit/manifest'
 import type {
   HolidayModeState,
-  HolidayModeUpdate,
   LoginCredentials,
 } from '@olivierzal/melcloud-api'
 import type * as Classic from '@olivierzal/melcloud-api/classic'
@@ -46,7 +45,7 @@ import {
 } from '@olivierzal/melcloud-api/protection'
 import { Temporal } from 'temporal-polyfill'
 
-import type { Api } from '../types/api.mts'
+import type { Api, HolidayModeSettings } from '../types/api.mts'
 import type { HomeySettings } from '../types/app-settings.mts'
 import type {
   DeviceSetting,
@@ -1460,7 +1459,7 @@ class ZoneSettingsManager {
   /**
    * @alerts Displays save errors to the user.
    */
-  public async setHolidayModeData(update: HolidayModeUpdate): Promise<void> {
+  public async setHolidayModeData(update: HolidayModeSettings): Promise<void> {
     const { endDate, isEnabled, startDate } = update
     await this.#putZoneSetting(
       {
@@ -1472,10 +1471,14 @@ class ZoneSettingsManager {
       },
       update,
       {
+        // A bound the form left absent is completed on the Homey's
+        // clock app-side: unknown here, so the optimistic cache holds
+        // null until the display refresh reads the real window back —
+        // which also makes any stale bound on a disable harmless.
         holiday_mode: {
-          endDate: isEnabled ? endDate : null,
+          endDate: endDate ?? null,
           isEnabled,
-          startDate: isEnabled ? startDate : null,
+          startDate: startDate ?? null,
         },
       },
     )
@@ -1721,7 +1724,7 @@ class ZoneSettingsManager {
   // the panel, alert success or failure.
   async #putZoneSetting(
     { display, id, path }: ZoneSettingDescriptor,
-    query: HolidayModeUpdate | ProtectionUpdate,
+    query: HolidayModeSettings | ProtectionUpdate,
     zoneSettings: MixableZoneSettings,
   ): Promise<void> {
     await this.#gateFor(id).runBusy(async () => {
@@ -1743,7 +1746,7 @@ class ZoneSettingsManager {
   // Build the holiday-mode update from the form, alerting and returning
   // `null` on a validation failure (a mixed enabled not chosen, or an
   // enabled window with no end date).
-  #readHolidayModeForm(): HolidayModeUpdate | null {
+  #readHolidayModeForm(): HolidayModeSettings | null {
     if (!this.#requireEnabledChosen(this.#holidayModeEnabled)) {
       return null
     }
@@ -1761,13 +1764,13 @@ class ZoneSettingsManager {
       )
       return null
     }
-    // The window defaults its start to now (an empty field); the dates are
-    // ignored when disabling.
-    const now = Temporal.Now.plainDateTimeISO().toString()
+    // An empty bound is submitted as absent: the app completes it on
+    // the HOMEY's clock, the one every entry point shares — the page
+    // stamping the phone's clock here was #1595.
     return {
-      endDate: endDate ?? now,
       isEnabled,
-      startDate: startDateValue === '' ? now : startDateValue,
+      ...(endDate !== undefined && { endDate }),
+      ...(startDateValue !== '' && { startDate: startDateValue }),
     }
   }
 

--- a/tests/unit/app.test.ts
+++ b/tests/unit/app.test.ts
@@ -2613,6 +2613,32 @@ describe('melCloudApp', () => {
       ).resolves.toBeUndefined()
     })
 
+    // One clock for every entry point: an absent bound is completed on
+    // the HOMEY's clock, never the caller's — the settings page used to
+    // stamp the phone's here (#1595).
+    it("should complete absent bounds on the Homey's clock", async () => {
+      const updateHolidayMode = mockUpdateResult(null)
+      await initWithFacade(app, mock<Classic.ZoneFacade>({ updateHolidayMode }))
+      vi.spyOn(Temporal.Now, 'plainDateTimeISO').mockReturnValue(
+        Temporal.PlainDateTime.from('2026-08-18T09:30:00'),
+      )
+      try {
+        await app.updateClassicHolidayMode({
+          settings: { endDate: '2026-08-25T12:00', isEnabled: true },
+          zoneId: '1',
+          zoneType: 'buildings',
+        })
+      } finally {
+        vi.mocked(Temporal.Now.plainDateTimeISO).mockRestore()
+      }
+
+      expect(updateHolidayMode).toHaveBeenCalledWith({
+        endDate: '2026-08-25T12:00',
+        isEnabled: true,
+        startDate: '2026-08-18T09:30:00',
+      })
+    })
+
     it('should throw on attribute errors', async () => {
       const mockFacade = mock<Classic.ZoneFacade>({
         updateHolidayMode: mockUpdateResult({ date: ['Invalid date'] }),

--- a/tests/unit/settings.test.ts
+++ b/tests/unit/settings.test.ts
@@ -1445,18 +1445,22 @@ describe('settings page', () => {
       })
     })
 
-    it('should default an empty start date to now', async () => {
+    // The page no longer stamps a clock at all: an absent bound is the
+    // app's to complete, on the HOMEY's clock — the phone stamping its
+    // own here was #1595.
+    it('should submit an empty start date as absent', async () => {
       const harness = await bootPage()
       commit(getInput('start_date'), '')
       commit(getInput('end_date'), '2026-09-15T18:00')
       getButton('apply_holiday_mode').click()
       await settleDetached()
-      const body = lastCallBody(
-        harness,
-        'PUT /classic/zones/buildings/1/settings/holiday-mode',
-      ) as { startDate: string }
 
-      expect(body.startDate).not.toBe('')
+      expect(
+        lastCallBody(
+          harness,
+          'PUT /classic/zones/buildings/1/settings/holiday-mode',
+        ),
+      ).toStrictEqual({ endDate: '2026-09-15T18:00', isEnabled: true })
     })
 
     it('should require an end date to enable the window', async () => {
@@ -1483,12 +1487,13 @@ describe('settings page', () => {
       commit(getSelect('enabled_holiday_mode'), 'false')
       getButton('apply_holiday_mode').click()
       await settleDetached()
-      const body = lastCallBody(
-        harness,
-        'PUT /classic/zones/buildings/1/settings/holiday-mode',
-      ) as { isEnabled: boolean }
 
-      expect(body.isEnabled).toBe(false)
+      expect(
+        lastCallBody(
+          harness,
+          'PUT /classic/zones/buildings/1/settings/holiday-mode',
+        ),
+      ).toStrictEqual({ isEnabled: false })
       // Disabling cleared the dates in the form.
       expect(getInput('start_date').value).toBe('')
       expect(getInput('end_date').value).toBe('')

--- a/types/api.mts
+++ b/types/api.mts
@@ -12,3 +12,16 @@ export interface AuthenticationAPI {
   readonly authenticate: (credentials: LoginCredentials) => Promise<void>
   readonly isAuthenticated: () => boolean
 }
+
+/**
+ * Holiday-mode window as the settings webview submits it: an absent
+ * bound means "start (or end) now", completed app-side on the HOMEY's
+ * clock — the one clock every entry point shares. The page used to
+ * stamp the PHONE's clock instead, which diverges from the flow cards'
+ * whenever the two sit in different timezones (#1595).
+ */
+export interface HolidayModeSettings {
+  readonly isEnabled: boolean
+  readonly endDate?: string
+  readonly startDate?: string
+}


### PR DESCRIPTION
Part of #1593 and #1595 — both stay open until the store submission goes through, then get closed manually (per process).

## melcloud-api 49.0.0 adoption

The library's holiday-mode contract now **names its timezone**: both MELCloud wires store UTC wall clock, and the projection to/from the caller's clock happens at every facade boundary ([melcloud-api#1728](https://github.com/OlivierZal/melcloud-api/pull/1728)). This fixes the ±1 h shift reported in #1593 (BST; ±2 h for CET users in summer, 0 in winter GMT — why it read as intermittent). **No app-side change was needed for it**: this app always spoke local wall clock, which is now the contract's reading — the exact-pin bump delivers the fix.

## One clock for "now" (#1595)

The settings page stamped an empty start date with the **phone's** clock while the flow cards used the **Homey's**. Now: the page submits an absent bound as absent (new app-local `HolidayModeSettings` — both bounds optional), and the app completes the window once, in `#completeHolidayModeWindow`, on `getTimeZone(homey)` — Classic route and both Home routes alike. The optimistic cache holds `null` for an unsent bound until the display refresh reads the real window back.

## Pins, where the old ones were too weak

The old "defaults an empty start to now" pin asserted `not.toBe('')` — which `undefined` satisfies, so the phone-stamp removal sailed through unnoticed. Now: empty-start body strict-equals `{endDate, isEnabled}`; disable body `{isEnabled: false}`; the app-side completion is pinned against a frozen Homey clock (`2026-08-18T09:30:00` in, exact window out).

Release riding along: 46.4.2 (changelog in 13 locales — "Holiday mode times are now stored and shown correctly in your own timezone, and the automatic start time follows your Homey's clock"). `homey:validate` publish-level green, 958 tests, coverage 100%.