### PR TITLE
refactor: mutualize the type-axis driver machinery

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -251,10 +251,24 @@ coverage.
   Template entries for capabilities a driver lacks are inert, but a
   capability another driver configures differently stays per-driver
   (e.g. `target_temperature`: ATA 10–31, ATW 10–30) — precedence would
-  resolve the collision, relying on it is a trap.
-- `measure_signal_strength` is never a default capability, on any driver:
-  it stays manifest-declared but opt-in through the shared `options`
-  settings group. Keep it out of every required-capability list.
+  resolve the collision, relying on it is a trap. A SECOND template
+  cannot carve out a subset either: template-over-template merging is
+  shallow per top-level property (measured 2026-08-18 — an `ata`
+  template's `capabilitiesOptions` erased every `defaults`-inherited
+  entry), so a block shared by only some drivers stays duplicated in
+  their compose files, pinned byte-identical by
+  `tests/unit/driver-compose.test.ts` (the widget-styles twin pattern).
+- `measure_signal_strength` is never a default capability, on any
+  driver: it stays manifest-declared but opt-in through the shared
+  `options` settings group. That rule is structural, not per-driver:
+  `withoutOptInCapabilities` (`lib/opt-in-capabilities.mts`) filters it
+  at the two default-capability consumers (pairing details in both
+  `toDeviceDetails`, init reconciliation in `#setCapabilities`), so
+  `getRequiredCapabilities` implementations return their raw lists.
+- The power-gated `thermostat_mode` read converters stay per-driver by
+  verdict (2026-08): two lines each, the destructured fields and enum
+  hops differ per dialect, and the inverse off-handling lives in the
+  base listener — a shared factory would outweigh the duplication.
 - Home drivers only ship surfaces the MELCloud Home app itself exposes,
   even when the API facade can read more — no outdoor temperature on
   Home ATW (not in the app UI; an absent setting would read as 0).

--- a/drivers/base-device.mts
+++ b/drivers/base-device.mts
@@ -12,7 +12,7 @@ import {
 } from '@olivierzal/melcloud-api'
 import { Temporal } from 'temporal-polyfill'
 
-import type { CapabilityConverter } from '../types/capabilities.mts'
+import type { CapabilityConverter } from '../types/bases.mts'
 import type {
   ClassicDeviceFacade,
   EnergyReportMode,
@@ -20,6 +20,7 @@ import type {
 } from '../types/device.mts'
 import { type Homey, Device } from '../lib/homey.mts'
 import { isTotalEnergyKey } from '../lib/is-total-energy-key.mts'
+import { withoutOptInCapabilities } from '../lib/opt-in-capabilities.mts'
 import { getLocale, getNow } from '../lib/temporal.mts'
 import type { BaseMELCloudDriver } from './base-driver.mts'
 import type { EnergyReportConfig } from './base-report.mts'
@@ -449,7 +450,7 @@ export abstract class BaseMELCloudDevice<
         ...Object.keys(settings).filter(
           (setting) => settings[setting] === true,
         ),
-        ...this.getRequiredCapabilities(),
+        ...withoutOptInCapabilities(this.getRequiredCapabilities()),
       ].filter((capability) => this.isCapabilitySupported(capability)),
     )
 

--- a/drivers/classic-device.mts
+++ b/drivers/classic-device.mts
@@ -8,7 +8,7 @@ import type {
   OperationalCapabilities,
   OperationalCapabilityTagEntry,
   SetCapabilities,
-} from '../types/capabilities.mts'
+} from '../types/classic-capabilities.mts'
 import type { Settings } from '../types/device-settings.mts'
 import type { EnergyReportConfig } from './base-report.mts'
 import type { ClassicMELCloudDriver } from './classic-driver.mts'

--- a/drivers/classic-driver.mts
+++ b/drivers/classic-driver.mts
@@ -6,9 +6,10 @@ import type {
   GetCapabilityTagMapping,
   ListCapabilityTagMapping,
   SetCapabilityTagMapping,
-} from '../types/capabilities.mts'
+} from '../types/classic-capabilities.mts'
 import type { ClassicMELCloudDevice } from '../types/classic.mts'
 import type { DeviceDetails } from '../types/device.mts'
+import { withoutOptInCapabilities } from '../lib/opt-in-capabilities.mts'
 import { typedEntries } from '../lib/typed-object.mts'
 import { BaseMELCloudDriver } from './base-driver.mts'
 
@@ -67,7 +68,9 @@ export abstract class ClassicMELCloudDriver<
     name: string
   }): DeviceDetails<T> {
     return {
-      capabilities: this.getRequiredCapabilities(data),
+      capabilities: withoutOptInCapabilities(
+        this.getRequiredCapabilities(data),
+      ),
       capabilitiesOptions: this.getCapabilitiesOptions(data),
       data: { id },
       name,

--- a/drivers/classic-report.mts
+++ b/drivers/classic-report.mts
@@ -4,7 +4,7 @@ import type {
   Capabilities,
   EnergyCapabilities,
   EnergyCapabilityTagEntry,
-} from '../types/capabilities.mts'
+} from '../types/classic-capabilities.mts'
 import { KILO } from '../lib/constants.mts'
 import { isTotalEnergyKey } from '../lib/is-total-energy-key.mts'
 import { typedEntries } from '../lib/typed-object.mts'

--- a/drivers/home-device.mts
+++ b/drivers/home-device.mts
@@ -6,6 +6,7 @@ import type {
   HomeDeviceFacade,
 } from '../types/home.mts'
 import { typedEntries } from '../lib/typed-object.mts'
+import type { EnergyReportConfig } from './base-report.mts'
 import type { HomeMELCloudDriver } from './home-driver.mts'
 import { BaseMELCloudDevice } from './base-device.mts'
 
@@ -28,6 +29,15 @@ export abstract class HomeMELCloudDevice<
   protected abstract readonly deviceToCapability: Partial<
     Record<string, HomeConvertFromDevice<T>>
   >
+
+  // Both Home report wires resolve total-mode reads the same way; only the
+  // regular cadence is type-specific (the ATW interval measures are
+  // near-live, the ATA cumulative one is not).
+  protected override readonly energyReportTotal: EnergyReportConfig = {
+    duration: { hours: 1 },
+    mode: 'total',
+    values: { millisecond: 0, minute: 5, second: 0 },
+  }
 
   // An offline unit is one whose disconnection streak has passed the
   // stale window.

--- a/drivers/home-driver.mts
+++ b/drivers/home-driver.mts
@@ -2,6 +2,7 @@ import type * as Home from '@olivierzal/melcloud-api/home'
 
 import type { HomeEnergyMeasureName } from '../types/device.mts'
 import type { HomeDeviceDetails, HomeMELCloudDevice } from '../types/home.mts'
+import { withoutOptInCapabilities } from '../lib/opt-in-capabilities.mts'
 import { BaseMELCloudDriver } from './base-driver.mts'
 
 export abstract class HomeMELCloudDriver extends BaseMELCloudDriver {
@@ -43,7 +44,9 @@ export abstract class HomeMELCloudDriver extends BaseMELCloudDriver {
   }): HomeDeviceDetails {
     const facade = this.homey.app.getHomeFacade(id, this.type)
     return {
-      capabilities: this.getRequiredCapabilities(facade),
+      capabilities: withoutOptInCapabilities(
+        this.getRequiredCapabilities(facade),
+      ),
       capabilitiesOptions: this.getCapabilitiesOptions(facade),
       data: { id },
       name,

--- a/drivers/home-melcloud/device.mts
+++ b/drivers/home-melcloud/device.mts
@@ -69,12 +69,6 @@ export default class HomeMELCloudDeviceAta extends HomeMELCloudDevice<AtaType> {
     values: { millisecond: 0, minute: 5, second: 0 },
   }
 
-  protected override readonly energyReportTotal: EnergyReportConfig = {
-    duration: { hours: 1 },
-    mode: 'total',
-    values: { millisecond: 0, minute: 5, second: 0 },
-  }
-
   protected override readonly thermostatMode: typeof ThermostatModeAta =
     ThermostatModeAta
 

--- a/drivers/home-melcloud/driver.mts
+++ b/drivers/home-melcloud/driver.mts
@@ -14,12 +14,10 @@ export default class HomeMELCloudDriverAta extends HomeMELCloudDriver {
   public override readonly type: typeof Home.DeviceType.Ata =
     Home.DeviceType.Ata
 
-  // Signal strength stays manifest-declared but opt-in through the
-  // shared options settings group; everything else — the energy
-  // capabilities included — is mandatory.
+  // Everything the manifest declares — the energy capabilities
+  // included — is mandatory; the base handles the signal-strength
+  // opt-in.
   public override getRequiredCapabilities(): string[] {
-    return this.manifest.capabilities.filter(
-      (capability) => capability !== 'measure_signal_strength',
-    )
+    return [...this.manifest.capabilities]
   }
 }

--- a/drivers/home-melcloud_atw/device.mts
+++ b/drivers/home-melcloud_atw/device.mts
@@ -65,12 +65,6 @@ export default class HomeMELCloudDeviceAtw extends HomeMELCloudDevice<AtwType> {
     values: { millisecond: 0, second: 0 },
   }
 
-  protected override readonly energyReportTotal: EnergyReportConfig = {
-    duration: { hours: 1 },
-    mode: 'total',
-    values: { millisecond: 0, minute: 5, second: 0 },
-  }
-
   protected override readonly createEnergyReport = (
     config: EnergyReportConfig,
   ): HomeEnergyReportAtw => new HomeEnergyReportAtw(this, config)

--- a/drivers/melcloud/device.mts
+++ b/drivers/melcloud/device.mts
@@ -5,7 +5,7 @@ import type {
   ConvertToDevice,
   OperationalCapabilities,
   SetCapabilities,
-} from '../../types/capabilities.mts'
+} from '../../types/classic-capabilities.mts'
 import type { EnergyReportConfig } from '../base-report.mts'
 import {
   horizontalFromDevice,

--- a/drivers/melcloud/driver.mts
+++ b/drivers/melcloud/driver.mts
@@ -19,6 +19,6 @@ export default class ClassicMELCloudDriverAta extends ClassicMELCloudDriver<AtaT
       ...this.tagMappings.set,
       ...this.tagMappings.get,
       ...this.tagMappings.list,
-    }).filter((capability) => capability !== 'measure_signal_strength')
+    })
   }
 }

--- a/drivers/melcloud_atw/device.mts
+++ b/drivers/melcloud_atw/device.mts
@@ -6,7 +6,7 @@ import type {
   ConvertToDevice,
   OperationalCapabilities,
   SetCapabilities,
-} from '../../types/capabilities.mts'
+} from '../../types/classic-capabilities.mts'
 import type { EnergyReportConfig } from '../base-report.mts'
 import { KILO } from '../../lib/constants.mts'
 import { getLocale, getTimeZone, toPlainDate } from '../../lib/temporal.mts'

--- a/drivers/melcloud_atw/driver.mts
+++ b/drivers/melcloud_atw/driver.mts
@@ -1,6 +1,6 @@
 import * as Classic from '@olivierzal/melcloud-api/classic'
 
-import type { Capabilities } from '../../types/capabilities.mts'
+import type { Capabilities } from '../../types/classic-capabilities.mts'
 import {
   getCapabilitiesOptions,
   tagMappings,

--- a/drivers/melcloud_erv/device.mts
+++ b/drivers/melcloud_erv/device.mts
@@ -5,7 +5,7 @@ import type {
   ConvertToDevice,
   OperationalCapabilities,
   SetCapabilities,
-} from '../../types/capabilities.mts'
+} from '../../types/classic-capabilities.mts'
 import {
   ThermostatModeErv,
   ventilationModeFromDevice,

--- a/drivers/melcloud_erv/driver.mts
+++ b/drivers/melcloud_erv/driver.mts
@@ -4,11 +4,9 @@ import { getCapabilitiesOptionsAtaErv } from '../../types/ata-erv.mts'
 import { tagMappings } from '../../types/classic-erv.mts'
 import { ClassicMELCloudDriver } from '../classic-driver.mts'
 
-const measureCapabilities = new Set([
-  'measure_co2',
-  'measure_pm25',
-  'measure_signal_strength',
-])
+// The sensor-gated measures: re-added below exactly when the unit
+// reports the matching sensor.
+const measureCapabilities = new Set(['measure_co2', 'measure_pm25'])
 
 type ErvType = typeof Classic.DeviceType.Erv
 

--- a/lib/opt-in-capabilities.mts
+++ b/lib/opt-in-capabilities.mts
@@ -1,0 +1,8 @@
+// Signal strength stays manifest-declared but opt-in through the shared
+// options settings group on every driver: both default-capability
+// consumers (pairing details, init reconciliation) exclude it through
+// this one filter, so the per-driver required lists need not.
+export const withoutOptInCapabilities = (
+  capabilities: readonly string[],
+): string[] =>
+  capabilities.filter((capability) => capability !== 'measure_signal_strength')

--- a/lib/typed-object.mts
+++ b/lib/typed-object.mts
@@ -7,3 +7,11 @@ export const typedFromEntries = <TKey extends string, TValue>(
   entries: Iterable<readonly [TKey, TValue]>,
   // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- Object.entries/fromEntries/keys lose key types; cast restores them
 ): Record<TKey, TValue> => Object.fromEntries(entries) as Record<TKey, TValue>
+
+export const invertEnum = <TEnum extends Record<string, PropertyKey>>(
+  enumObject: TEnum,
+): Record<TEnum[keyof TEnum], keyof TEnum> =>
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- Object.entries/fromEntries/keys lose key types; cast restores them
+  Object.fromEntries(
+    Object.entries(enumObject).map(([key, value]) => [value, key]),
+  ) as Record<TEnum[keyof TEnum], keyof TEnum>

--- a/tests/unit/classic-device-test-device.ts
+++ b/tests/unit/classic-device-test-device.ts
@@ -5,7 +5,7 @@ import type {
   ConvertToDevice,
   OperationalCapabilities,
   SetCapabilities,
-} from '../../types/capabilities.mts'
+} from '../../types/classic-capabilities.mts'
 import { ClassicMELCloudDevice } from '../../drivers/classic-device.mts'
 import { createInstance } from './create-test-instance.ts'
 

--- a/tests/unit/classic-device.test.ts
+++ b/tests/unit/classic-device.test.ts
@@ -11,7 +11,7 @@ import type {
   GetCapabilityTagMapping,
   ListCapabilityTagMapping,
   SetCapabilityTagMapping,
-} from '../../types/capabilities.mts'
+} from '../../types/classic-capabilities.mts'
 import { ClassicMELCloudDevice } from '../../drivers/classic-device.mts'
 import {
   createCapabilityListenerCallbackGetter,

--- a/tests/unit/classic-driver-test-driver.ts
+++ b/tests/unit/classic-driver-test-driver.ts
@@ -6,7 +6,7 @@ import type {
   GetCapabilityTagMapping,
   ListCapabilityTagMapping,
   SetCapabilityTagMapping,
-} from '../../types/capabilities.mts'
+} from '../../types/classic-capabilities.mts'
 import { ClassicMELCloudDriver } from '../../drivers/classic-driver.mts'
 import { mock } from '../helpers.ts'
 import { createInstance } from './create-test-instance.ts'

--- a/tests/unit/classic-driver.test.ts
+++ b/tests/unit/classic-driver.test.ts
@@ -5,7 +5,7 @@ import type FlowCardCondition from 'homey/lib/FlowCardCondition'
 import type PairSession from 'homey/lib/PairSession'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { EnergyCapabilityTagMapping } from '../../types/capabilities.mts'
+import type { EnergyCapabilityTagMapping } from '../../types/classic-capabilities.mts'
 import { ClassicMELCloudDriver } from '../../drivers/classic-driver.mts'
 import {
   testFlowListenerRegistration,

--- a/tests/unit/classic-report.test.ts
+++ b/tests/unit/classic-report.test.ts
@@ -15,7 +15,7 @@ import type { EnergyReportConfig } from '../../drivers/base-report.mts'
 import type { ClassicMELCloudDevice } from '../../drivers/classic-device.mts'
 import type { ClassicMELCloudDriver } from '../../drivers/classic-driver.mts'
 import type { Homey } from '../../lib/homey.mts'
-import type { EnergyCapabilityTagMapping } from '../../types/capabilities.mts'
+import type { EnergyCapabilityTagMapping } from '../../types/classic-capabilities.mts'
 import { EnergyReport } from '../../drivers/classic-report.mts'
 import { getMockCallArg, mock } from '../helpers.ts'
 

--- a/tests/unit/driver-compose.test.ts
+++ b/tests/unit/driver-compose.test.ts
@@ -1,0 +1,31 @@
+import { readFile } from 'node:fs/promises'
+
+import { describe, expect, it } from 'vitest'
+
+// The two ATA drivers configure `thermostat_mode` identically, and the
+// compose template mechanism cannot carry the sharing: template-over-
+// template merging is shallow per top-level property (measured
+// 2026-08-18 — an `ata` template's `capabilitiesOptions` erased every
+// `defaults`-inherited entry), so hoisting the block would either lose
+// the defaults or lean on the template precedence CLAUDE.md forbids.
+// The twins stay; this pin is what turns an edit to one without the
+// other into a failure instead of a silent drift.
+const readThermostatModeOptions = async (driver: string): Promise<unknown> => {
+  const compose = JSON.parse(
+    await readFile(`drivers/${driver}/driver.compose.json`, 'utf8'),
+  ) as { capabilitiesOptions: Record<string, unknown> }
+  return compose.capabilitiesOptions.thermostat_mode
+}
+
+describe('ata driver compose twins', () => {
+  it('should keep the thermostat_mode options byte-identical', async () => {
+    const [classic, home] = await Promise.all(
+      ['melcloud', 'home-melcloud'].map(async (driver) =>
+        readThermostatModeOptions(driver),
+      ),
+    )
+
+    expect(classic).toBeDefined()
+    expect(classic).toStrictEqual(home)
+  })
+})

--- a/tests/unit/home-base-driver.test.ts
+++ b/tests/unit/home-base-driver.test.ts
@@ -105,8 +105,8 @@ describe(BaseMELCloudDriver, () => {
   })
 
   describe('required capabilities', () => {
-    it('should exclude measure_signal_strength from required capabilities', () => {
-      expect(driver.getRequiredCapabilities()).not.toContain(
+    it('should include the opt-in measure_signal_strength in the raw list', () => {
+      expect(driver.getRequiredCapabilities()).toContain(
         'measure_signal_strength',
       )
     })

--- a/tests/unit/melcloud-atw-device.test.ts
+++ b/tests/unit/melcloud-atw-device.test.ts
@@ -8,7 +8,7 @@ import type {
   GetCapabilityTagMapping,
   ListCapabilityTagMapping,
   SetCapabilityTagMapping,
-} from '../../types/capabilities.mts'
+} from '../../types/classic-capabilities.mts'
 import { HotWaterMode } from '../../types/atw.mts'
 import {
   testEnergyReportConfig,

--- a/tests/unit/melcloud-driver.test.ts
+++ b/tests/unit/melcloud-driver.test.ts
@@ -27,10 +27,10 @@ describe(ClassicMELCloudDriverAta, () => {
   testTagMappings(() => driver, tagMappings)
 
   describe('required capabilities', () => {
-    it('should return all operational capabilities except measure_signal_strength', () => {
+    it('should return every operational capability, opt-ins included', () => {
       const capabilities = driver.getRequiredCapabilities()
 
-      expect(capabilities).not.toContain('measure_signal_strength')
+      expect(capabilities).toContain('measure_signal_strength')
       expect(capabilities).toContain('onoff')
       expect(capabilities).toContain('measure_temperature')
     })
@@ -41,7 +41,7 @@ describe(ClassicMELCloudDriverAta, () => {
         ...tagMappings.set,
         ...tagMappings.get,
         ...tagMappings.list,
-      }).filter((key) => key !== 'measure_signal_strength')
+      })
 
       expect(capabilities).toStrictEqual(allKeys)
     })

--- a/tests/unit/melcloud-erv-driver.test.ts
+++ b/tests/unit/melcloud-erv-driver.test.ts
@@ -59,7 +59,7 @@ describe(ClassicMELCloudDriverErv, () => {
       expect(capabilities).toContain('thermostat_mode')
       expect(capabilities).not.toContain('measure_co2')
       expect(capabilities).not.toContain('measure_pm25')
-      expect(capabilities).not.toContain('measure_signal_strength')
+      expect(capabilities).toContain('measure_signal_strength')
     })
 
     it('should include measure_co2 when HasCO2Sensor is true', () => {

--- a/types/ata-erv.mts
+++ b/types/ata-erv.mts
@@ -1,8 +1,8 @@
 import type * as Classic from '@olivierzal/melcloud-api/classic'
 
-import type { CapabilitiesOptionsAtaErv } from './capabilities.mts'
 import type { HomeAtaDeviceProfile } from './home-ata.mts'
 import {
+  type CapabilitiesOptionsAtaErv,
   type CapabilitiesOptionsValues,
   type LocalizedStrings,
   localizeWithAffix,

--- a/types/ata.mts
+++ b/types/ata.mts
@@ -1,5 +1,7 @@
 import * as Classic from '@olivierzal/melcloud-api/classic'
 
+import { invertEnum } from '../lib/typed-object.mts'
+
 export const ThermostatModeAta = {
   auto: 'auto',
   cool: 'cool',
@@ -15,37 +17,14 @@ export type ThermostatModeAta =
 export const horizontalFromDevice: Record<
   Classic.Horizontal,
   keyof typeof Classic.Horizontal
-> = {
-  [Classic.Horizontal.auto]: 'auto',
-  [Classic.Horizontal.center]: 'center',
-  [Classic.Horizontal.center_left]: 'center_left',
-  [Classic.Horizontal.center_right]: 'center_right',
-  [Classic.Horizontal.leftwards]: 'leftwards',
-  [Classic.Horizontal.rightwards]: 'rightwards',
-  [Classic.Horizontal.swing]: 'swing',
-  [Classic.Horizontal.wide]: 'wide',
-}
+> = invertEnum(Classic.Horizontal)
 
 export const operationModeFromDevice: Record<
   Classic.OperationMode,
   keyof typeof Classic.OperationMode
-> = {
-  [Classic.OperationMode.auto]: 'auto',
-  [Classic.OperationMode.cool]: 'cool',
-  [Classic.OperationMode.dry]: 'dry',
-  [Classic.OperationMode.fan]: 'fan',
-  [Classic.OperationMode.heat]: 'heat',
-}
+> = invertEnum(Classic.OperationMode)
 
 export const verticalFromDevice: Record<
   Classic.Vertical,
   keyof typeof Classic.Vertical
-> = {
-  [Classic.Vertical.auto]: 'auto',
-  [Classic.Vertical.downwards]: 'downwards',
-  [Classic.Vertical.mid_high]: 'mid_high',
-  [Classic.Vertical.mid_low]: 'mid_low',
-  [Classic.Vertical.middle]: 'middle',
-  [Classic.Vertical.swing]: 'swing',
-  [Classic.Vertical.upwards]: 'upwards',
-}
+> = invertEnum(Classic.Vertical)

--- a/types/atw.mts
+++ b/types/atw.mts
@@ -115,7 +115,7 @@ export const getThermostatModeValuesAtw = (
     ? thermostatModeValuesAtw
     : thermostatModeValuesAtw.filter(({ id }) => !id.endsWith(COOL_SUFFIX))
 
-export const thermostatModeZone2TitleAtw: LocalizedStrings = addSuffixToTitle(
+const thermostatModeZone2TitleAtw: LocalizedStrings = addSuffixToTitle(
   thermostatMode.title,
   {
     ar: '- المنطقة 2',
@@ -133,3 +133,38 @@ export const thermostatModeZone2TitleAtw: LocalizedStrings = addSuffixToTitle(
     sv: '- zon 2',
   },
 )
+
+//
+// The runtime `thermostat_mode` options both ATW dialects compute.
+//
+export interface ThermostatModeOptionsAtw {
+  readonly thermostat_mode: {
+    readonly values: readonly CapabilitiesOptionsValues<
+      keyof typeof Classic.OperationModeZone
+    >[]
+  }
+  readonly 'thermostat_mode.zone2': {
+    readonly title: LocalizedStrings
+    readonly values: readonly CapabilitiesOptionsValues<
+      keyof typeof Classic.OperationModeZone
+    >[]
+  }
+}
+
+// Only complete option objects, and only for capabilities the device will
+// actually have: device-level options shadow the manifest's per capability,
+// and setting options on an absent capability fails. Both dialects share
+// this body; their adapters only translate the wire spelling of
+// "can cool" and "has a second zone".
+export const buildAtwThermostatModeOptions = (
+  canCool: boolean,
+  hasZone2: boolean,
+): Partial<ThermostatModeOptionsAtw> => {
+  const values = getThermostatModeValuesAtw(canCool)
+  return {
+    thermostat_mode: { values },
+    ...(hasZone2 && {
+      'thermostat_mode.zone2': { title: thermostatModeZone2TitleAtw, values },
+    }),
+  }
+}

--- a/types/bases.mts
+++ b/types/bases.mts
@@ -39,10 +39,22 @@ export interface BaseSetCapabilities {
 
 export type BaseSettings = Partial<Record<string, unknown>>
 
+export interface CapabilitiesOptionsAtaErv {
+  readonly fan_speed: RangeOptions
+}
+
 export interface CapabilitiesOptionsValues<T extends string> {
   readonly id: T
   readonly title: LocalizedStrings
 }
+
+/**
+ * Base write-converter type for capability-to-device transforms.
+ */
+export type CapabilityConverter = {
+  // eslint-disable-next-line @typescript-eslint/method-signature-style -- method syntax is bivariant, letting concrete converters narrow `value` to their capability's type
+  bivariant(value: unknown): unknown
+}['bivariant']
 
 export interface LocalizedStrings extends Partial<Record<string, string>> {
   readonly en: string

--- a/types/classic-atw.mts
+++ b/types/classic-atw.mts
@@ -3,6 +3,7 @@
 import type { HomeAtwOperationalState } from '@olivierzal/melcloud-api'
 import * as Classic from '@olivierzal/melcloud-api/classic'
 
+import { invertEnum } from '../lib/typed-object.mts'
 import type {
   BaseGetCapabilities,
   BaseListCapabilities,
@@ -11,11 +12,7 @@ import type {
   LocalizedStrings,
   RangeOptions,
 } from './bases.mts'
-import {
-  type HotWaterMode,
-  getThermostatModeValuesAtw,
-  thermostatModeZone2TitleAtw,
-} from './atw.mts'
+import { type HotWaterMode, buildAtwThermostatModeOptions } from './atw.mts'
 
 export const operationModeStateFromDevice: Record<
   Classic.OperationModeState,
@@ -32,26 +29,13 @@ export const operationModeStateFromDevice: Record<
 export const operationModeZoneFromDevice: Record<
   Classic.OperationModeZone,
   keyof typeof Classic.OperationModeZone
-> = {
-  [Classic.OperationModeZone.curve]: 'curve',
-  [Classic.OperationModeZone.flow]: 'flow',
-  [Classic.OperationModeZone.flow_cool]: 'flow_cool',
-  [Classic.OperationModeZone.room]: 'room',
-  [Classic.OperationModeZone.room_cool]: 'room_cool',
-}
+> = invertEnum(Classic.OperationModeZone)
 
 export const getCapabilitiesOptions = ({
   CanCool: canCool,
   HasZone2: hasClassicZone2,
-}: Readonly<Classic.ListDeviceDataAtw>): Partial<CapabilitiesOptions> => {
-  const values = getThermostatModeValuesAtw(canCool)
-  return {
-    thermostat_mode: { values },
-    ...(hasClassicZone2 && {
-      'thermostat_mode.zone2': { title: thermostatModeZone2TitleAtw, values },
-    }),
-  }
-}
+}: Readonly<Classic.ListDeviceDataAtw>): Partial<CapabilitiesOptions> =>
+  buildAtwThermostatModeOptions(canCool, hasClassicZone2)
 
 export interface Capabilities
   extends

--- a/types/classic-capabilities.mts
+++ b/types/classic-capabilities.mts
@@ -1,6 +1,6 @@
 import type * as Classic from '@olivierzal/melcloud-api/classic'
 
-import type { RangeOptions } from './bases.mts'
+import type { CapabilitiesOptionsAtaErv } from './bases.mts'
 import type * as classicAta from './classic-ata.mts'
 import type * as classicAtw from './classic-atw.mts'
 import type * as classicErv from './classic-erv.mts'
@@ -36,18 +36,6 @@ export type CapabilitiesOptions<T extends Classic.DeviceType> =
   T extends typeof Classic.DeviceType.Atw
     ? classicAtw.CapabilitiesOptions
     : CapabilitiesOptionsAtaErv
-
-export interface CapabilitiesOptionsAtaErv {
-  readonly fan_speed: RangeOptions
-}
-
-/**
- * Base write-converter type for capability-to-device transforms.
- */
-export type CapabilityConverter = {
-  // eslint-disable-next-line @typescript-eslint/method-signature-style -- method syntax is bivariant, letting concrete converters narrow `value` to their capability's type
-  bivariant(value: unknown): unknown
-}['bivariant']
 
 /**
  * Converter from the classic device payload to the corresponding Homey

--- a/types/device.mts
+++ b/types/device.mts
@@ -1,6 +1,6 @@
 import type * as Classic from '@olivierzal/melcloud-api/classic'
 
-import type { CapabilitiesOptions } from './capabilities.mts'
+import type { CapabilitiesOptions } from './classic-capabilities.mts'
 
 export interface ClassicDeviceFacade {
   readonly updateValues: (data: Record<string, unknown>) => Promise<unknown>

--- a/types/erv.mts
+++ b/types/erv.mts
@@ -1,5 +1,7 @@
 import * as Classic from '@olivierzal/melcloud-api/classic'
 
+import { invertEnum } from '../lib/typed-object.mts'
+
 export const ThermostatModeErv = {
   auto: 'auto',
   bypass: 'bypass',
@@ -13,8 +15,4 @@ export type ThermostatModeErv =
 export const ventilationModeFromDevice: Record<
   Classic.VentilationMode,
   keyof typeof Classic.VentilationMode
-> = {
-  [Classic.VentilationMode.auto]: 'auto',
-  [Classic.VentilationMode.bypass]: 'bypass',
-  [Classic.VentilationMode.recovery]: 'recovery',
-}
+> = invertEnum(Classic.VentilationMode)

--- a/types/home-atw.mts
+++ b/types/home-atw.mts
@@ -9,11 +9,7 @@ import type {
   LocalizedStrings,
 } from './bases.mts'
 import type { HomeEnergyMeasureName } from './device.mts'
-import {
-  type HotWaterMode,
-  getThermostatModeValuesAtw,
-  thermostatModeZone2TitleAtw,
-} from './atw.mts'
+import { type HotWaterMode, buildAtwThermostatModeOptions } from './atw.mts'
 
 interface HomeGetCapabilitiesAtw extends BaseGetCapabilities {
   readonly 'measure_temperature.tank_water': number
@@ -100,20 +96,8 @@ export type HomeAtwDeviceProfile = Pick<
   'capabilities' | 'hasCoolingMode'
 >
 
-// Only complete option objects, and only for capabilities the device will
-// actually have: device-level options shadow the manifest's per capability
-// (temperature ranges/steps/titles stay in the compose manifest — the facade
-// clamps setpoints device-side anyway), and setting options on an absent
-// capability fails.
 export const homeGetCapabilitiesOptionsAtw = ({
   capabilities: { hasZone2 },
   hasCoolingMode,
-}: HomeAtwDeviceProfile): Partial<HomeCapabilitiesOptionsAtw> => {
-  const values = getThermostatModeValuesAtw(hasCoolingMode)
-  return {
-    thermostat_mode: { values },
-    ...(hasZone2 && {
-      'thermostat_mode.zone2': { title: thermostatModeZone2TitleAtw, values },
-    }),
-  }
-}
+}: HomeAtwDeviceProfile): Partial<HomeCapabilitiesOptionsAtw> =>
+  buildAtwThermostatModeOptions(hasCoolingMode, hasZone2)


### PR DESCRIPTION
## Vague 1 of the interface-mutualization plan — com.melcloud driver side

### Factored
- **`invertEnum`** (`lib/typed-object.mts`) replaces the five handwritten enum-inversion tables (~53 lines): `horizontalFromDevice`, `operationModeFromDevice`, `verticalFromDevice`, `operationModeZoneFromDevice`, `ventilationModeFromDevice`. `operationModeStateFromDevice` keeps its handwritten body — it is a real cross-enum rename (`legionellaPrevention` → `'legionella'`), not an inversion.
- **`buildAtwThermostatModeOptions`** (`types/atw.mts`) carries the one body both ATW dialects computed; the Classic and Home adapters keep only their wire destructuring (the `ata-erv.mts` fan-speed precedent).
- **`energyReportTotal`** hoists into `HomeMELCloudDevice` (byte-identical in both Home devices); the `regular` cadences stay per-type (documented telemetry rationale).
- **`withoutOptInCapabilities`** (`lib/opt-in-capabilities.mts`): the `measure_signal_strength` exclusion becomes one named structural filter at the two default-capability consumers (pairing `toDeviceDetails` ×2, init `#setCapabilities`) — the five per-driver exclusion idioms (two `!==` filters, one `Set`, two allow-lists-by-omission) are relieved of it.
- **`types/capabilities.mts` → `types/classic-capabilities.mts`**: the file's 13 other exports are all `Classic`-parameterized; its two dialect-neutral types (`CapabilitiesOptionsAtaErv`, `CapabilityConverter`) move to `types/bases.mts`, so the Home paths stop importing Classic-only modules.

### Measured verdicts (recorded in CLAUDE.md, not forced)
- The 112-line ATA `thermostat_mode` compose block **stays a byte-identical twin**, pinned by the new `tests/unit/driver-compose.test.ts`: template-over-template merging is shallow per top-level property (measured — an `ata` template's `capabilitiesOptions` erased every `defaults`-inherited entry), so a second template cannot carve out a subset without the precedence trap.
- The power-gated `thermostat_mode` read converters **stay per-driver**: two lines each, divergent shapes per dialect, inverse off-handling in the base listener — a factory would outweigh the duplication.

959 tests / 52 files, coverage 100 % on all four metrics, 0 lint, 0 typecheck, `homey:validate` green, `app.json` regenerated byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKsbttD4wLTrZnZDwKK1Fn