### PR TITLE
build(deps): bump @olivierzal/melcloud-api to 49.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "GPL-3.0-only",
       "dependencies": {
         "@olivierzal/homey-kit": "5.0.0",
-        "@olivierzal/melcloud-api": "49.0.0",
+        "@olivierzal/melcloud-api": "49.1.0",
         "source-map-support": "^0.5.21",
         "temporal-polyfill": "^1.0.1"
       },
@@ -1117,9 +1117,9 @@
       }
     },
     "node_modules/@olivierzal/melcloud-api": {
-      "version": "49.0.0",
-      "resolved": "https://npm.pkg.github.com/download/@olivierzal/melcloud-api/49.0.0/c5cd96f3c5ac702a45f49874811f519a5a75d0c5",
-      "integrity": "sha512-q1GezXrBp+m8bRRuJvZ58pHhTjjCBN1yYNo5ZNkJR0Va6mEKA1WpuWpNlKeZGAWTUSdfgmWfP0nek2V4jOOz8Q==",
+      "version": "49.1.0",
+      "resolved": "https://npm.pkg.github.com/download/@olivierzal/melcloud-api/49.1.0/4444828c7a1e53d0dcb4e01e8bda9d0644209db7",
+      "integrity": "sha512-gRuvZx8UOC0NmLJiOeXryNAum3g0W/0mB0Jwe/VVH2GDzuVFP2HVuW8ixnzTj9HO2WrYPRqG2YZTnjr9f7AHig==",
       "license": "MIT",
       "dependencies": {
         "temporal-polyfill": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "prettier": "@olivierzal/configs/prettier",
   "dependencies": {
     "@olivierzal/homey-kit": "5.0.0",
-    "@olivierzal/melcloud-api": "49.0.0",
+    "@olivierzal/melcloud-api": "49.1.0",
     "source-map-support": "^0.5.21",
     "temporal-polyfill": "^1.0.1"
   },


### PR DESCRIPTION
Adopts [melcloud-api 49.1.0](https://github.com/OlivierZal/melcloud-api/releases/tag/v49.1.0) — non-breaking:

- Contract kernels for signal-strength, energy-report and the holiday-mode disabled-window write clause (library-side test surface; no consumer change).
- Classic ATA/ERV `getInternalTemperatures`/`getHourlyTemperatures` resolve an empty chart without I/O; ERV `getEnergy` refuses before any I/O.
- The Classic report interfaces' `query` parameters are now optional (widening) and the classes no longer take the undeclared `shouldUseExactRange` boolean.

Full suite green against the new pin (958 tests / 51 files, 0 lint, 0 typecheck, build OK). No call-site change required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKsbttD4wLTrZnZDwKK1Fn