### PR TITLE
feat!: target-neutral settings routes over melcloud-api 50.0.0

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -1828,5 +1828,20 @@
     "pl": "Godziny trybu wakacyjnego są teraz zapisywane i wyświetlane poprawnie w Twojej strefie czasowej, a automatyczny czas rozpoczęcia korzysta z zegara Homey.",
     "ru": "Время режима отпуска теперь сохраняется и отображается корректно в вашем часовом поясе, а автоматическое время начала следует часам вашего Homey.",
     "sv": "Semesterlägets tider sparas och visas nu korrekt i din egen tidszon, och den automatiska starttiden följer din Homeys klocka."
+  },
+  "46.5.0": {
+    "ar": "تحسينات داخلية في الموثوقية وإعدادات المناطق.",
+    "da": "Interne forbedringer af pålidelighed og zoneindstillinger.",
+    "de": "Interne Verbesserungen der Zuverlässigkeit und der Zoneneinstellungen.",
+    "en": "Internal improvements to reliability and zone settings.",
+    "es": "Mejoras internas de fiabilidad y de los ajustes de zonas.",
+    "fr": "Améliorations internes de la fiabilité et des réglages de zones.",
+    "it": "Miglioramenti interni all'affidabilità e alle impostazioni delle zone.",
+    "ko": "안정성 및 구역 설정에 대한 내부 개선.",
+    "nl": "Interne verbeteringen aan betrouwbaarheid en zone-instellingen.",
+    "no": "Interne forbedringer av pålitelighet og soneinnstillinger.",
+    "pl": "Wewnętrzne ulepszenia niezawodności i ustawień stref.",
+    "ru": "Внутренние улучшения надёжности и настроек зон.",
+    "sv": "Interna förbättringar av tillförlitlighet och zoninställningar."
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -12,14 +12,6 @@
       "method": "GET",
       "path": "/classic/buildings"
     },
-    "getClassicFrostProtection": {
-      "method": "GET",
-      "path": "/classic/zones/:zoneType/:zoneId/settings/frost-protection"
-    },
-    "getClassicHolidayMode": {
-      "method": "GET",
-      "path": "/classic/zones/:zoneType/:zoneId/settings/holiday-mode"
-    },
     "getDeviceGroups": {
       "method": "GET",
       "path": "/devices/groups"
@@ -36,33 +28,9 @@
       "method": "GET",
       "path": "/logs/errors"
     },
-    "getHomeBuildingFrostProtection": {
-      "method": "GET",
-      "path": "/home/buildings/:buildingId/settings/frost-protection"
-    },
-    "getHomeBuildingHolidayMode": {
-      "method": "GET",
-      "path": "/home/buildings/:buildingId/settings/holiday-mode"
-    },
-    "getHomeBuildingOverheatProtection": {
-      "method": "GET",
-      "path": "/home/buildings/:buildingId/settings/overheat-protection"
-    },
     "getHomeDevices": {
       "method": "GET",
       "path": "/home/devices"
-    },
-    "getHomeFrostProtection": {
-      "method": "GET",
-      "path": "/home/devices/:deviceId/settings/frost-protection"
-    },
-    "getHomeHolidayMode": {
-      "method": "GET",
-      "path": "/home/devices/:deviceId/settings/holiday-mode"
-    },
-    "getHomeOverheatProtection": {
-      "method": "GET",
-      "path": "/home/devices/:deviceId/settings/overheat-protection"
     },
     "getHomeTargets": {
       "method": "GET",
@@ -71,6 +39,18 @@
     "getLanguage": {
       "method": "GET",
       "path": "/language"
+    },
+    "getTargetFrostProtection": {
+      "method": "GET",
+      "path": "/targets/:targetId/settings/frost-protection"
+    },
+    "getTargetHolidayMode": {
+      "method": "GET",
+      "path": "/targets/:targetId/settings/holiday-mode"
+    },
+    "getTargetOverheatProtection": {
+      "method": "GET",
+      "path": "/targets/:targetId/settings/overheat-protection"
     },
     "getWebviewHashes": {
       "method": "GET",
@@ -96,41 +76,21 @@
       "method": "POST",
       "path": "/boot-error"
     },
-    "updateClassicFrostProtection": {
-      "method": "PUT",
-      "path": "/classic/zones/:zoneType/:zoneId/settings/frost-protection"
-    },
-    "updateClassicHolidayMode": {
-      "method": "PUT",
-      "path": "/classic/zones/:zoneType/:zoneId/settings/holiday-mode"
-    },
     "updateDeviceSettings": {
       "method": "PUT",
       "path": "/settings/devices"
     },
-    "updateHomeBuildingFrostProtection": {
+    "updateTargetFrostProtection": {
       "method": "PUT",
-      "path": "/home/buildings/:buildingId/settings/frost-protection"
+      "path": "/targets/:targetId/settings/frost-protection"
     },
-    "updateHomeBuildingHolidayMode": {
+    "updateTargetHolidayMode": {
       "method": "PUT",
-      "path": "/home/buildings/:buildingId/settings/holiday-mode"
+      "path": "/targets/:targetId/settings/holiday-mode"
     },
-    "updateHomeBuildingOverheatProtection": {
+    "updateTargetOverheatProtection": {
       "method": "PUT",
-      "path": "/home/buildings/:buildingId/settings/overheat-protection"
-    },
-    "updateHomeFrostProtection": {
-      "method": "PUT",
-      "path": "/home/devices/:deviceId/settings/frost-protection"
-    },
-    "updateHomeHolidayMode": {
-      "method": "PUT",
-      "path": "/home/devices/:deviceId/settings/holiday-mode"
-    },
-    "updateHomeOverheatProtection": {
-      "method": "PUT",
-      "path": "/home/devices/:deviceId/settings/overheat-protection"
+      "path": "/targets/:targetId/settings/overheat-protection"
     }
   },
   "author": {
@@ -342,5 +302,5 @@
       "värmeåtervinning"
     ]
   },
-  "version": "46.4.2"
+  "version": "46.5.0"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,7 +154,17 @@ coverage.
   `/sessions`, `logWebviewBoot` on `/boot-error`); handler renames are
   wire-invisible (routing is method+path), path renames are NOT (phone
   webviews cache bundles across versions; stale callers now surface an
-  error — legacy aliases were dropped by decision, 2026-07). The
+  error — legacy aliases were dropped by decision, 2026-07, and the
+  settings routes migrated once more under the same policy, 2026-08).
+  The zone SETTINGS routes are target-neutral:
+  `/targets/:targetId/settings/{frost-protection,holiday-mode,overheat-protection}`,
+  where `targetId` is the picker value verbatim (`buildings_1`,
+  `homeDevices_<guid>` — split at the FIRST underscore) — one route
+  family for every dialect and level; the app model resolves the facade
+  (`#getSettingsTarget`) and the melcloud-api 50.0.0 facades answer the
+  same read/write methods on every target, so no per-family route or
+  aggregation code remains app-side. Overheat stays Home-only: a
+  Classic target reads `null` and refuses the write. The
   inter-app grouping route is `GET /devices/groups` (the extension
   degrades to "no grouping" when it is absent).
   `@olivierzal/homey-kit/settings` is the settings pages' transport

--- a/api.mts
+++ b/api.mts
@@ -4,17 +4,17 @@ import type * as Home from '@olivierzal/melcloud-api/home'
 import type { Homey } from 'homey/lib/Homey'
 import { getErrorMessage } from '@olivierzal/homey-kit'
 import {
-  type AggregatedHolidayModeState,
-  type AggregatedProtectionState,
-  type HolidayModeState,
   type LoginCredentials,
-  type ProtectionState,
   type ProtectionUpdate,
   AuthenticationError,
   AuthenticationThrottledError,
 } from '@olivierzal/melcloud-api'
 
-import type { HolidayModeSettings } from './types/api.mts'
+import type {
+  HolidayModeSettings,
+  TargetHolidayModeState,
+  TargetProtectionState,
+} from './types/api.mts'
 import type { DeviceSettings, Settings } from './types/device-settings.mts'
 import type {
   ErrorLogQueryParams,
@@ -176,23 +176,21 @@ const api = {
   }: {
     homey: Homey
     params: { targetId: string }
-  }): Promise<AggregatedProtectionState | ProtectionState | null> =>
-    app.getTargetFrostProtection(targetId),
+  }): Promise<TargetProtectionState> => app.getTargetFrostProtection(targetId),
   getTargetHolidayMode: async ({
     homey: { app },
     params: { targetId },
   }: {
     homey: Homey
     params: { targetId: string }
-  }): Promise<AggregatedHolidayModeState | HolidayModeState | null> =>
-    app.getTargetHolidayMode(targetId),
+  }): Promise<TargetHolidayModeState> => app.getTargetHolidayMode(targetId),
   getTargetOverheatProtection: async ({
     homey: { app },
     params: { targetId },
   }: {
     homey: Homey
     params: { targetId: string }
-  }): Promise<AggregatedProtectionState | ProtectionState | null> =>
+  }): Promise<TargetProtectionState> =>
     app.getTargetOverheatProtection(targetId),
   getWebviewHashes: async ({
     homey: { app },

--- a/api.mts
+++ b/api.mts
@@ -4,6 +4,8 @@ import type * as Home from '@olivierzal/melcloud-api/home'
 import type { Homey } from 'homey/lib/Homey'
 import { getErrorMessage } from '@olivierzal/homey-kit'
 import {
+  type AggregatedHolidayModeState,
+  type AggregatedProtectionState,
   type HolidayModeState,
   type LoginCredentials,
   type ProtectionState,
@@ -20,12 +22,11 @@ import type {
 } from './types/error-log.mts'
 import type {
   DeviceGroup,
-  DeviceOrZoneData,
   HomeBuildingZone,
   HomeDeviceZone,
 } from './types/zone.mts'
 import { getClassicBuildings } from './lib/classic-facade-manager.mts'
-import { toDeviceOrZoneData, toNonNegativeInt } from './lib/validation.mts'
+import { toNonNegativeInt } from './lib/validation.mts'
 import { getWebviewHashes } from './lib/webview-hashes.mts'
 
 // The user-facing service names, interpolated into the failure
@@ -113,22 +114,6 @@ const api = {
     app.classicApi.logOut()
   },
   getClassicBuildings: (): Classic.BuildingZone[] => getClassicBuildings(),
-  getClassicFrostProtection: async ({
-    homey: { app },
-    params,
-  }: {
-    homey: Homey
-    params: DeviceOrZoneData
-  }): Promise<ProtectionState | null> =>
-    app.getClassicFrostProtection(toDeviceOrZoneData(params)),
-  getClassicHolidayMode: async ({
-    homey: { app },
-    params,
-  }: {
-    homey: Homey
-    params: DeviceOrZoneData
-  }): Promise<HolidayModeState | null> =>
-    app.getClassicHolidayMode(toDeviceOrZoneData(params)),
   /**
    * Lists the MELCloud buildings of both dialects with the device ids
    * they own, for the extension app's per-building settings grouping.
@@ -170,62 +155,14 @@ const api = {
     const parsedOffset = toOptionalNonNegativeInt(offset, 'offset')
     const parsedPeriod = toOptionalNonNegativeInt(period, 'period')
     return app.getErrorLog({
-      from,
-      offset: parsedOffset,
-      period: parsedPeriod,
-      to,
+      ...(from !== undefined && { from }),
+      ...(parsedOffset !== undefined && { offset: parsedOffset }),
+      ...(parsedPeriod !== undefined && { period: parsedPeriod }),
+      ...(to !== undefined && { to }),
     })
   },
-  getHomeBuildingFrostProtection: ({
-    homey: { app },
-    params: { buildingId },
-  }: {
-    homey: Homey
-    params: { buildingId: string }
-  }): { isEnabled: boolean | null; max: number | null; min: number | null } =>
-    app.getHomeBuildingFrostProtection(buildingId),
-  getHomeBuildingHolidayMode: ({
-    homey: { app },
-    params: { buildingId },
-  }: {
-    homey: Homey
-    params: { buildingId: string }
-  }): {
-    endDate: string | null
-    isEnabled: boolean | null
-    startDate: string | null
-  } => app.getHomeBuildingHolidayMode(buildingId),
-  getHomeBuildingOverheatProtection: ({
-    homey: { app },
-    params: { buildingId },
-  }: {
-    homey: Homey
-    params: { buildingId: string }
-  }): { isEnabled: boolean | null; max: number | null; min: number | null } =>
-    app.getHomeBuildingOverheatProtection(buildingId),
   getHomeDevices: ({ homey: { app } }: { homey: Homey }): HomeDeviceZone[] =>
     app.getHomeDeviceZones(),
-  getHomeFrostProtection: ({
-    homey: { app },
-    params: { deviceId },
-  }: {
-    homey: Homey
-    params: { deviceId: string }
-  }): ProtectionState | null => app.getHomeFrostProtection(deviceId),
-  getHomeHolidayMode: ({
-    homey: { app },
-    params: { deviceId },
-  }: {
-    homey: Homey
-    params: { deviceId: string }
-  }): HolidayModeState | null => app.getHomeHolidayMode(deviceId),
-  getHomeOverheatProtection: ({
-    homey: { app },
-    params: { deviceId },
-  }: {
-    homey: Homey
-    params: { deviceId: string }
-  }): ProtectionState | null => app.getHomeOverheatProtection(deviceId),
   getHomeTargets: ({
     homey: { app },
   }: {
@@ -233,6 +170,30 @@ const api = {
   }): (HomeBuildingZone | HomeDeviceZone)[] => app.getHomeTargets(),
   getLanguage: ({ homey: { i18n } }: { homey: Homey }): string =>
     i18n.getLanguage(),
+  getTargetFrostProtection: async ({
+    homey: { app },
+    params: { targetId },
+  }: {
+    homey: Homey
+    params: { targetId: string }
+  }): Promise<AggregatedProtectionState | ProtectionState | null> =>
+    app.getTargetFrostProtection(targetId),
+  getTargetHolidayMode: async ({
+    homey: { app },
+    params: { targetId },
+  }: {
+    homey: Homey
+    params: { targetId: string }
+  }): Promise<AggregatedHolidayModeState | HolidayModeState | null> =>
+    app.getTargetHolidayMode(targetId),
+  getTargetOverheatProtection: async ({
+    homey: { app },
+    params: { targetId },
+  }: {
+    homey: Homey
+    params: { targetId: string }
+  }): Promise<AggregatedProtectionState | ProtectionState | null> =>
+    app.getTargetOverheatProtection(targetId),
   getWebviewHashes: async ({
     homey: { app },
   }: {
@@ -258,9 +219,13 @@ const api = {
     logSettingsRoute(app, 'DELETE /home/sessions')
     app.homeApi.logOut()
   },
-  isClassicAuthenticated: ({ homey: { app } }: { homey: Homey }): boolean => {
+  isClassicAuthenticated: async ({
+    homey: { app },
+  }: {
+    homey: Homey
+  }): Promise<boolean> => {
     logSettingsRoute(app, 'GET /classic/sessions')
-    return app.classicApi.isAuthenticated()
+    return app.classicApi.ensureAuthenticated()
   },
   isHomeAuthenticated: async ({
     homey: { app },
@@ -279,32 +244,6 @@ const api = {
   }): void => {
     app.error('Settings webview boot failed:', JSON.stringify(body))
   },
-  updateClassicFrostProtection: async ({
-    body,
-    homey: { app },
-    params,
-  }: {
-    body: ProtectionUpdate
-    homey: Homey
-    params: DeviceOrZoneData
-  }): Promise<void> =>
-    app.updateClassicFrostProtection({
-      settings: body,
-      ...toDeviceOrZoneData(params),
-    }),
-  updateClassicHolidayMode: async ({
-    body,
-    homey: { app },
-    params,
-  }: {
-    body: HolidayModeSettings
-    homey: Homey
-    params: DeviceOrZoneData
-  }): Promise<void> =>
-    app.updateClassicHolidayMode({
-      settings: body,
-      ...toDeviceOrZoneData(params),
-    }),
   updateDeviceSettings: async ({
     body,
     homey: { app },
@@ -314,61 +253,33 @@ const api = {
     homey: Homey
     query: { driverId?: string }
   }): Promise<void> => app.updateDeviceSettings({ driverId, settings: body }),
-  updateHomeBuildingFrostProtection: async ({
+  updateTargetFrostProtection: async ({
     body,
     homey: { app },
-    params: { buildingId },
+    params: { targetId },
   }: {
     body: ProtectionUpdate
     homey: Homey
-    params: { buildingId: string }
-  }): Promise<void> => app.updateHomeBuildingFrostProtection(buildingId, body),
-  updateHomeBuildingHolidayMode: async ({
+    params: { targetId: string }
+  }): Promise<void> => app.updateTargetFrostProtection(targetId, body),
+  updateTargetHolidayMode: async ({
     body,
     homey: { app },
-    params: { buildingId },
+    params: { targetId },
   }: {
     body: HolidayModeSettings
     homey: Homey
-    params: { buildingId: string }
-  }): Promise<void> => app.updateHomeBuildingHolidayMode(buildingId, body),
-  updateHomeBuildingOverheatProtection: async ({
+    params: { targetId: string }
+  }): Promise<void> => app.updateTargetHolidayMode(targetId, body),
+  updateTargetOverheatProtection: async ({
     body,
     homey: { app },
-    params: { buildingId },
+    params: { targetId },
   }: {
     body: ProtectionUpdate
     homey: Homey
-    params: { buildingId: string }
-  }): Promise<void> =>
-    app.updateHomeBuildingOverheatProtection(buildingId, body),
-  updateHomeFrostProtection: async ({
-    body,
-    homey: { app },
-    params: { deviceId },
-  }: {
-    body: ProtectionUpdate
-    homey: Homey
-    params: { deviceId: string }
-  }): Promise<void> => app.updateHomeFrostProtection([deviceId], body),
-  updateHomeHolidayMode: async ({
-    body,
-    homey: { app },
-    params: { deviceId },
-  }: {
-    body: HolidayModeSettings
-    homey: Homey
-    params: { deviceId: string }
-  }): Promise<void> => app.updateHomeHolidayMode([deviceId], body),
-  updateHomeOverheatProtection: async ({
-    body,
-    homey: { app },
-    params: { deviceId },
-  }: {
-    body: ProtectionUpdate
-    homey: Homey
-    params: { deviceId: string }
-  }): Promise<void> => app.updateHomeOverheatProtection([deviceId], body),
+    params: { targetId: string }
+  }): Promise<void> => app.updateTargetOverheatProtection(targetId, body),
 }
 
 export default api

--- a/app.json
+++ b/app.json
@@ -13,14 +13,6 @@
       "method": "GET",
       "path": "/classic/buildings"
     },
-    "getClassicFrostProtection": {
-      "method": "GET",
-      "path": "/classic/zones/:zoneType/:zoneId/settings/frost-protection"
-    },
-    "getClassicHolidayMode": {
-      "method": "GET",
-      "path": "/classic/zones/:zoneType/:zoneId/settings/holiday-mode"
-    },
     "getDeviceGroups": {
       "method": "GET",
       "path": "/devices/groups"
@@ -37,33 +29,9 @@
       "method": "GET",
       "path": "/logs/errors"
     },
-    "getHomeBuildingFrostProtection": {
-      "method": "GET",
-      "path": "/home/buildings/:buildingId/settings/frost-protection"
-    },
-    "getHomeBuildingHolidayMode": {
-      "method": "GET",
-      "path": "/home/buildings/:buildingId/settings/holiday-mode"
-    },
-    "getHomeBuildingOverheatProtection": {
-      "method": "GET",
-      "path": "/home/buildings/:buildingId/settings/overheat-protection"
-    },
     "getHomeDevices": {
       "method": "GET",
       "path": "/home/devices"
-    },
-    "getHomeFrostProtection": {
-      "method": "GET",
-      "path": "/home/devices/:deviceId/settings/frost-protection"
-    },
-    "getHomeHolidayMode": {
-      "method": "GET",
-      "path": "/home/devices/:deviceId/settings/holiday-mode"
-    },
-    "getHomeOverheatProtection": {
-      "method": "GET",
-      "path": "/home/devices/:deviceId/settings/overheat-protection"
     },
     "getHomeTargets": {
       "method": "GET",
@@ -72,6 +40,18 @@
     "getLanguage": {
       "method": "GET",
       "path": "/language"
+    },
+    "getTargetFrostProtection": {
+      "method": "GET",
+      "path": "/targets/:targetId/settings/frost-protection"
+    },
+    "getTargetHolidayMode": {
+      "method": "GET",
+      "path": "/targets/:targetId/settings/holiday-mode"
+    },
+    "getTargetOverheatProtection": {
+      "method": "GET",
+      "path": "/targets/:targetId/settings/overheat-protection"
     },
     "getWebviewHashes": {
       "method": "GET",
@@ -97,41 +77,21 @@
       "method": "POST",
       "path": "/boot-error"
     },
-    "updateClassicFrostProtection": {
-      "method": "PUT",
-      "path": "/classic/zones/:zoneType/:zoneId/settings/frost-protection"
-    },
-    "updateClassicHolidayMode": {
-      "method": "PUT",
-      "path": "/classic/zones/:zoneType/:zoneId/settings/holiday-mode"
-    },
     "updateDeviceSettings": {
       "method": "PUT",
       "path": "/settings/devices"
     },
-    "updateHomeBuildingFrostProtection": {
+    "updateTargetFrostProtection": {
       "method": "PUT",
-      "path": "/home/buildings/:buildingId/settings/frost-protection"
+      "path": "/targets/:targetId/settings/frost-protection"
     },
-    "updateHomeBuildingHolidayMode": {
+    "updateTargetHolidayMode": {
       "method": "PUT",
-      "path": "/home/buildings/:buildingId/settings/holiday-mode"
+      "path": "/targets/:targetId/settings/holiday-mode"
     },
-    "updateHomeBuildingOverheatProtection": {
+    "updateTargetOverheatProtection": {
       "method": "PUT",
-      "path": "/home/buildings/:buildingId/settings/overheat-protection"
-    },
-    "updateHomeFrostProtection": {
-      "method": "PUT",
-      "path": "/home/devices/:deviceId/settings/frost-protection"
-    },
-    "updateHomeHolidayMode": {
-      "method": "PUT",
-      "path": "/home/devices/:deviceId/settings/holiday-mode"
-    },
-    "updateHomeOverheatProtection": {
-      "method": "PUT",
-      "path": "/home/devices/:deviceId/settings/overheat-protection"
+      "path": "/targets/:targetId/settings/overheat-protection"
     }
   },
   "author": {
@@ -343,7 +303,7 @@
       "värmeåtervinning"
     ]
   },
-  "version": "46.4.2",
+  "version": "46.5.0",
   "flow": {
     "triggers": [
       {

--- a/app.mts
+++ b/app.mts
@@ -13,6 +13,8 @@ import {
   mergeDeviceSettings,
 } from '@olivierzal/homey-kit/manifest'
 import {
+  type AggregatedHolidayModeState,
+  type AggregatedProtectionState,
   type DeviceType,
   type HolidayModeState,
   type HolidayModeUpdate,
@@ -21,12 +23,13 @@ import {
   type ProtectionUpdate,
   type ReportChartLineOptions,
   type ReportChartPieOptions,
+  type Result,
   type SettingManager,
   type SyncCallback,
   isClassicAtaFacade,
-  isHomeAtaFacade,
   NoChangesError,
   operationModeToClassic,
+  resolveErrorLogWindow,
 } from '@olivierzal/melcloud-api'
 import { Intl, Temporal } from 'temporal-polyfill'
 import * as Classic from '@olivierzal/melcloud-api/classic'
@@ -82,20 +85,24 @@ const byName = (
   other: { readonly name: string },
 ): number => first.name.localeCompare(other.name)
 
-// The value shared by every entry, or `null` when they disagree — a Home
-// building aggregates per-device frost/holiday, and a field the devices do
-// not agree on reads as "mixed" (`null`).
-const commonValue = <T,>(values: readonly T[]): NonNullable<T> | null => {
-  const [first, ...rest] = values
-  return values.length > 0 && rest.every((value) => value === first)
-    ? (first ?? null)
-    : null
-}
-
 const HOLIDAY_MODE_MAX_DURATION_DAYS = 365
 const HOLIDAY_MODE_OFF_DURATION = 0
 
 const NOTIFICATION_DELAY_MS = 10_000
+
+// The one surface every settings target answers — Classic zone/device
+// facades, Home device facades and the Home building facade alike; the
+// widened return unions absorb the building aggregates' per-field nulls.
+interface SettingsTarget {
+  readonly getFrostProtection: () => Promise<
+    Result<AggregatedProtectionState | ProtectionState | null>
+  >
+  readonly getHolidayMode: () => Promise<
+    Result<AggregatedHolidayModeState | HolidayModeState | null>
+  >
+  readonly updateFrostProtection: (update: ProtectionUpdate) => Promise<void>
+  readonly updateHolidayMode: (update: HolidayModeUpdate) => Promise<void>
+}
 
 const DRIVER_IDS_BY_TYPE: Partial<Record<DeviceType, string>> = {
   [Classic.DeviceType.Ata]: 'melcloud',
@@ -232,32 +239,6 @@ interface RawErrorEntry {
   readonly device: string
   readonly error: string
   readonly instant: Temporal.Instant
-}
-
-// Mirrors the Classic pagination tiling (a page spans `period` days, the
-// next one ends the day before it starts) so a Home-only account still
-// browses windows when Classic is signed out.
-const syntheticErrorLogWindow = (
-  { from, period, to }: Classic.ErrorLogQuery,
-  timeZone: string,
-): Omit<Classic.ErrorLog, 'errors'> => {
-  const periodDays = period ?? DEFAULT_ERROR_LOG_PERIOD_DAYS
-  const toDate =
-    to !== undefined && to !== ''
-      ? Temporal.PlainDate.from(to)
-      : Temporal.Now.plainDateISO(timeZone)
-  // A user-picked "since" date pins the window start, like the
-  // library's own parseErrorLogQuery does on the Classic path.
-  const fromDate =
-    from !== undefined && from !== ''
-      ? Temporal.PlainDate.from(from)
-      : toDate.subtract({ days: periodDays })
-  const nextToDate = fromDate.subtract({ days: 1 })
-  return {
-    fromDate: fromDate.toString(),
-    nextFromDate: nextToDate.subtract({ days: periodDays }).toString(),
-    nextToDate: nextToDate.toString(),
-  }
 }
 
 const isWithinErrorLogWindow = (
@@ -498,24 +479,6 @@ export default class MELCloudApp extends App {
     return this.#facadeManager.get(instance)
   }
 
-  public async getClassicFrostProtection({
-    zoneId,
-    zoneType,
-  }: DeviceOrZoneData): Promise<ProtectionState | null> {
-    return unwrapResult(
-      await this.getClassicFacade(zoneType, zoneId).getFrostProtection(),
-    )
-  }
-
-  public async getClassicHolidayMode({
-    zoneId,
-    zoneType,
-  }: DeviceOrZoneData): Promise<HolidayModeState | null> {
-    return unwrapResult(
-      await this.getClassicFacade(zoneType, zoneId).getHolidayMode(),
-    )
-  }
-
   public async getClassicHourlyTemperatures({
     deviceId,
     hour,
@@ -615,7 +578,7 @@ export default class MELCloudApp extends App {
   ): Promise<FormattedErrorLog> {
     const locale = this.homey.i18n.getLanguage()
     const timeZone = getTimeZone(this.homey)
-    const { errors, fromDate, ...rest } = await this.#getClassicErrorLogPage(
+    const { entries, fromDate, ...rest } = await this.#getClassicErrorLogPage(
       query,
       timeZone,
     )
@@ -631,11 +594,11 @@ export default class MELCloudApp extends App {
     const homeEntries = allHomeEntries.filter((entry) =>
       isWithinErrorLogWindow(entry.instant, window),
     )
-    const classicEntries = errors.map(
-      ({ date, deviceId, error }): RawErrorEntry => ({
+    const classicEntries = entries.map(
+      ({ at, deviceId, message }): RawErrorEntry => ({
         device: this.#classicRegistry.devices.getById(deviceId)?.name ?? '',
-        error,
-        instant: parseErrorDate(date, timeZone),
+        error: message,
+        instant: parseErrorDate(at, timeZone),
       }),
     )
     return {
@@ -661,12 +624,14 @@ export default class MELCloudApp extends App {
   // Member operation modes in the Classic vocabulary — what the widget's
   // mixed-mode scene resolver consumes.
   public getHomeBuildingAtaModes(buildingId: string): number[] {
-    return this.#getHomeBuildingFacade(buildingId).devices.map(
-      (device) =>
-        operationModeToClassic[
-          this.#homeFacadeManager.get(device).operationMode
-        ],
-    )
+    return this.#getHomeBuildingFacade(buildingId)
+      .devices.filter((device) => device.isAta())
+      .map(
+        (device) =>
+          operationModeToClassic[
+            this.#homeFacadeManager.get(device).operationMode
+          ],
+      )
   }
 
   public async getHomeBuildingAtaState(
@@ -675,87 +640,6 @@ export default class MELCloudApp extends App {
     return unwrapResult(
       await this.#getHomeBuildingFacade(buildingId).getGroup(),
     )
-  }
-
-  // Aggregate frost protection across a Home building's devices: each field
-  // is the shared value, or `null` when the devices disagree ("mixed").
-  public getHomeBuildingFrostProtection(buildingId: string): {
-    isEnabled: boolean | null
-    max: number | null
-    min: number | null
-  } {
-    const frostProtections = this.#getHomeBuildingDeviceIds(buildingId).map(
-      (deviceId) => this.getHomeFrostProtection(deviceId),
-    )
-    return {
-      // A device with no frost config counts as off, so an all-unconfigured
-      // building reads "No" rather than "mixed".
-      isEnabled: commonValue(
-        frostProtections.map(
-          (frostProtection) => frostProtection?.isEnabled ?? false,
-        ),
-      ),
-      max: commonValue(
-        frostProtections.map((frostProtection) => frostProtection?.max),
-      ),
-      min: commonValue(
-        frostProtections.map((frostProtection) => frostProtection?.min),
-      ),
-    }
-  }
-
-  // Aggregate holiday mode across a Home building's devices, `null` per
-  // field on disagreement ("mixed").
-  public getHomeBuildingHolidayMode(buildingId: string): {
-    endDate: string | null
-    isEnabled: boolean | null
-    startDate: string | null
-  } {
-    const holidayModes = this.#getHomeBuildingDeviceIds(buildingId).map(
-      (deviceId) => this.getHomeHolidayMode(deviceId),
-    )
-    return {
-      endDate: commonValue(
-        holidayModes.map((holidayMode) => holidayMode?.endDate),
-      ),
-      isEnabled: commonValue(
-        holidayModes.map((holidayMode) => holidayMode?.isEnabled ?? false),
-      ),
-      startDate: commonValue(
-        holidayModes.map((holidayMode) => holidayMode?.startDate),
-      ),
-    }
-  }
-
-  // Aggregate overheat protection across a Home building's ATA devices
-  // (the feature is ATA-only), `null` per field on disagreement ("mixed").
-  public getHomeBuildingOverheatProtection(buildingId: string): {
-    isEnabled: boolean | null
-    max: number | null
-    min: number | null
-  } {
-    const overheatProtections = this.#getHomeBuildingAtaDeviceIds(
-      buildingId,
-    ).map((deviceId) => this.getHomeOverheatProtection(deviceId))
-    return {
-      // A device with no overheat config counts as off, so an
-      // all-unconfigured building reads "No" rather than "mixed".
-      isEnabled: commonValue(
-        overheatProtections.map(
-          (overheatProtection) => overheatProtection?.isEnabled ?? false,
-        ),
-      ),
-      max: commonValue(
-        overheatProtections.map(
-          (overheatProtection) => overheatProtection?.max,
-        ),
-      ),
-      min: commonValue(
-        overheatProtections.map(
-          (overheatProtection) => overheatProtection?.min,
-        ),
-      ),
-    }
   }
 
   public getHomeDevicesByType(type: Home.DeviceType): Home.Device[] {
@@ -797,14 +681,6 @@ export default class MELCloudApp extends App {
     return this.#getHomeDeviceFacade(deviceId, type)
   }
 
-  public getHomeFrostProtection(deviceId: string): ProtectionState | null {
-    return this.#getHomeDeviceFacade(deviceId).frostProtection
-  }
-
-  public getHomeHolidayMode(deviceId: string): HolidayModeState | null {
-    return this.#getHomeDeviceFacade(deviceId).holidayMode
-  }
-
   public async getHomeHourlyTemperatures({
     deviceId,
     hour,
@@ -832,13 +708,6 @@ export default class MELCloudApp extends App {
         this.#chartDaysQuery(days),
       ),
     )
-  }
-
-  public getHomeOverheatProtection(deviceId: string): ProtectionState | null {
-    const facade = this.#getHomeDeviceFacade(deviceId)
-    // ATA-only: the wire carries the field on ATW too, but the official
-    // app never offers the feature there — only the ATA facade exposes it.
-    return isHomeAtaFacade(facade) ? facade.overheatProtection : null
   }
 
   public async getHomeSignal({
@@ -877,6 +746,33 @@ export default class MELCloudApp extends App {
     )
   }
 
+  public async getTargetFrostProtection(
+    targetId: string,
+  ): Promise<AggregatedProtectionState | ProtectionState | null> {
+    return unwrapResult(
+      await this.#getSettingsTarget(targetId).getFrostProtection(),
+    )
+  }
+
+  public async getTargetHolidayMode(
+    targetId: string,
+  ): Promise<AggregatedHolidayModeState | HolidayModeState | null> {
+    return unwrapResult(
+      await this.#getSettingsTarget(targetId).getHolidayMode(),
+    )
+  }
+
+  // Overheat protection exists on Home targets only: a Classic target
+  // reads `null`, like a Home target that never configured it.
+  public async getTargetOverheatProtection(
+    targetId: string,
+  ): Promise<AggregatedProtectionState | ProtectionState | null> {
+    const target = this.#getOverheatTarget(targetId)
+    return target === null
+      ? null
+      : unwrapResult(await target.getOverheatProtection())
+  }
+
   public async updateClassicAtaState({
     state,
     zoneId,
@@ -884,26 +780,6 @@ export default class MELCloudApp extends App {
   }: DeviceOrZoneData & { state: Classic.GroupState }): Promise<void> {
     await this.#getClassicAtaGroupFacade({ zoneId, zoneType }).updateGroupState(
       state,
-    )
-  }
-
-  public async updateClassicFrostProtection({
-    settings,
-    zoneId,
-    zoneType,
-  }: DeviceOrZoneData & { settings: ProtectionUpdate }): Promise<void> {
-    await this.getClassicFacade(zoneType, zoneId).updateFrostProtection(
-      settings,
-    )
-  }
-
-  public async updateClassicHolidayMode({
-    settings,
-    zoneId,
-    zoneType,
-  }: DeviceOrZoneData & { settings: HolidayModeSettings }): Promise<void> {
-    await this.getClassicFacade(zoneType, zoneId).updateHolidayMode(
-      this.#completeHolidayModeWindow(settings),
     )
   }
 
@@ -963,58 +839,33 @@ export default class MELCloudApp extends App {
     await this.#getHomeBuildingFacade(buildingId).updateGroupState(state)
   }
 
-  public async updateHomeBuildingFrostProtection(
-    buildingId: string,
+  public async updateTargetFrostProtection(
+    targetId: string,
     settings: ProtectionUpdate,
   ): Promise<void> {
-    await this.updateHomeFrostProtection(
-      this.#getHomeBuildingDeviceIds(buildingId),
-      settings,
-    )
+    await this.#getSettingsTarget(targetId).updateFrostProtection(settings)
   }
 
-  public async updateHomeBuildingHolidayMode(
-    buildingId: string,
+  public async updateTargetHolidayMode(
+    targetId: string,
     settings: HolidayModeSettings,
   ): Promise<void> {
-    await this.updateHomeHolidayMode(
-      this.#getHomeBuildingDeviceIds(buildingId),
-      settings,
-    )
-  }
-
-  public async updateHomeBuildingOverheatProtection(
-    buildingId: string,
-    settings: ProtectionUpdate,
-  ): Promise<void> {
-    await this.updateHomeOverheatProtection(
-      this.#getHomeBuildingDeviceIds(buildingId),
-      settings,
-    )
-  }
-
-  public async updateHomeFrostProtection(
-    deviceIds: readonly string[],
-    settings: ProtectionUpdate,
-  ): Promise<void> {
-    await this.#homeFacadeManager.updateFrostProtection(deviceIds, settings)
-  }
-
-  public async updateHomeHolidayMode(
-    deviceIds: readonly string[],
-    settings: HolidayModeSettings,
-  ): Promise<void> {
-    await this.#homeFacadeManager.updateHolidayMode(
-      deviceIds,
+    await this.#getSettingsTarget(targetId).updateHolidayMode(
       this.#completeHolidayModeWindow(settings),
     )
   }
 
-  public async updateHomeOverheatProtection(
-    deviceIds: readonly string[],
+  public async updateTargetOverheatProtection(
+    targetId: string,
     settings: ProtectionUpdate,
   ): Promise<void> {
-    await this.#homeFacadeManager.updateOverheatProtection(deviceIds, settings)
+    const target = this.#getOverheatTarget(targetId)
+    if (target === null) {
+      // Overheat protection does not exist on the Classic wire: a write
+      // addressed to a Classic target is a caller error, not a no-op.
+      throw new NotFoundError(this.homey.__('errors.deviceNotFound'))
+    }
+    await target.updateOverheatProtection(settings)
   }
 
   readonly #onSync: SyncCallback = async ({ ids, type } = {}) => {
@@ -1224,7 +1075,13 @@ export default class MELCloudApp extends App {
     timeZone: string,
   ): Promise<Classic.ErrorLog> {
     if (!this.classicApi.isAuthenticated()) {
-      return { errors: [], ...syntheticErrorLogWindow(query, timeZone) }
+      // A Home-only account pages the same windows the Classic API
+      // would have answered: the library publishes its own tiling.
+      const { fromDate, nextFromDate, nextToDate } = resolveErrorLogWindow(
+        { period: DEFAULT_ERROR_LOG_PERIOD_DAYS, ...query },
+        timeZone,
+      )
+      return { entries: [], fromDate, nextFromDate, nextToDate }
     }
     return unwrapResult(await this.#classicApi.getErrorLog(query))
   }
@@ -1263,21 +1120,7 @@ export default class MELCloudApp extends App {
   }
 
   // The ids of every device (ATA and ATW) in a `/context` building.
-  #getHomeBuildingAtaDeviceIds(buildingId: string): string[] {
-    return this.#homeRegistry
-      .getDevices()
-      .filter((device) => device.building.id === buildingId && device.isAta())
-      .map((device) => device.id)
-  }
-
-  #getHomeBuildingDeviceIds(buildingId: string): string[] {
-    return this.#homeRegistry
-      .getDevices()
-      .filter((device) => device.building.id === buildingId)
-      .map((device) => device.id)
-  }
-
-  #getHomeBuildingFacade(buildingId: string): Home.BuildingAtaFacade {
+  #getHomeBuildingFacade(buildingId: string): Home.BuildingFacade {
     const facade = this.#homeFacadeManager.getBuilding(buildingId)
     if (facade === null) {
       throw new NotFoundError(this.homey.__('errors.deviceNotFound'))
@@ -1296,10 +1139,10 @@ export default class MELCloudApp extends App {
       this.error('Home error log fetch failed:', name, result.error)
       return []
     }
-    return result.value.map(({ errorCode, errorReason, timestamp }) => ({
+    return result.value.map(({ at, code, message }) => ({
       device: name,
-      error: errorReason ?? errorCode,
-      instant: parseErrorDate(timestamp, timeZone),
+      error: message ?? code ?? '',
+      instant: parseErrorDate(at, timeZone),
     }))
   }
 
@@ -1331,6 +1174,33 @@ export default class MELCloudApp extends App {
       ),
     )
     return logs.flat()
+  }
+
+  // Overheat protection exists on Home targets only; a Classic value
+  // resolves to `null` rather than a facade.
+  #getOverheatTarget(
+    targetId: string,
+  ): Home.BuildingFacade | Home.DeviceAtaFacade | Home.DeviceAtwFacade | null {
+    if (isHomeBuildingValue(targetId)) {
+      return this.#getHomeBuildingFacade(getHomeBuildingId(targetId))
+    }
+    return isHomeDeviceValue(targetId)
+      ? this.#getHomeDeviceFacade(getHomeDeviceId(targetId))
+      : null
+  }
+
+  // The one target resolver behind the neutral settings routes: the
+  // targetId is the picker value verbatim (`${model}_${id}`), so
+  // addressing is the only family-visible step left.
+  #getSettingsTarget(targetId: string): SettingsTarget {
+    if (isHomeBuildingValue(targetId)) {
+      return this.#getHomeBuildingFacade(getHomeBuildingId(targetId))
+    }
+    if (isHomeDeviceValue(targetId)) {
+      return this.#getHomeDeviceFacade(getHomeDeviceId(targetId))
+    }
+    const { zoneId, zoneType } = toZoneValueData(targetId)
+    return this.getClassicFacade(zoneType, zoneId)
   }
 
   // Driver ids are a store compat contract: Home drivers are namespaced
@@ -1452,20 +1322,11 @@ export default class MELCloudApp extends App {
     this.#homeFacadeManager = new Home.FacadeManager(this.#homeApi)
   }
 
-  // Is holiday mode on for a flat target value? A single Home device, or a
-  // whole Home building (on only when every device agrees), or a Classic
-  // zone/device — routed by parsing the option value.
+  // Is holiday mode on for a flat target value? The option value IS the
+  // targetId, so the neutral read answers directly — a building is "on"
+  // only when every member agrees (the aggregate's `null` reads false).
   async #isHolidayModeEnabled(value: string): Promise<boolean> {
-    if (isHomeDeviceValue(value)) {
-      return this.getHomeHolidayMode(getHomeDeviceId(value))?.isEnabled === true
-    }
-    if (isHomeBuildingValue(value)) {
-      return (
-        this.getHomeBuildingHolidayMode(getHomeBuildingId(value)).isEnabled ===
-        true
-      )
-    }
-    const holidayMode = await this.getClassicHolidayMode(toZoneValueData(value))
+    const holidayMode = await this.getTargetHolidayMode(value)
     return holidayMode?.isEnabled === true
   }
 
@@ -1613,25 +1474,12 @@ export default class MELCloudApp extends App {
     return false
   }
 
-  // Route a holiday-mode write from a flat target value: a single Home
-  // device, a whole Home building (its devices batched), or a Classic
-  // zone/device — the same value parsing the settings page uses.
+  // Route a holiday-mode write from a flat target value: the option
+  // value IS the targetId the neutral write takes.
   async #updateHolidayModeTarget(
     value: string,
     settings: HolidayModeUpdate,
   ): Promise<void> {
-    if (isHomeDeviceValue(value)) {
-      await this.updateHomeHolidayMode([getHomeDeviceId(value)], settings)
-    } else if (isHomeBuildingValue(value)) {
-      await this.updateHomeBuildingHolidayMode(
-        getHomeBuildingId(value),
-        settings,
-      )
-    } else {
-      await this.updateClassicHolidayMode({
-        settings,
-        ...toZoneValueData(value),
-      })
-    }
+    await this.updateTargetHolidayMode(value, settings)
   }
 }

--- a/app.mts
+++ b/app.mts
@@ -13,13 +13,9 @@ import {
   mergeDeviceSettings,
 } from '@olivierzal/homey-kit/manifest'
 import {
-  type AggregatedHolidayModeState,
-  type AggregatedProtectionState,
   type DeviceType,
-  type HolidayModeState,
   type HolidayModeUpdate,
   type Hour,
-  type ProtectionState,
   type ProtectionUpdate,
   type ReportChartLineOptions,
   type ReportChartPieOptions,
@@ -35,7 +31,12 @@ import { Intl, Temporal } from 'temporal-polyfill'
 import * as Classic from '@olivierzal/melcloud-api/classic'
 import * as Home from '@olivierzal/melcloud-api/home'
 
-import type { Api, HolidayModeSettings } from './types/api.mts'
+import type {
+  Api,
+  HolidayModeSettings,
+  TargetHolidayModeState,
+  TargetProtectionState,
+} from './types/api.mts'
 import type { HomeySettings } from './types/app-settings.mts'
 import type { GroupAtaStates } from './types/classic-ata.mts'
 import type { DeviceSettings, Settings } from './types/device-settings.mts'
@@ -94,12 +95,8 @@ const NOTIFICATION_DELAY_MS = 10_000
 // facades, Home device facades and the Home building facade alike; the
 // widened return unions absorb the building aggregates' per-field nulls.
 interface SettingsTarget {
-  readonly getFrostProtection: () => Promise<
-    Result<AggregatedProtectionState | ProtectionState | null>
-  >
-  readonly getHolidayMode: () => Promise<
-    Result<AggregatedHolidayModeState | HolidayModeState | null>
-  >
+  readonly getFrostProtection: () => Promise<Result<TargetProtectionState>>
+  readonly getHolidayMode: () => Promise<Result<TargetHolidayModeState>>
   readonly updateFrostProtection: (update: ProtectionUpdate) => Promise<void>
   readonly updateHolidayMode: (update: HolidayModeUpdate) => Promise<void>
 }
@@ -748,7 +745,7 @@ export default class MELCloudApp extends App {
 
   public async getTargetFrostProtection(
     targetId: string,
-  ): Promise<AggregatedProtectionState | ProtectionState | null> {
+  ): Promise<TargetProtectionState> {
     return unwrapResult(
       await this.#getSettingsTarget(targetId).getFrostProtection(),
     )
@@ -756,7 +753,7 @@ export default class MELCloudApp extends App {
 
   public async getTargetHolidayMode(
     targetId: string,
-  ): Promise<AggregatedHolidayModeState | HolidayModeState | null> {
+  ): Promise<TargetHolidayModeState> {
     return unwrapResult(
       await this.#getSettingsTarget(targetId).getHolidayMode(),
     )
@@ -766,7 +763,7 @@ export default class MELCloudApp extends App {
   // reads `null`, like a Home target that never configured it.
   public async getTargetOverheatProtection(
     targetId: string,
-  ): Promise<AggregatedProtectionState | ProtectionState | null> {
+  ): Promise<TargetProtectionState> {
     const target = this.#getOverheatTarget(targetId)
     return target === null
       ? null

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "com.melcloud",
-  "version": "46.4.2",
+  "version": "46.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "com.melcloud",
-      "version": "46.4.2",
+      "version": "46.5.0",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@olivierzal/homey-kit": "5.0.0",
-        "@olivierzal/melcloud-api": "49.2.0",
+        "@olivierzal/melcloud-api": "50.0.0",
         "source-map-support": "^0.5.21",
         "temporal-polyfill": "^1.0.1"
       },
@@ -1117,9 +1117,9 @@
       }
     },
     "node_modules/@olivierzal/melcloud-api": {
-      "version": "49.2.0",
-      "resolved": "https://npm.pkg.github.com/download/@olivierzal/melcloud-api/49.2.0/756eb84932e810313cc5127b71c2cb8f5d0ad2d4",
-      "integrity": "sha512-TJd0xyt5jY9Eo7BaYVk4RAN3/hYRifQWZ9ISA4YtJU0g1Qi+irOad4dmygrHdaVIcj8nXVVeWynj5Eje8iAXKg==",
+      "version": "50.0.0",
+      "resolved": "https://npm.pkg.github.com/download/@olivierzal/melcloud-api/50.0.0/6e20266cb7aa7c6e704031675f2221a2b74008ba",
+      "integrity": "sha512-+myXGLSwg6p4hQbpJVm/tqqVjEzLsRHhe2rIktWYC4bJM3od3YNasGWt7rlh2mSg9RElicBwxSayYVEmT0Wt6w==",
       "license": "MIT",
       "dependencies": {
         "temporal-polyfill": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.melcloud",
-  "version": "46.4.2",
+  "version": "46.5.0",
   "description": "MELCloud for Homey",
   "homepage": "https://github.com/OlivierZal/com.melcloud/",
   "bugs": {
@@ -33,7 +33,7 @@
   "prettier": "@olivierzal/configs/prettier",
   "dependencies": {
     "@olivierzal/homey-kit": "5.0.0",
-    "@olivierzal/melcloud-api": "49.2.0",
+    "@olivierzal/melcloud-api": "50.0.0",
     "source-map-support": "^0.5.21",
     "temporal-polyfill": "^1.0.1"
   },

--- a/settings/index.mts
+++ b/settings/index.mts
@@ -63,15 +63,7 @@ import {
   populateZoneOptions as populateZoneSelect,
   translateAriaLabels,
 } from '../public/dom.mts'
-import {
-  type PickerZone,
-  getHomeBuildingId,
-  getHomeDeviceId,
-  getZoneId,
-  getZonePath,
-  isHomeBuildingValue,
-  isHomeDeviceValue,
-} from '../public/zones.mts'
+import { type PickerZone, getZoneId } from '../public/zones.mts'
 
 // ── Helpers ──
 
@@ -367,31 +359,26 @@ const createValuesGate = (
       JSON.stringify(elements.map((element) => element.value)),
   })
 
-// Option values driving the Home-only overheat panel: `capable` lists
-// every Home ATA device plus each building owning one (the flat target
-// list puts a building right before its devices); `atwBuildings` lists
-// the buildings owning at least one ATW, so a capable building can show
-// the "(air-to-air)" scope qualifier when its bulk write skips ATW.
+// Option values driving the Home-only overheat panel, read off the
+// membership flags each served building node carries: `capable` lists
+// every Home ATA device plus each building owning one; `atwBuildings`
+// lists the buildings owning at least one ATW, so a capable building
+// can show the "(air-to-air)" scope qualifier when its bulk write
+// skips ATW.
 const collectOverheatZoneValues = (
   zones: readonly PickerZone[],
-): { atwBuildings: string[]; capable: string[] } => {
-  const atwBuildings: string[] = []
-  const capable: string[] = []
-  let buildingValue: string | null = null
-  for (const zone of zones) {
-    if (zone.model === 'homeBuildings') {
-      buildingValue = getZoneId(zone.id, zone.model)
-    } else if (zone.model === 'homeDevices' && zone.deviceType === 'ata') {
-      capable.push(
-        getZoneId(zone.id, zone.model),
-        ...(buildingValue === null ? [] : [buildingValue]),
-      )
-    } else if (buildingValue !== null && zone.model === 'homeDevices') {
-      atwBuildings.push(buildingValue)
-    }
-  }
-  return { atwBuildings, capable }
-}
+): { atwBuildings: string[]; capable: string[] } => ({
+  atwBuildings: zones
+    .filter((zone) => zone.model === 'homeBuildings' && zone.hasAtw)
+    .map((zone) => getZoneId(zone.id, zone.model)),
+  capable: zones
+    .filter(
+      (zone) =>
+        (zone.model === 'homeBuildings' && zone.hasAta) ||
+        (zone.model === 'homeDevices' && zone.deviceType === 'ata'),
+    )
+    .map((zone) => getZoneId(zone.id, zone.model)),
+})
 
 // Serialize a device-settings section's controls as a pure form snapshot for
 // its DirtyGate — the same value-only shape the frost/holiday gates use. A
@@ -1710,14 +1697,10 @@ class ZoneSettingsManager {
     }
   }
 
+  // The picker value IS the targetId of the neutral settings routes:
+  // addressing needs no family branch at all anymore.
   #getZoneSettingsBase(): string {
-    const { value } = this.#zone
-    if (isHomeBuildingValue(value)) {
-      return `/home/buildings/${getHomeBuildingId(value)}`
-    }
-    return isHomeDeviceValue(value)
-      ? `/home/devices/${getHomeDeviceId(value)}`
-      : `/classic/zones/${getZonePath(value)}`
+    return `/targets/${this.#zone.value}`
   }
 
   // PUT one zone-setting panel: refresh the cached zone mapping and

--- a/tests/unit/api.test.ts
+++ b/tests/unit/api.test.ts
@@ -3,9 +3,10 @@ import type * as Classic from '@olivierzal/melcloud-api/classic'
 import type * as Home from '@olivierzal/melcloud-api/home'
 import type { Homey } from 'homey/lib/Homey'
 import {
+  type HolidayModeState,
   type HolidayModeUpdate,
   type LoginCredentials,
-  type ProtectionUpdate,
+  type ProtectionState,
   AuthenticationError,
   AuthenticationThrottledError,
 } from '@olivierzal/melcloud-api'
@@ -16,11 +17,7 @@ import type {
   ErrorLogQueryParams,
   FormattedErrorLog,
 } from '../../types/error-log.mts'
-import type {
-  HomeBuildingZone,
-  HomeDeviceZone,
-  ZoneData,
-} from '../../types/zone.mts'
+import type { HomeBuildingZone, HomeDeviceZone } from '../../types/zone.mts'
 import { mock } from '../helpers.ts'
 
 const mockGetBuildings =
@@ -38,6 +35,7 @@ const { default: api } = await import('../../api.mts')
 
 const mockIsAuthenticated = vi.fn<() => boolean>()
 const mockIsHomeAuthenticated = vi.fn<() => boolean>()
+const mockEnsureClassicAuthenticated = vi.fn<() => Promise<boolean>>()
 const mockEnsureHomeAuthenticated = vi.fn<() => Promise<boolean>>()
 const mockGetHomeBuildings = vi.fn<Home.Registry['getBuildings']>()
 const mockClassicAuthenticate = vi.fn<() => Promise<void>>()
@@ -48,45 +46,19 @@ const mockHomeLogOut = vi.fn<() => void>()
 const mockApp = {
   classicApi: {
     authenticate: mockClassicAuthenticate,
+    ensureAuthenticated: mockEnsureClassicAuthenticated,
     isAuthenticated: mockIsAuthenticated,
     logOut: mockClassicLogOut,
   },
   error: vi.fn<(...args: readonly unknown[]) => void>(),
-  getClassicFrostProtection:
-    vi.fn<() => Promise<Classic.FrostProtectionData>>(),
-  getClassicHolidayMode: vi.fn<() => Promise<Classic.HolidayModeData>>(),
   getDeviceSettings: vi.fn<() => DeviceSettings>(),
   getDriverSettings: vi.fn<() => Partial<Record<string, DriverSetting[]>>>(),
   getErrorLog: vi.fn<() => Promise<FormattedErrorLog>>(),
-  getHomeBuildingFrostProtection:
-    vi.fn<
-      () => {
-        FPEnabled: boolean | null
-        FPMaxTemperature: number | null
-        FPMinTemperature: number | null
-      }
-    >(),
-  getHomeBuildingHolidayMode:
-    vi.fn<
-      () => {
-        HMEnabled: boolean | null
-        HMEndDate: string | null
-        HMStartDate: string | null
-      }
-    >(),
-  getHomeBuildingOverheatProtection:
-    vi.fn<
-      () => {
-        OHEnabled: boolean | null
-        OHMaxTemperature: number | null
-        OHMinTemperature: number | null
-      }
-    >(),
   getHomeDeviceZones: vi.fn<() => HomeDeviceZone[]>(),
-  getHomeFrostProtection: vi.fn<() => Home.FrostProtection | null>(),
-  getHomeHolidayMode: vi.fn<() => Home.HolidayMode | null>(),
-  getHomeOverheatProtection: vi.fn<() => Home.OverheatProtection | null>(),
   getHomeTargets: vi.fn<() => (HomeBuildingZone | HomeDeviceZone)[]>(),
+  getTargetFrostProtection: vi.fn<() => Promise<ProtectionState | null>>(),
+  getTargetHolidayMode: vi.fn<() => Promise<HolidayModeState | null>>(),
+  getTargetOverheatProtection: vi.fn<() => Promise<ProtectionState | null>>(),
   homeApi: {
     authenticate: mockHomeAuthenticate,
     ensureAuthenticated: mockEnsureHomeAuthenticated,
@@ -95,15 +67,10 @@ const mockApp = {
     registry: { getBuildings: mockGetHomeBuildings },
   },
   log: vi.fn<(...args: readonly unknown[]) => void>(),
-  updateClassicFrostProtection: vi.fn<() => Promise<void>>(),
-  updateClassicHolidayMode: vi.fn<() => Promise<void>>(),
   updateDeviceSettings: vi.fn<() => Promise<void>>(),
-  updateHomeBuildingFrostProtection: vi.fn<() => Promise<void>>(),
-  updateHomeBuildingHolidayMode: vi.fn<() => Promise<void>>(),
-  updateHomeBuildingOverheatProtection: vi.fn<() => Promise<void>>(),
-  updateHomeFrostProtection: vi.fn<() => Promise<void>>(),
-  updateHomeHolidayMode: vi.fn<() => Promise<void>>(),
-  updateHomeOverheatProtection: vi.fn<() => Promise<void>>(),
+  updateTargetFrostProtection: vi.fn<() => Promise<void>>(),
+  updateTargetHolidayMode: vi.fn<() => Promise<void>>(),
+  updateTargetOverheatProtection: vi.fn<() => Promise<void>>(),
 }
 
 const mockI18n = { getLanguage: vi.fn<() => string>() }
@@ -285,83 +252,12 @@ describe('api', () => {
     })
   })
 
-  describe('frost protection settings retrieval', () => {
-    it('should delegate to app.getClassicFrostProtection with params', async () => {
-      const frostProtection = mock<Classic.FrostProtectionData>()
-      const params = mock<ZoneData>({ zoneId: '1', zoneType: 'buildings' })
-      mockApp.getClassicFrostProtection.mockResolvedValue(frostProtection)
-
-      const result = await api.getClassicFrostProtection({ homey, params })
-
-      expect(result).toBe(frostProtection)
-      expect(mockApp.getClassicFrostProtection).toHaveBeenCalledWith(params)
-    })
-  })
-
-  describe('holiday mode settings retrieval', () => {
-    it('should delegate to app.getClassicHolidayMode with params', async () => {
-      const holidayMode = mock<Classic.HolidayModeData>()
-      const params = mock<ZoneData>({ zoneId: '1', zoneType: 'buildings' })
-      mockApp.getClassicHolidayMode.mockResolvedValue(holidayMode)
-
-      const result = await api.getClassicHolidayMode({ homey, params })
-
-      expect(result).toBe(holidayMode)
-      expect(mockApp.getClassicHolidayMode).toHaveBeenCalledWith(params)
-    })
-  })
-
   describe('home devices retrieval', () => {
     it('should delegate to app.getHomeDeviceZones', () => {
       const devices = [mock<HomeDeviceZone>({ id: 'guid-1' })]
       mockApp.getHomeDeviceZones.mockReturnValue(devices)
 
       expect(api.getHomeDevices({ homey })).toBe(devices)
-    })
-  })
-
-  describe('home frost protection settings retrieval', () => {
-    it('should delegate to app.getHomeFrostProtection with the device id', () => {
-      const frostProtection = mock<Home.FrostProtection>()
-      mockApp.getHomeFrostProtection.mockReturnValue(frostProtection)
-
-      const result = api.getHomeFrostProtection({
-        homey,
-        params: { deviceId: 'guid-1' },
-      })
-
-      expect(result).toBe(frostProtection)
-      expect(mockApp.getHomeFrostProtection).toHaveBeenCalledWith('guid-1')
-    })
-  })
-
-  describe('home overheat protection settings retrieval', () => {
-    it('should delegate to app.getHomeOverheatProtection with the device id', () => {
-      const overheatProtection = mock<Home.OverheatProtection>()
-      mockApp.getHomeOverheatProtection.mockReturnValue(overheatProtection)
-
-      const result = api.getHomeOverheatProtection({
-        homey,
-        params: { deviceId: 'guid-1' },
-      })
-
-      expect(result).toBe(overheatProtection)
-      expect(mockApp.getHomeOverheatProtection).toHaveBeenCalledWith('guid-1')
-    })
-  })
-
-  describe('home holiday mode settings retrieval', () => {
-    it('should delegate to app.getHomeHolidayMode with the device id', () => {
-      const holidayMode = mock<Home.HolidayMode>()
-      mockApp.getHomeHolidayMode.mockReturnValue(holidayMode)
-
-      const result = api.getHomeHolidayMode({
-        homey,
-        params: { deviceId: 'guid-1' },
-      })
-
-      expect(result).toBe(holidayMode)
-      expect(mockApp.getHomeHolidayMode).toHaveBeenCalledWith('guid-1')
     })
   })
 
@@ -374,92 +270,50 @@ describe('api', () => {
     })
   })
 
-  describe('home building frost protection retrieval', () => {
-    it('should delegate to app.getHomeBuildingFrostProtection with the id', () => {
-      const aggregate = {
-        FPEnabled: true,
-        FPMaxTemperature: null,
-        FPMinTemperature: 6,
-      }
-      mockApp.getHomeBuildingFrostProtection.mockReturnValue(aggregate)
+  describe('target settings retrieval', () => {
+    it.each([
+      'getTargetFrostProtection',
+      'getTargetHolidayMode',
+      'getTargetOverheatProtection',
+    ] as const)('delegates %s with the raw targetId', async (handler) => {
+      const value = mock<HolidayModeState & ProtectionState>()
+      mockApp[handler].mockResolvedValue(value)
 
-      const result = api.getHomeBuildingFrostProtection({
+      const result = await api[handler]({
         homey,
-        params: { buildingId: 'b1' },
+        params: { targetId: 'homeDevices_guid-1' },
       })
 
-      expect(result).toBe(aggregate)
-      expect(mockApp.getHomeBuildingFrostProtection).toHaveBeenCalledWith('b1')
+      expect(result).toBe(value)
+      expect(mockApp[handler]).toHaveBeenCalledWith('homeDevices_guid-1')
     })
   })
 
-  describe('home building overheat protection retrieval', () => {
-    it('should delegate to app.getHomeBuildingOverheatProtection with the id', () => {
-      const aggregate = {
-        OHEnabled: true,
-        OHMaxTemperature: null,
-        OHMinTemperature: 35,
-      }
-      mockApp.getHomeBuildingOverheatProtection.mockReturnValue(aggregate)
-
-      const result = api.getHomeBuildingOverheatProtection({
-        homey,
-        params: { buildingId: 'b1' },
-      })
-
-      expect(result).toBe(aggregate)
-      expect(mockApp.getHomeBuildingOverheatProtection).toHaveBeenCalledWith(
-        'b1',
-      )
-    })
-  })
-
-  describe('home building holiday mode retrieval', () => {
-    it('should delegate to app.getHomeBuildingHolidayMode with the id', () => {
-      const aggregate = { HMEnabled: null, HMEndDate: 'e', HMStartDate: null }
-      mockApp.getHomeBuildingHolidayMode.mockReturnValue(aggregate)
-
-      const result = api.getHomeBuildingHolidayMode({
-        homey,
-        params: { buildingId: 'b1' },
-      })
-
-      expect(result).toBe(aggregate)
-      expect(mockApp.getHomeBuildingHolidayMode).toHaveBeenCalledWith('b1')
-    })
-  })
-
-  describe('home building frost protection update', () => {
-    it('should delegate to app.updateHomeBuildingFrostProtection', async () => {
+  describe('target settings update', () => {
+    it.each([
+      'updateTargetFrostProtection',
+      'updateTargetOverheatProtection',
+    ] as const)('delegates %s with targetId and body', async (handler) => {
       const body = { isEnabled: true, max: 16, min: 4 }
-      mockApp.updateHomeBuildingFrostProtection.mockResolvedValue()
+      mockApp[handler].mockResolvedValue()
 
-      await api.updateHomeBuildingFrostProtection({
-        body,
-        homey,
-        params: { buildingId: 'b1' },
-      })
+      await api[handler]({ body, homey, params: { targetId: 'buildings_1' } })
 
-      expect(mockApp.updateHomeBuildingFrostProtection).toHaveBeenCalledWith(
-        'b1',
-        body,
-      )
+      expect(mockApp[handler]).toHaveBeenCalledWith('buildings_1', body)
     })
-  })
 
-  describe('home building holiday mode update', () => {
-    it('should delegate to app.updateHomeBuildingHolidayMode', async () => {
+    it('delegates updateTargetHolidayMode with targetId and body', async () => {
       const body = mock<HolidayModeUpdate>()
-      mockApp.updateHomeBuildingHolidayMode.mockResolvedValue()
+      mockApp.updateTargetHolidayMode.mockResolvedValue()
 
-      await api.updateHomeBuildingHolidayMode({
+      await api.updateTargetHolidayMode({
         body,
         homey,
-        params: { buildingId: 'b1' },
+        params: { targetId: 'homeBuildings_b1' },
       })
 
-      expect(mockApp.updateHomeBuildingHolidayMode).toHaveBeenCalledWith(
-        'b1',
+      expect(mockApp.updateTargetHolidayMode).toHaveBeenCalledWith(
+        'homeBuildings_b1',
         body,
       )
     })
@@ -557,21 +411,17 @@ describe('api', () => {
   })
 
   describe('classic session retrieval', () => {
-    it('should delegate to app.classicApi.isAuthenticated', () => {
-      mockIsAuthenticated.mockReturnValue(true)
+    it('should delegate to app.classicApi.ensureAuthenticated', async () => {
+      mockEnsureClassicAuthenticated.mockResolvedValue(true)
 
-      const isAuthenticated = api.isClassicAuthenticated({ homey })
-
-      expect(isAuthenticated).toBe(true)
-      expect(mockIsAuthenticated).toHaveBeenCalledTimes(1)
+      await expect(api.isClassicAuthenticated({ homey })).resolves.toBe(true)
+      expect(mockEnsureClassicAuthenticated).toHaveBeenCalledTimes(1)
     })
 
-    it('should return false when not authenticated', () => {
-      mockIsAuthenticated.mockReturnValue(false)
+    it('should return false when not authenticated', async () => {
+      mockEnsureClassicAuthenticated.mockResolvedValue(false)
 
-      const isAuthenticated = api.isClassicAuthenticated({ homey })
-
-      expect(isAuthenticated).toBe(false)
+      await expect(api.isClassicAuthenticated({ homey })).resolves.toBe(false)
     })
   })
 
@@ -644,106 +494,6 @@ describe('api', () => {
         driverId: undefined,
         settings: body,
       })
-    })
-  })
-
-  describe('frost protection settings update', () => {
-    it('should delegate to app.updateClassicFrostProtection', async () => {
-      const body = mock<ProtectionUpdate>()
-      const params = mock<ZoneData>({ zoneId: '1', zoneType: 'buildings' })
-      mockApp.updateClassicFrostProtection.mockResolvedValue()
-
-      await api.updateClassicFrostProtection({ body, homey, params })
-
-      expect(mockApp.updateClassicFrostProtection).toHaveBeenCalledWith({
-        settings: body,
-        ...params,
-      })
-    })
-  })
-
-  describe('holiday mode settings update', () => {
-    it('should delegate to app.updateClassicHolidayMode', async () => {
-      const body = mock<HolidayModeUpdate>()
-      const params = mock<ZoneData>({ zoneId: '1', zoneType: 'buildings' })
-      mockApp.updateClassicHolidayMode.mockResolvedValue()
-
-      await api.updateClassicHolidayMode({ body, homey, params })
-
-      expect(mockApp.updateClassicHolidayMode).toHaveBeenCalledWith({
-        settings: body,
-        ...params,
-      })
-    })
-  })
-
-  describe('home frost protection settings update', () => {
-    it('should delegate to app.updateHomeFrostProtection for the device', async () => {
-      const body = { isEnabled: true, max: 16, min: 4 }
-      mockApp.updateHomeFrostProtection.mockResolvedValue()
-
-      await api.updateHomeFrostProtection({
-        body,
-        homey,
-        params: { deviceId: 'guid-1' },
-      })
-
-      expect(mockApp.updateHomeFrostProtection).toHaveBeenCalledWith(
-        ['guid-1'],
-        body,
-      )
-    })
-  })
-
-  describe('home overheat protection settings update', () => {
-    it('should delegate to app.updateHomeOverheatProtection for the device', async () => {
-      const body = { isEnabled: true, max: 37, min: 35 }
-      mockApp.updateHomeOverheatProtection.mockResolvedValue()
-
-      await api.updateHomeOverheatProtection({
-        body,
-        homey,
-        params: { deviceId: 'guid-1' },
-      })
-
-      expect(mockApp.updateHomeOverheatProtection).toHaveBeenCalledWith(
-        ['guid-1'],
-        body,
-      )
-    })
-
-    it('should delegate to app.updateHomeBuildingOverheatProtection for the building', async () => {
-      const body = { isEnabled: false, max: 37, min: 35 }
-      mockApp.updateHomeBuildingOverheatProtection.mockResolvedValue()
-
-      await api.updateHomeBuildingOverheatProtection({
-        body,
-        homey,
-        params: { buildingId: 'b1' },
-      })
-
-      expect(mockApp.updateHomeBuildingOverheatProtection).toHaveBeenCalledWith(
-        'b1',
-        body,
-      )
-    })
-  })
-
-  describe('home holiday mode settings update', () => {
-    it('should delegate to app.updateHomeHolidayMode for the device', async () => {
-      const body = mock<HolidayModeUpdate>()
-      mockApp.updateHomeHolidayMode.mockResolvedValue()
-
-      await api.updateHomeHolidayMode({
-        body,
-        homey,
-        params: { deviceId: 'guid-1' },
-      })
-
-      expect(mockApp.updateHomeHolidayMode).toHaveBeenCalledWith(
-        ['guid-1'],
-        body,
-      )
     })
   })
 

--- a/tests/unit/app.test.ts
+++ b/tests/unit/app.test.ts
@@ -2,7 +2,6 @@ import {
   type HolidayModeState,
   type HolidayModeUpdate,
   type LoginCredentials,
-  type ProtectionState,
   type ProtectionUpdate,
   type ReportChartLineOptions,
   type ReportChartPieOptions,
@@ -546,41 +545,6 @@ const stubHomeDevice = (facade: unknown): void => {
     isAtw: (): boolean => false,
   })
   mockHomeFacadeManagerGet.mockReturnValue(facade)
-}
-
-// Two ATA devices in building 'b1', each with its own frost/holiday, so the
-// building aggregate can be exercised across agreement and disagreement.
-const stubBuilding = (
-  frostById: Record<string, unknown>,
-  holidayById: Record<string, unknown> = {},
-  overheatById: Record<string, unknown> = {},
-): void => {
-  const devices = [
-    {
-      building: { id: 'b1' },
-      id: 'd1',
-      isAta: (): boolean => true,
-      isAtw: (): boolean => false,
-    },
-    {
-      building: { id: 'b1' },
-      id: 'd2',
-      isAta: (): boolean => true,
-      isAtw: (): boolean => false,
-    },
-  ]
-  mockHomeRegistry.getDevices.mockReturnValue(devices)
-  mockHomeRegistry.getById.mockImplementation((id) =>
-    devices.find((device) => device.id === id),
-  )
-  mockHomeFacadeManagerGet.mockImplementation((model) => ({
-    frostProtection: frostById[(model as { id: string }).id] ?? null,
-    holidayMode: holidayById[(model as { id: string }).id] ?? null,
-    overheatProtection: overheatById[(model as { id: string }).id] ?? null,
-    // The facade guards read the discriminator the wave added, so the
-    // stub carries it instead of relying on structural sniffing.
-    type: Home.DeviceType.Ata,
-  }))
 }
 
 const getSyncCallbackFrom = (
@@ -1322,10 +1286,10 @@ describe('melCloudApp', () => {
 
     const stubHomeAtaDevice = (
       entries: {
-        clearedTimestamp: string | null
-        errorCode: string
-        errorReason: string | null
-        timestamp: string
+        at: string
+        deviceId: string
+        code?: string
+        message?: string
       }[],
     ): void => {
       mockHomeRegistry.getDevicesByType.mockImplementation((type) =>
@@ -1346,8 +1310,8 @@ describe('melCloudApp', () => {
     it('should merge Home errors chronologically into the Classic window', async () => {
       mockApiInstance.getErrorLog.mockResolvedValue(
         ok({
-          errors: [
-            { date: '2026-03-28T14:30:00.000Z', deviceId: 42, error: 'test' },
+          entries: [
+            { at: '2026-03-28T14:30:00.000Z', deviceId: 42, message: 'test' },
           ],
           fromDate: '2026-03-01',
           nextFromDate: '2026-03-15',
@@ -1359,22 +1323,17 @@ describe('melCloudApp', () => {
       })
       stubHomeAtaDevice([
         {
-          clearedTimestamp: null,
-          errorCode: 'E101',
-          errorReason: 'Sensor failure',
-          timestamp: '2026-03-20T10:00:00Z',
+          at: '2026-03-20T10:00:00Z',
+          code: 'E101',
+          deviceId: 'guid-1',
+          message: 'Sensor failure',
         },
+        { at: '2026-03-25T08:00:00Z', code: 'E202', deviceId: 'guid-1' },
         {
-          clearedTimestamp: null,
-          errorCode: 'E202',
-          errorReason: null,
-          timestamp: '2026-03-25T08:00:00Z',
-        },
-        {
-          clearedTimestamp: null,
-          errorCode: 'E303',
-          errorReason: 'Too old',
-          timestamp: '2026-02-15T10:00:00Z',
+          at: '2026-02-15T10:00:00Z',
+          code: 'E303',
+          deviceId: 'guid-1',
+          message: 'Too old',
         },
       ])
       await app.onInit()
@@ -1389,16 +1348,33 @@ describe('melCloudApp', () => {
       expect(errorLog.errors[1]?.device).toBe('Studeerkamer')
     })
 
+    it('renders an empty text for a Home entry with neither message nor code', async () => {
+      mockApiInstance.getErrorLog.mockResolvedValue(
+        ok({
+          entries: [],
+          fromDate: '2026-03-01',
+          nextFromDate: '2026-03-15',
+          nextToDate: '2026-03-31',
+        }),
+      )
+      stubHomeAtaDevice([{ at: '2026-03-20T10:00:00Z', deviceId: 'guid-1' }])
+      await app.onInit()
+
+      const errorLog = await app.getErrorLog(mock<Classic.ErrorLogQuery>())
+
+      expect(errorLog.errors[0]?.error).toBe('')
+    })
+
     it('should show an em dash for sentinel dates and sink them last', async () => {
       mockApiInstance.getErrorLog.mockResolvedValue(
         ok({
-          errors: [
+          entries: [
             {
-              date: '0001-01-01T00:09:00',
+              at: '0001-01-01T00:09:00',
               deviceId: 42,
-              error: 'Unknown Error',
+              message: 'Unknown Error',
             },
-            { date: '2026-03-28T14:30:00.000Z', deviceId: 42, error: 'test' },
+            { at: '2026-03-28T14:30:00.000Z', deviceId: 42, message: 'test' },
           ],
           fromDate: '2026-03-01',
           nextFromDate: '2026-03-15',
@@ -1420,8 +1396,8 @@ describe('melCloudApp', () => {
     it('should keep the log when a Home device fails to answer', async () => {
       mockApiInstance.getErrorLog.mockResolvedValue(
         ok({
-          errors: [
-            { date: '2026-03-28T14:30:00.000Z', deviceId: 42, error: 'test' },
+          entries: [
+            { at: '2026-03-28T14:30:00.000Z', deviceId: 42, message: 'test' },
           ],
           fromDate: '2026-03-01',
           nextFromDate: '2026-03-15',
@@ -1465,10 +1441,10 @@ describe('melCloudApp', () => {
       mockApiInstance.isAuthenticated.mockReturnValue(false)
       stubHomeAtaDevice([
         {
-          clearedTimestamp: null,
-          errorCode: 'E101',
-          errorReason: 'Sensor failure',
-          timestamp: '2026-03-15T10:00:00Z',
+          at: '2026-03-15T10:00:00Z',
+          code: 'E101',
+          deviceId: 'guid-1',
+          message: 'Sensor failure',
         },
       ])
       await app.onInit()
@@ -1502,10 +1478,10 @@ describe('melCloudApp', () => {
       mockApiInstance.isAuthenticated.mockReturnValue(false)
       stubHomeAtaDevice([
         {
-          clearedTimestamp: null,
-          errorCode: 'E101',
-          errorReason: 'Sensor failure',
-          timestamp: '2026-01-05T10:00:00Z',
+          at: '2026-01-05T10:00:00Z',
+          code: 'E101',
+          deviceId: 'guid-1',
+          message: 'Sensor failure',
         },
       ])
       await app.onInit()
@@ -1530,8 +1506,8 @@ describe('melCloudApp', () => {
       const deviceName = 'Living Room'
       mockApiInstance.getErrorLog.mockResolvedValue(
         ok({
-          errors: [
-            { date: '2026-03-28T14:30:00.000Z', deviceId: 42, error: 'test' },
+          entries: [
+            { at: '2026-03-28T14:30:00.000Z', deviceId: 42, message: 'test' },
           ],
           fromDate: '2026-03-01',
           nextFromDate: '2026-03-15',
@@ -1564,8 +1540,8 @@ describe('melCloudApp', () => {
     it('should fall back to empty device name when device is not in registry', async () => {
       mockApiInstance.getErrorLog.mockResolvedValue(
         ok({
-          errors: [
-            { date: '2026-03-28T14:30:00', deviceId: 999, error: 'test' },
+          entries: [
+            { at: '2026-03-28T14:30:00', deviceId: 999, message: 'test' },
           ],
           fromDate: '2026-03-01',
           nextFromDate: '2026-03-15',
@@ -1849,7 +1825,7 @@ describe('melCloudApp', () => {
 
     it('should return the building group state', async () => {
       mockHomeFacadeManagerGetBuilding.mockReturnValue(
-        mock<Home.BuildingAtaFacade>({
+        mock<Home.BuildingFacade>({
           getGroup: vi
             .fn<() => Promise<unknown>>()
             .mockResolvedValue({ ok: true, value: groupState }),
@@ -1870,9 +1846,7 @@ describe('melCloudApp', () => {
         .fn<(state: unknown) => Promise<unknown>>()
         .mockResolvedValue({ AttributeErrors: null, Success: true })
       mockHomeFacadeManagerGetBuilding.mockReturnValue(
-        mock<Home.BuildingAtaFacade>({
-          updateGroupState: mockUpdateGroupState,
-        }),
+        mock<Home.BuildingFacade>({ updateGroupState: mockUpdateGroupState }),
       )
       await app.onInit()
 
@@ -1885,9 +1859,9 @@ describe('melCloudApp', () => {
     })
 
     it('should list the member modes in the classic vocabulary', async () => {
-      const member = { id: 'device-1' }
+      const member = { id: 'device-1', isAta: (): boolean => true }
       mockHomeFacadeManagerGetBuilding.mockReturnValue(
-        mock<Home.BuildingAtaFacade>({ devices: [member] }),
+        mock<Home.BuildingFacade>({ devices: [member] }),
       )
       mockHomeFacadeManagerGet.mockReturnValue(
         mock<Home.DeviceAtaFacade>({ operationMode: 'Heat' }),
@@ -1920,10 +1894,7 @@ describe('melCloudApp', () => {
       })
       await initWithFacade(app, mockFacade)
 
-      const frostProtection = await app.getClassicFrostProtection({
-        zoneId: '1',
-        zoneType: 'buildings',
-      })
+      const frostProtection = await app.getTargetFrostProtection('buildings_1')
 
       expect(frostProtection).toBe(mockData)
     })
@@ -1939,10 +1910,7 @@ describe('melCloudApp', () => {
       })
       await initWithFacade(app, mockFacade)
 
-      const holidayMode = await app.getClassicHolidayMode({
-        zoneId: '1',
-        zoneType: 'buildings',
-      })
+      const holidayMode = await app.getTargetHolidayMode('buildings_1')
 
       expect(holidayMode).toBe(mockData)
     })
@@ -2571,11 +2539,10 @@ describe('melCloudApp', () => {
       )
 
       await expect(
-        app.updateClassicFrostProtection({
-          settings: mock<ProtectionUpdate>(),
-          zoneId: '1',
-          zoneType: 'buildings',
-        }),
+        app.updateTargetFrostProtection(
+          'buildings_1',
+          mock<ProtectionUpdate>(),
+        ),
       ).resolves.toBeUndefined()
     })
 
@@ -2588,11 +2555,10 @@ describe('melCloudApp', () => {
       )
 
       await expect(
-        app.updateClassicFrostProtection({
-          settings: mock<ProtectionUpdate>(),
-          zoneId: '1',
-          zoneType: 'buildings',
-        }),
+        app.updateTargetFrostProtection(
+          'buildings_1',
+          mock<ProtectionUpdate>(),
+        ),
       ).rejects.toThrow('min: Too low')
     })
   })
@@ -2605,11 +2571,7 @@ describe('melCloudApp', () => {
       )
 
       await expect(
-        app.updateClassicHolidayMode({
-          settings: mock<HolidayModeUpdate>(),
-          zoneId: '1',
-          zoneType: 'buildings',
-        }),
+        app.updateTargetHolidayMode('buildings_1', mock<HolidayModeUpdate>()),
       ).resolves.toBeUndefined()
     })
 
@@ -2623,10 +2585,9 @@ describe('melCloudApp', () => {
         Temporal.PlainDateTime.from('2026-08-18T09:30:00'),
       )
       try {
-        await app.updateClassicHolidayMode({
-          settings: { endDate: '2026-08-25T12:00', isEnabled: true },
-          zoneId: '1',
-          zoneType: 'buildings',
+        await app.updateTargetHolidayMode('buildings_1', {
+          endDate: '2026-08-25T12:00',
+          isEnabled: true,
         })
       } finally {
         vi.mocked(Temporal.Now.plainDateTimeISO).mockRestore()
@@ -2646,11 +2607,7 @@ describe('melCloudApp', () => {
       await initWithFacade(app, mockFacade)
 
       await expect(
-        app.updateClassicHolidayMode({
-          settings: mock<HolidayModeUpdate>(),
-          zoneId: '1',
-          zoneType: 'buildings',
-        }),
+        app.updateTargetHolidayMode('buildings_1', mock<HolidayModeUpdate>()),
       ).rejects.toThrow('date: Invalid date')
     })
   })
@@ -2819,20 +2776,20 @@ describe('melCloudApp', () => {
         )
         try {
           await app.onInit()
-          stubHomeDevice({})
+          const updateHolidayMode = vi
+            .fn<() => Promise<void>>()
+            .mockResolvedValue()
+          stubHomeDevice({ updateHolidayMode })
 
           await getActionRunListener()({ duration: 3, zone: homeHolidayZone })
 
           // Start = now (matching the Classic path's omitted `from`), end =
-          // midnight 3 days out; the single device is sent as a one-item set.
-          expect(mockHomeFacadeManagerUpdateHolidayMode).toHaveBeenCalledWith(
-            ['guid-1'],
-            {
-              endDate: '2026-07-22T00:00:00',
-              isEnabled: true,
-              startDate: '2026-07-19T08:30:00',
-            },
-          )
+          // midnight 3 days out; the device facade writes its own unit.
+          expect(updateHolidayMode).toHaveBeenCalledWith({
+            endDate: '2026-07-22T00:00:00',
+            isEnabled: true,
+            startDate: '2026-07-19T08:30:00',
+          })
         } finally {
           vi.mocked(Temporal.Now.plainDateTimeISO).mockRestore()
         }
@@ -2844,22 +2801,25 @@ describe('melCloudApp', () => {
         )
         try {
           await app.onInit()
-          stubBuilding({})
+          const updateHolidayMode = vi
+            .fn<() => Promise<void>>()
+            .mockResolvedValue()
+          mockHomeFacadeManagerGetBuilding.mockReturnValue({
+            updateHolidayMode,
+          })
 
           await getActionRunListener()({
             duration: 3,
             zone: { id: 'homeBuildings_b1' },
           })
 
-          // A whole Home building fans the one window out over every device.
-          expect(mockHomeFacadeManagerUpdateHolidayMode).toHaveBeenCalledWith(
-            ['d1', 'd2'],
-            {
-              endDate: '2026-07-22T00:00:00',
-              isEnabled: true,
-              startDate: '2026-07-19T08:30:00',
-            },
-          )
+          // A whole Home building batches the one window over its members
+          // — the fan-out lives in the library's building facade.
+          expect(updateHolidayMode).toHaveBeenCalledWith({
+            endDate: '2026-07-22T00:00:00',
+            isEnabled: true,
+            startDate: '2026-07-19T08:30:00',
+          })
         } finally {
           vi.mocked(Temporal.Now.plainDateTimeISO).mockRestore()
         }
@@ -3056,18 +3016,18 @@ describe('melCloudApp', () => {
         )
         try {
           await app.onInit()
-          stubHomeDevice({})
+          const updateHolidayMode = vi
+            .fn<() => Promise<void>>()
+            .mockResolvedValue()
+          stubHomeDevice({ updateHolidayMode })
 
           await getFalseRunListener()({ zone: homeHolidayZone })
 
-          expect(mockHomeFacadeManagerUpdateHolidayMode).toHaveBeenCalledWith(
-            ['guid-1'],
-            {
-              endDate: '2026-07-19T08:30:00',
-              isEnabled: false,
-              startDate: '2026-07-19T08:30:00',
-            },
-          )
+          expect(updateHolidayMode).toHaveBeenCalledWith({
+            endDate: '2026-07-19T08:30:00',
+            isEnabled: false,
+            startDate: '2026-07-19T08:30:00',
+          })
         } finally {
           vi.mocked(Temporal.Now.plainDateTimeISO).mockRestore()
         }
@@ -3101,7 +3061,11 @@ describe('melCloudApp', () => {
         'should mirror a Home device holiday state ($shouldBeOn)',
         async ({ holidayMode, shouldBeOn }) => {
           await app.onInit()
-          stubHomeDevice({ holidayMode })
+          stubHomeDevice({
+            getHolidayMode: vi
+              .fn<() => Promise<unknown>>()
+              .mockResolvedValue(ok(holidayMode)),
+          })
 
           const run = getMockCallArg<
             (args: { zone: TestHolidayZone }) => Promise<boolean>
@@ -3112,20 +3076,24 @@ describe('melCloudApp', () => {
       )
 
       it.each([
-        {
-          holidayById: { d1: { isEnabled: true }, d2: { isEnabled: true } },
-          shouldBeOn: true,
-        },
+        { isAggregateEnabled: true, shouldBeOn: true },
         // Devices disagree: the building aggregate is "mixed", read as off.
-        {
-          holidayById: { d1: { isEnabled: true }, d2: { isEnabled: false } },
-          shouldBeOn: false,
-        },
+        { isAggregateEnabled: null, shouldBeOn: false },
       ])(
         'should mirror a Home building holiday state ($shouldBeOn)',
-        async ({ holidayById, shouldBeOn }) => {
+        async ({ isAggregateEnabled, shouldBeOn }) => {
           await app.onInit()
-          stubBuilding({}, holidayById)
+          mockHomeFacadeManagerGetBuilding.mockReturnValue({
+            getHolidayMode: vi
+              .fn<() => Promise<unknown>>()
+              .mockResolvedValue(
+                ok({
+                  endDate: null,
+                  isEnabled: isAggregateEnabled,
+                  startDate: null,
+                }),
+              ),
+          })
 
           const run = getMockCallArg<
             (args: { zone: TestHolidayZone }) => Promise<boolean>
@@ -3139,229 +3107,142 @@ describe('melCloudApp', () => {
     })
   })
 
-  describe('home frost protection', () => {
-    it('should read a Home device frost protection off the facade', async () => {
+  describe('home target settings', () => {
+    it('reads a Home device frost protection through the target route', async () => {
       await app.onInit()
-      const frostProtection = mock<Home.FrostProtection>({ active: true })
-      stubHomeDevice({ frostProtection })
+      const state = { isEnabled: true, max: 12, min: 6 }
+      stubHomeDevice({
+        getFrostProtection: vi
+          .fn<() => Promise<unknown>>()
+          .mockResolvedValue(ok(state)),
+      })
 
-      expect(app.getHomeFrostProtection('guid-1')).toBe(frostProtection)
+      await expect(
+        app.getTargetFrostProtection('homeDevices_guid-1'),
+      ).resolves.toBe(state)
     })
 
-    it('should batch a frost protection update across the given devices', async () => {
+    it('writes a Home device frost protection through its facade', async () => {
       await app.onInit()
+      const updateFrostProtection = vi
+        .fn<() => Promise<void>>()
+        .mockResolvedValue()
+      stubHomeDevice({ updateFrostProtection })
 
-      await app.updateHomeFrostProtection(['guid-1', 'guid-2'], {
+      await app.updateTargetFrostProtection('homeDevices_guid-1', {
         isEnabled: true,
         max: 16,
         min: 4,
       })
 
-      expect(mockHomeFacadeManagerUpdateFrostProtection).toHaveBeenCalledWith(
-        ['guid-1', 'guid-2'],
-        { isEnabled: true, max: 16, min: 4 },
-      )
-    })
-  })
-
-  describe('home overheat protection', () => {
-    it('should read a Home ATA device overheat protection off the facade', async () => {
-      await app.onInit()
-      const overheatProtection = mock<ProtectionState>({ isEnabled: true })
-      stubHomeDevice({ overheatProtection, type: Home.DeviceType.Ata })
-
-      expect(app.getHomeOverheatProtection('guid-1')).toBe(overheatProtection)
-    })
-
-    it('should read null for an ATW facade, which never carries it', async () => {
-      await app.onInit()
-      stubHomeDevice({ frostProtection: null, type: Home.DeviceType.Atw })
-
-      expect(app.getHomeOverheatProtection('guid-1')).toBeNull()
-    })
-
-    it('should batch an overheat protection update across the given devices', async () => {
-      await app.onInit()
-
-      await app.updateHomeOverheatProtection(['guid-1', 'guid-2'], {
-        isEnabled: true,
-        max: 37,
-        min: 35,
-      })
-
-      expect(
-        mockHomeFacadeManagerUpdateOverheatProtection,
-      ).toHaveBeenCalledWith(['guid-1', 'guid-2'], {
-        isEnabled: true,
-        max: 37,
-        min: 35,
-      })
-    })
-  })
-
-  describe('home building frost protection and holiday mode', () => {
-    it('keeps shared frost values and nulls the disagreements', async () => {
-      await app.onInit()
-      stubBuilding({
-        d1: { isEnabled: true, max: 12, min: 6 },
-        d2: { isEnabled: true, max: 14, min: 6 },
-      })
-
-      expect(app.getHomeBuildingFrostProtection('b1')).toStrictEqual({
-        isEnabled: true,
-        max: null,
-        min: 6,
-      })
-    })
-
-    it('reads an all-unconfigured building as off, not mixed', async () => {
-      await app.onInit()
-      stubBuilding({})
-
-      expect(app.getHomeBuildingFrostProtection('b1')).toStrictEqual({
-        isEnabled: false,
-        max: null,
-        min: null,
-      })
-    })
-
-    it('aggregates holiday mode across the building devices', async () => {
-      await app.onInit()
-      stubBuilding(
-        {},
-        {
-          d1: { endDate: 'e', isEnabled: true, startDate: 's' },
-          d2: { endDate: 'e', isEnabled: true, startDate: 'x' },
-        },
-      )
-
-      expect(app.getHomeBuildingHolidayMode('b1')).toStrictEqual({
-        endDate: 'e',
-        isEnabled: true,
-        startDate: null,
-      })
-    })
-
-    it('reads an all-unconfigured holiday building as off', async () => {
-      await app.onInit()
-      stubBuilding({}, {})
-
-      expect(app.getHomeBuildingHolidayMode('b1')).toStrictEqual({
-        endDate: null,
-        isEnabled: false,
-        startDate: null,
-      })
-    })
-
-    it('keeps shared overheat values and nulls the disagreements', async () => {
-      await app.onInit()
-      stubBuilding(
-        {},
-        {},
-        {
-          d1: { isEnabled: true, max: 37, min: 35 },
-          d2: { isEnabled: true, max: 38, min: 35 },
-        },
-      )
-
-      expect(app.getHomeBuildingOverheatProtection('b1')).toStrictEqual({
-        isEnabled: true,
-        max: null,
-        min: 35,
-      })
-    })
-
-    it('reads an all-unconfigured overheat building as off, not mixed', async () => {
-      await app.onInit()
-      stubBuilding({}, {}, {})
-
-      expect(app.getHomeBuildingOverheatProtection('b1')).toStrictEqual({
-        isEnabled: false,
-        max: null,
-        min: null,
-      })
-    })
-
-    it('aggregates overheat over the ATA devices only', async () => {
-      await app.onInit()
-      stubBuilding({}, {}, { d1: { isEnabled: true, max: 37, min: 35 } })
-      // Turn d2 into an ATW device: it must not drag the aggregate to
-      // "mixed" — the feature is ATA-only.
-      const devices = [
-        {
-          building: { id: 'b1' },
-          id: 'd1',
-          isAta: (): boolean => true,
-          isAtw: (): boolean => false,
-        },
-        {
-          building: { id: 'b1' },
-          id: 'd2',
-          isAta: (): boolean => false,
-          isAtw: (): boolean => true,
-        },
-      ]
-      mockHomeRegistry.getDevices.mockReturnValue(devices)
-      mockHomeRegistry.getById.mockImplementation((id) =>
-        devices.find((device) => device.id === id),
-      )
-
-      expect(app.getHomeBuildingOverheatProtection('b1')).toStrictEqual({
-        isEnabled: true,
-        max: 37,
-        min: 35,
-      })
-    })
-
-    it('batches a building overheat update across all its devices', async () => {
-      await app.onInit()
-      stubBuilding({})
-
-      await app.updateHomeBuildingOverheatProtection('b1', {
-        isEnabled: false,
-        max: 37,
-        min: 35,
-      })
-
-      expect(
-        mockHomeFacadeManagerUpdateOverheatProtection,
-      ).toHaveBeenCalledWith(['d1', 'd2'], {
-        isEnabled: false,
-        max: 37,
-        min: 35,
-      })
-    })
-
-    it('batches a building frost update across all its devices', async () => {
-      await app.onInit()
-      stubBuilding({})
-
-      await app.updateHomeBuildingFrostProtection('b1', {
+      expect(updateFrostProtection).toHaveBeenCalledWith({
         isEnabled: true,
         max: 16,
         min: 4,
       })
-
-      expect(mockHomeFacadeManagerUpdateFrostProtection).toHaveBeenCalledWith(
-        ['d1', 'd2'],
-        { isEnabled: true, max: 16, min: 4 },
-      )
     })
 
-    it('batches a building holiday update across all its devices', async () => {
+    it('reads a Home device overheat protection without a type guard', async () => {
       await app.onInit()
-      stubBuilding({})
+      const state = { isEnabled: true, max: 37, min: 35 }
+      stubHomeDevice({
+        getOverheatProtection: vi
+          .fn<() => Promise<unknown>>()
+          .mockResolvedValue(ok(state)),
+      })
 
-      await app.updateHomeBuildingHolidayMode('b1', {
+      await expect(
+        app.getTargetOverheatProtection('homeDevices_guid-1'),
+      ).resolves.toBe(state)
+    })
+
+    it('reads null overheat protection for a Classic target', async () => {
+      await app.onInit()
+
+      await expect(
+        app.getTargetOverheatProtection('devices_1'),
+      ).resolves.toBeNull()
+    })
+
+    it('refuses an overheat write addressed to a Classic target', async () => {
+      await app.onInit()
+
+      await expect(
+        app.updateTargetOverheatProtection('devices_1', {
+          isEnabled: true,
+          max: 37,
+          min: 35,
+        }),
+      ).rejects.toThrow('errors.deviceNotFound')
+    })
+
+    it('writes a Home device overheat protection through its facade', async () => {
+      await app.onInit()
+      const updateOverheatProtection = vi
+        .fn<() => Promise<void>>()
+        .mockResolvedValue()
+      stubHomeDevice({ updateOverheatProtection })
+
+      await app.updateTargetOverheatProtection('homeDevices_guid-1', {
+        isEnabled: true,
+        max: 37,
+        min: 35,
+      })
+
+      expect(updateOverheatProtection).toHaveBeenCalledWith({
+        isEnabled: true,
+        max: 37,
+        min: 35,
+      })
+    })
+
+    it('reads the building aggregates through the building facade', async () => {
+      await app.onInit()
+      const aggregate = { isEnabled: true, max: null, min: 6 }
+      mockHomeFacadeManagerGetBuilding.mockReturnValue({
+        getFrostProtection: vi
+          .fn<() => Promise<unknown>>()
+          .mockResolvedValue(ok(aggregate)),
+      })
+
+      await expect(
+        app.getTargetFrostProtection('homeBuildings_b1'),
+      ).resolves.toBe(aggregate)
+      expect(mockHomeFacadeManagerGetBuilding).toHaveBeenCalledWith('b1')
+    })
+
+    it('writes the building batches through the building facade', async () => {
+      await app.onInit()
+      const updateHolidayMode = vi.fn<() => Promise<void>>().mockResolvedValue()
+      const updateOverheatProtection = vi
+        .fn<() => Promise<void>>()
+        .mockResolvedValue()
+      mockHomeFacadeManagerGetBuilding.mockReturnValue({
+        updateHolidayMode,
+        updateOverheatProtection,
+      })
+
+      await app.updateTargetHolidayMode('homeBuildings_b1', {
         endDate: 'e',
         isEnabled: true,
         startDate: 's',
       })
+      await app.updateTargetOverheatProtection('homeBuildings_b1', {
+        isEnabled: false,
+        max: 37,
+        min: 35,
+      })
 
-      expect(mockHomeFacadeManagerUpdateHolidayMode).toHaveBeenCalledWith(
-        ['d1', 'd2'],
-        { endDate: 'e', isEnabled: true, startDate: 's' },
-      )
+      expect(updateHolidayMode).toHaveBeenCalledWith({
+        endDate: 'e',
+        isEnabled: true,
+        startDate: 's',
+      })
+      expect(updateOverheatProtection).toHaveBeenCalledWith({
+        isEnabled: false,
+        max: 37,
+        min: 35,
+      })
     })
 
     it('serves the library picker list unfiltered when no type is given', async () => {

--- a/tests/unit/settings.test.ts
+++ b/tests/unit/settings.test.ts
@@ -187,6 +187,8 @@ const classicBuildingsFixture = (): unknown => [
 const homeTargetsFixture = (): unknown => [
   {
     buildingName: 'Villa',
+    hasAta: true,
+    hasAtw: true,
     id: 'building_1',
     level: 0,
     model: 'homeBuildings',
@@ -237,13 +239,12 @@ const defaultRoutes = (): Record<string, unknown> => ({
   'DELETE /home/sessions': undefined,
   'GET /classic/buildings': classicBuildingsFixture(),
   'GET /classic/sessions': true,
-  'GET /classic/zones/buildings/1/settings/frost-protection':
-    protectionFixture(),
-  'GET /classic/zones/buildings/1/settings/holiday-mode': holidayFixture(),
   'GET /home/sessions': false,
   'GET /language': 'fr',
   'GET /settings/devices': deviceSettingsFixture(),
   'GET /settings/drivers': driverSettingsFixture(),
+  'GET /targets/buildings_1/settings/frost-protection': protectionFixture(),
+  'GET /targets/buildings_1/settings/holiday-mode': holidayFixture(),
   'GET /webview-hashes': {},
   'POST /boot-error': undefined,
   'POST /classic/sessions': undefined,
@@ -1219,15 +1220,15 @@ describe('settings page', () => {
       await settleDetached()
 
       expect(calledPaths(harness)).toStrictEqual([
-        'GET /classic/zones/devices/11/settings/frost-protection',
-        'GET /classic/zones/devices/11/settings/holiday-mode',
+        'GET /targets/devices_11/settings/frost-protection',
+        'GET /targets/devices_11/settings/holiday-mode',
       ])
     })
 
     it('should fall back to defaults when the panel fetch fails', async () => {
       await bootPage({
         failures: {
-          'GET /classic/zones/buildings/1/settings/frost-protection': new Error(
+          'GET /targets/buildings_1/settings/frost-protection': new Error(
             'panel down',
           ),
         },
@@ -1240,10 +1241,10 @@ describe('settings page', () => {
     it('should keep the form on a refresh of an uncached panel', async () => {
       await bootPage({
         failures: {
-          'GET /classic/zones/buildings/1/settings/frost-protection': new Error(
+          'GET /targets/buildings_1/settings/frost-protection': new Error(
             'panel down',
           ),
-          'GET /classic/zones/buildings/1/settings/holiday-mode': new Error(
+          'GET /targets/buildings_1/settings/holiday-mode': new Error(
             'panel down',
           ),
         },
@@ -1266,12 +1267,12 @@ describe('settings page', () => {
       await bootPage({
         routes: {
           ...defaultRoutes(),
-          'GET /classic/zones/buildings/1/settings/frost-protection': {
+          'GET /targets/buildings_1/settings/frost-protection': {
             isEnabled: null,
             max: null,
             min: null,
           },
-          'GET /classic/zones/buildings/1/settings/holiday-mode': {
+          'GET /targets/buildings_1/settings/holiday-mode': {
             endDate: null,
             isEnabled: null,
             startDate: null,
@@ -1289,7 +1290,7 @@ describe('settings page', () => {
       await bootPage({
         routes: {
           ...defaultRoutes(),
-          'GET /classic/zones/buildings/1/settings/holiday-mode': null,
+          'GET /targets/buildings_1/settings/holiday-mode': null,
         },
       })
 
@@ -1307,7 +1308,7 @@ describe('settings page', () => {
       expect(
         lastCallBody(
           harness,
-          'PUT /classic/zones/buildings/1/settings/frost-protection',
+          'PUT /targets/buildings_1/settings/frost-protection',
         ),
       ).toStrictEqual({ isEnabled: true, max: 10, min: 6 })
       expect(harness.alert).toHaveBeenCalledWith('settings.success')
@@ -1325,7 +1326,7 @@ describe('settings page', () => {
       expect(
         lastCallBody(
           harness,
-          'PUT /classic/zones/buildings/1/settings/frost-protection',
+          'PUT /targets/buildings_1/settings/frost-protection',
         ),
       ).toStrictEqual({ isEnabled: true, max: 12, min: 10 })
     })
@@ -1337,7 +1338,7 @@ describe('settings page', () => {
       await settleDetached()
 
       expect(calledPaths(harness)).not.toContain(
-        'PUT /classic/zones/buildings/1/settings/frost-protection',
+        'PUT /targets/buildings_1/settings/frost-protection',
       )
 
       const [message] = harness.alert.mock.calls.at(-1) ?? []
@@ -1360,7 +1361,7 @@ describe('settings page', () => {
       await bootPage({
         routes: {
           ...defaultRoutes(),
-          'GET /classic/zones/buildings/1/settings/frost-protection': {
+          'GET /targets/buildings_1/settings/frost-protection': {
             isEnabled: false,
             max: 12,
             min: 8,
@@ -1379,7 +1380,7 @@ describe('settings page', () => {
       const harness = await bootPage({
         routes: {
           ...defaultRoutes(),
-          'GET /classic/zones/buildings/1/settings/frost-protection': {
+          'GET /targets/buildings_1/settings/frost-protection': {
             isEnabled: null,
             max: 12,
             min: 8,
@@ -1398,7 +1399,7 @@ describe('settings page', () => {
         'settings.zones.enabledRequired',
       )
       expect(calledPaths(harness)).not.toContain(
-        'PUT /classic/zones/buildings/1/settings/frost-protection',
+        'PUT /targets/buildings_1/settings/frost-protection',
       )
     })
 
@@ -1414,7 +1415,7 @@ describe('settings page', () => {
     it('should alert when the frost write fails', async () => {
       const harness = await bootPage({
         failures: {
-          'PUT /classic/zones/buildings/1/settings/frost-protection': new Error(
+          'PUT /targets/buildings_1/settings/frost-protection': new Error(
             'frost down',
           ),
         },
@@ -1434,10 +1435,7 @@ describe('settings page', () => {
       await settleDetached()
 
       expect(
-        lastCallBody(
-          harness,
-          'PUT /classic/zones/buildings/1/settings/holiday-mode',
-        ),
+        lastCallBody(harness, 'PUT /targets/buildings_1/settings/holiday-mode'),
       ).toStrictEqual({
         endDate: '2026-09-15T18:00',
         isEnabled: true,
@@ -1456,10 +1454,7 @@ describe('settings page', () => {
       await settleDetached()
 
       expect(
-        lastCallBody(
-          harness,
-          'PUT /classic/zones/buildings/1/settings/holiday-mode',
-        ),
+        lastCallBody(harness, 'PUT /targets/buildings_1/settings/holiday-mode'),
       ).toStrictEqual({ endDate: '2026-09-15T18:00', isEnabled: true })
     })
 
@@ -1467,7 +1462,7 @@ describe('settings page', () => {
       const harness = await bootPage({
         routes: {
           ...defaultRoutes(),
-          'GET /classic/zones/buildings/1/settings/holiday-mode': null,
+          'GET /targets/buildings_1/settings/holiday-mode': null,
         },
       })
       commit(getSelect('enabled_holiday_mode'), 'true')
@@ -1478,7 +1473,7 @@ describe('settings page', () => {
         'settings.holidayMode.endDateMissing',
       )
       expect(calledPaths(harness)).not.toContain(
-        'PUT /classic/zones/buildings/1/settings/holiday-mode',
+        'PUT /targets/buildings_1/settings/holiday-mode',
       )
     })
 
@@ -1489,10 +1484,7 @@ describe('settings page', () => {
       await settleDetached()
 
       expect(
-        lastCallBody(
-          harness,
-          'PUT /classic/zones/buildings/1/settings/holiday-mode',
-        ),
+        lastCallBody(harness, 'PUT /targets/buildings_1/settings/holiday-mode'),
       ).toStrictEqual({ isEnabled: false })
       // Disabling cleared the dates in the form.
       expect(getInput('start_date').value).toBe('')
@@ -1503,7 +1495,7 @@ describe('settings page', () => {
       await bootPage({
         routes: {
           ...defaultRoutes(),
-          'GET /classic/zones/buildings/1/settings/holiday-mode': {
+          'GET /targets/buildings_1/settings/holiday-mode': {
             endDate: null,
             isEnabled: false,
             startDate: null,
@@ -1519,7 +1511,7 @@ describe('settings page', () => {
       await bootPage({
         routes: {
           ...defaultRoutes(),
-          'GET /classic/zones/buildings/1/settings/holiday-mode': {
+          'GET /targets/buildings_1/settings/holiday-mode': {
             endDate: null,
             isEnabled: true,
             startDate: null,
@@ -1536,7 +1528,7 @@ describe('settings page', () => {
       const harness = await bootPage({
         routes: {
           ...defaultRoutes(),
-          'GET /classic/zones/buildings/1/settings/holiday-mode': {
+          'GET /targets/buildings_1/settings/holiday-mode': {
             endDate: null,
             isEnabled: null,
             startDate: null,
@@ -1555,7 +1547,7 @@ describe('settings page', () => {
         'settings.zones.enabledRequired',
       )
       expect(calledPaths(harness)).not.toContain(
-        'PUT /classic/zones/buildings/1/settings/holiday-mode',
+        'PUT /targets/buildings_1/settings/holiday-mode',
       )
     })
 
@@ -1605,7 +1597,7 @@ describe('settings page', () => {
       expect(getSpan('overheat_protection_scope').hidden).toBe(true)
       // The capable target also fetched its overheat panel.
       expect(calledPaths(harness)).toContain(
-        'GET /home/devices/ata_device/settings/overheat-protection',
+        'GET /targets/homeDevices_ata_device/settings/overheat-protection',
       )
     })
 
@@ -1617,7 +1609,7 @@ describe('settings page', () => {
 
       expect(getFieldset('overheat_protection_panel').hidden).toBe(true)
       expect(calledPaths(harness)).not.toContain(
-        'GET /home/devices/atw_device/settings/overheat-protection',
+        'GET /targets/homeDevices_atw_device/settings/overheat-protection',
       )
     })
 
@@ -1634,7 +1626,7 @@ describe('settings page', () => {
       expect(
         lastCallBody(
           harness,
-          'PUT /home/buildings/building_1/settings/overheat-protection',
+          'PUT /targets/homeBuildings_building_1/settings/overheat-protection',
         ),
       ).toStrictEqual({ isEnabled: true, max: 38, min: 33 })
     })
@@ -1649,7 +1641,7 @@ describe('settings page', () => {
       await settleDetached()
 
       expect(calledPaths(harness)).not.toContain(
-        'PUT /home/devices/ata_device/settings/overheat-protection',
+        'PUT /targets/homeDevices_ata_device/settings/overheat-protection',
       )
 
       const [message] = harness.alert.mock.calls.at(-1) ?? []
@@ -1660,11 +1652,8 @@ describe('settings page', () => {
     it('should require a choice on a mixed building overheat', async () => {
       const harness = await bootHome({
         routes: {
-          'GET /home/buildings/building_1/settings/overheat-protection': {
-            isEnabled: null,
-            max: null,
-            min: null,
-          },
+          'GET /targets/homeBuildings_building_1/settings/overheat-protection':
+            { isEnabled: null, max: null, min: null },
         },
       })
       commit(getSelect('zones'), 'homeBuildings_building_1')
@@ -1680,20 +1669,18 @@ describe('settings page', () => {
         'settings.zones.enabledRequired',
       )
       expect(calledPaths(harness)).not.toContain(
-        'PUT /home/buildings/building_1/settings/overheat-protection',
+        'PUT /targets/homeBuildings_building_1/settings/overheat-protection',
       )
     })
 
     it('should keep the form on a refresh of an unfetched target', async () => {
       await bootHome({
         failures: {
-          'GET /home/devices/ata_device/settings/frost-protection': new Error(
-            'down',
-          ),
-          'GET /home/devices/ata_device/settings/holiday-mode': new Error(
-            'down',
-          ),
-          'GET /home/devices/ata_device/settings/overheat-protection':
+          'GET /targets/homeDevices_ata_device/settings/frost-protection':
+            new Error('down'),
+          'GET /targets/homeDevices_ata_device/settings/holiday-mode':
+            new Error('down'),
+          'GET /targets/homeDevices_ata_device/settings/overheat-protection':
             new Error('down'),
         },
       })

--- a/types/api.mts
+++ b/types/api.mts
@@ -1,4 +1,10 @@
-import type { LoginCredentials } from '@olivierzal/melcloud-api'
+import type {
+  AggregatedHolidayModeState,
+  AggregatedProtectionState,
+  HolidayModeState,
+  LoginCredentials,
+  ProtectionState,
+} from '@olivierzal/melcloud-api'
 
 /**
  * Identifier for one of the two MELCloud APIs.
@@ -25,3 +31,18 @@ export interface HolidayModeSettings {
   readonly endDate?: string
   readonly startDate?: string
 }
+
+/**
+ * What a settings target answers for its holiday window: a single
+ * target's state, a multi-device target's per-field aggregate, or
+ * `null` when never configured.
+ */
+export type TargetHolidayModeState =
+  AggregatedHolidayModeState | HolidayModeState | null
+
+/**
+ * What a settings target answers for a protection read — the
+ * protection twin of {@link TargetHolidayModeState}.
+ */
+export type TargetProtectionState =
+  AggregatedProtectionState | ProtectionState | null

--- a/types/error-log.mts
+++ b/types/error-log.mts
@@ -1,5 +1,3 @@
-import type * as Classic from '@olivierzal/melcloud-api/classic'
-
 // Shared between settings/index.mts (URLSearchParams source) and api.mts
 // (Homey-routed query receiver). Defined as strings because URL query params
 // are inherently strings — api.mts converts to numbers for the Classic
@@ -11,17 +9,17 @@ export interface ErrorLogQueryParams {
   readonly to: string
 }
 
-export interface FormattedErrorDetails extends Omit<
-  Classic.ErrorDetails,
-  'deviceId'
-> {
+// The display row the settings table renders: the neutral entry's
+// moment and message localized, its device id resolved to a name.
+export interface FormattedErrorDetails {
+  readonly date: string
   readonly device: string
+  readonly error: string
 }
 
-export interface FormattedErrorLog extends Omit<
-  Classic.ErrorLog,
-  'errors' | 'fromDate'
-> {
+export interface FormattedErrorLog {
   readonly errors: readonly FormattedErrorDetails[]
   readonly fromDateHuman: string
+  readonly nextFromDate: string
+  readonly nextToDate: string
 }

--- a/types/zone.mts
+++ b/types/zone.mts
@@ -25,6 +25,16 @@ export interface DeviceOrZoneData {
 // same-named devices on different buildings apart.
 export interface HomeBuildingZone {
   readonly buildingName: string
+  /**
+   * Whether the building holds at least one air-to-air unit — gates the
+   * per-building overheat panel without a positional scan.
+   */
+  readonly hasAta: boolean
+  /**
+   * Whether the building holds at least one air-to-water unit — with
+   * `hasAta`, qualifies a mixed building's bulk-write scope.
+   */
+  readonly hasAtw: boolean
   readonly id: string
   readonly level: 0
   readonly model: 'homeBuildings'


### PR DESCRIPTION
## Vague 2 adoption — the app side of the cross-dialect contracts (store 46.5.0)

**−687 lines net.** Adopts [melcloud-api 50.0.0](https://github.com/OlivierZal/melcloud-api/releases/tag/v50.0.0) and migrates the zone settings to target-neutral routes, per the explicit route-migration decision (option 2, confirmed).

### Routes: 16 → 6
`/targets/:targetId/settings/{frost-protection,holiday-mode,overheat-protection}` (GET+PUT) replace the three per-family route sets. The `targetId` is the picker value verbatim (`buildings_1`, `homeDevices_<guid>`), so the webview's `#getZoneSettingsBase()` collapses to `/targets/${value}` — no family branch left client-side. Path renames break cached phone webviews by design (no aliases — the 2026-07 precedent); the freshness handshake refetches them on first mismatch.

### App model: 22 → 6 methods
`getTarget*`/`updateTarget*` behind one `#getSettingsTarget` resolver — every 50.0.0 facade (Classic zone/device, Home device, Home building) answers the same methods. Gone: `commonValue` ×3 and the hand-rolled building aggregation (now the library's `HomeBuildingFacade`), the `isHomeAtaFacade` overheat guard (ATW answers `null` on the base), the per-family flow-card branches (the option value IS the targetId). Overheat on a Classic target: `null` on read, refused on write.

### Also
- Error log speaks the neutral vocabulary (`entries`/`at`/`message`); `resolveErrorLogWindow` replaces the app's synthetic-window copy of the Classic tiling.
- The client-side positional overheat scan is replaced by the served `hasAta`/`hasAtw` membership flags (filter-independent, from the library).
- Both session GETs answer through `ensureAuthenticated` (the Classic side now self-heals like Home).
- CLAUDE.md route conventions updated in the same PR; store changelog `46.5.0` in all 13 locales.

943 tests / 52 files, coverage 100 % ×4, `homey:validate` green at publish level, both route kernels (api-contract, api-route-guards) pass against the new manifest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKsbttD4wLTrZnZDwKK1Fn