### PR TITLE
build(deps): bump @olivierzal/melcloud-api to 49.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "GPL-3.0-only",
       "dependencies": {
         "@olivierzal/homey-kit": "5.0.0",
-        "@olivierzal/melcloud-api": "49.1.0",
+        "@olivierzal/melcloud-api": "49.2.0",
         "source-map-support": "^0.5.21",
         "temporal-polyfill": "^1.0.1"
       },
@@ -1117,9 +1117,9 @@
       }
     },
     "node_modules/@olivierzal/melcloud-api": {
-      "version": "49.1.0",
-      "resolved": "https://npm.pkg.github.com/download/@olivierzal/melcloud-api/49.1.0/4444828c7a1e53d0dcb4e01e8bda9d0644209db7",
-      "integrity": "sha512-gRuvZx8UOC0NmLJiOeXryNAum3g0W/0mB0Jwe/VVH2GDzuVFP2HVuW8ixnzTj9HO2WrYPRqG2YZTnjr9f7AHig==",
+      "version": "49.2.0",
+      "resolved": "https://npm.pkg.github.com/download/@olivierzal/melcloud-api/49.2.0/756eb84932e810313cc5127b71c2cb8f5d0ad2d4",
+      "integrity": "sha512-TJd0xyt5jY9Eo7BaYVk4RAN3/hYRifQWZ9ISA4YtJU0g1Qi+irOad4dmygrHdaVIcj8nXVVeWynj5Eje8iAXKg==",
       "license": "MIT",
       "dependencies": {
         "temporal-polyfill": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "prettier": "@olivierzal/configs/prettier",
   "dependencies": {
     "@olivierzal/homey-kit": "5.0.0",
-    "@olivierzal/melcloud-api": "49.1.0",
+    "@olivierzal/melcloud-api": "49.2.0",
     "source-map-support": "^0.5.21",
     "temporal-polyfill": "^1.0.1"
   },


### PR DESCRIPTION
Adopts [melcloud-api 49.2.0](https://github.com/OlivierZal/melcloud-api/releases/tag/v49.2.0) — non-breaking:

- Home device base hoists (`capabilities`, `power`, `inStandbyMode`, `getEnergy`, `getErrorLog`, ctor, `updateValues` pipeline behind the optional `clampValues` hook) — inheritance, not removal.
- New surface: the `ClassicOperationModeZone` ↔ `HomeAtwZoneMode` bijection, ATW `temperatureStep`, ATA `inStandbyMode`, published `ClassicDeviceErvFacade`, `HomeDeviceValues`/`HomeEnergyQuery`.

Full suite green against the new pin (958 tests / 51 files, 0 typecheck). No call-site change required; the type-axis driver refactor lands separately in #(refactor/type-axis-drivers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKsbttD4wLTrZnZDwKK1Fn