### PR TITLE
feat: adopt melcloud-api 51.0.0, zone types from the library

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -1843,5 +1843,20 @@
     "pl": "Wewnętrzne ulepszenia niezawodności i ustawień stref.",
     "ru": "Внутренние улучшения надёжности и настроек зон.",
     "sv": "Interna förbättringar av tillförlitlighet och zoninställningar."
+  },
+  "46.6.0": {
+    "ar": "تحسينات داخلية لدعم المناطق والموثوقية.",
+    "da": "Interne forbedringer af zoneunderstøttelse og pålidelighed.",
+    "de": "Interne Verbesserungen der Zonenunterstützung und Zuverlässigkeit.",
+    "en": "Internal improvements to zone support and reliability.",
+    "es": "Mejoras internas en la compatibilidad de zonas y la fiabilidad.",
+    "fr": "Améliorations internes du support des zones et de la fiabilité.",
+    "it": "Miglioramenti interni al supporto delle zone e all’affidabilità.",
+    "ko": "구역 지원 및 안정성에 대한 내부 개선.",
+    "nl": "Interne verbeteringen aan zone-ondersteuning en betrouwbaarheid.",
+    "no": "Interne forbedringer av sonestøtte og pålitelighet.",
+    "pl": "Wewnętrzne ulepszenia obsługi stref i niezawodności.",
+    "ru": "Внутренние улучшения поддержки зон и надёжности.",
+    "sv": "Interna förbättringar av zonstöd och tillförlitlighet."
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -302,5 +302,5 @@
       "värmeåtervinning"
     ]
   },
-  "version": "46.5.0"
+  "version": "46.6.0"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -279,6 +279,23 @@ coverage.
   verdict (2026-08): two lines each, the destructured fields and enum
   hops differ per dialect, and the inverse off-handling lives in the
   base listener — a shared factory would outweigh the duplication.
+- The Home ATA read tables' composed bijections stay as written, by
+  verdict (2026-08): the four double-hop reads
+  (`horizontalFromDevice[horizontalToClassic[…]]` and kin) compose ONLY
+  published bijections with the app's `invertEnum` tables. Routing them
+  through `toClassicAtaGroupState` would trade the enum hops for null
+  handling of the group sentinels (its fields are nullable by group
+  semantics), and a Classic-numbered read surface on the Home facades
+  would mint a second neutral vocabulary — the exact move the
+  ClassicGroupState precedent forbids. The ATW side already needs no
+  conversion at all (the facades speak the normalized vocabularies).
+- Zone types come from the library: `types/zone.mts` keeps only the
+  app's routing shapes (`DeviceGroup`, `DeviceOrZoneData`, `ZoneData`);
+  `HomeBuildingZone`/`HomeDeviceZone` — and the cross-dialect
+  `FlatZone` union — are melcloud-api's, imported type-only (erased,
+  so webview bundles never touch the barrel). A second ATW zone is a
+  nullable read (`facade.zone2`), never a type guard: `hasClassicZone2`
+  died with melcloud-api 51.0.0.
 - Home drivers only ship surfaces the MELCloud Home app itself exposes,
   even when the API facade can read more — no outdoor temperature on
   Home ATW (not in the app UI; an absent setting would read as 0).

--- a/api.mts
+++ b/api.mts
@@ -4,6 +4,8 @@ import type * as Home from '@olivierzal/melcloud-api/home'
 import type { Homey } from 'homey/lib/Homey'
 import { getErrorMessage } from '@olivierzal/homey-kit'
 import {
+  type HomeBuildingZone,
+  type HomeDeviceZone,
   type LoginCredentials,
   type ProtectionUpdate,
   AuthenticationError,
@@ -20,11 +22,7 @@ import type {
   ErrorLogQueryParams,
   FormattedErrorLog,
 } from './types/error-log.mts'
-import type {
-  DeviceGroup,
-  HomeBuildingZone,
-  HomeDeviceZone,
-} from './types/zone.mts'
+import type { DeviceGroup } from './types/zone.mts'
 import { getClassicBuildings } from './lib/classic-facade-manager.mts'
 import { toNonNegativeInt } from './lib/validation.mts'
 import { getWebviewHashes } from './lib/webview-hashes.mts'

--- a/app.json
+++ b/app.json
@@ -303,7 +303,7 @@
       "värmeåtervinning"
     ]
   },
-  "version": "46.5.0",
+  "version": "46.6.0",
   "flow": {
     "triggers": [
       {

--- a/app.mts
+++ b/app.mts
@@ -15,6 +15,8 @@ import {
 import {
   type DeviceType,
   type HolidayModeUpdate,
+  type HomeBuildingZone,
+  type HomeDeviceZone,
   type Hour,
   type ProtectionUpdate,
   type ReportChartLineOptions,
@@ -49,12 +51,7 @@ import type { HomeDeviceFacade } from './types/home.mts'
 import type { ManifestDriverCapabilitiesOptions } from './types/manifest.mts'
 import type { MELCloudDevice, MELCloudDriver } from './types/melcloud.mts'
 import type { GetAtaOptions } from './types/widgets.mts'
-import type {
-  DeviceOrZoneData,
-  HomeBuildingZone,
-  HomeDeviceZone,
-  ZoneData,
-} from './types/zone.mts'
+import type { DeviceOrZoneData, ZoneData } from './types/zone.mts'
 import {
   changelog,
   fanSpeed,

--- a/drivers/melcloud_atw/device.mts
+++ b/drivers/melcloud_atw/device.mts
@@ -1,4 +1,4 @@
-import { hasClassicZone2, isClassicAtwFacade } from '@olivierzal/melcloud-api'
+import { isClassicAtwFacade } from '@olivierzal/melcloud-api'
 import * as Classic from '@olivierzal/melcloud-api/classic'
 
 import type {
@@ -149,13 +149,11 @@ export default class ClassicMELCloudDeviceAtw extends ClassicMELCloudDevice<
       'operational_state.zone1',
       facade.zone1.operationalState,
     )
-    if (
-      this.hasCapability('operational_state.zone2') &&
-      hasClassicZone2(facade)
-    ) {
+    const { zone2 } = facade
+    if (zone2 !== null && this.hasCapability('operational_state.zone2')) {
       await this.setCapabilityValue(
         'operational_state.zone2',
-        facade.zone2.operationalState,
+        zone2.operationalState,
       )
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "com.melcloud",
-  "version": "46.5.0",
+  "version": "46.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "com.melcloud",
-      "version": "46.5.0",
+      "version": "46.6.0",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@olivierzal/homey-kit": "5.0.0",
-        "@olivierzal/melcloud-api": "50.0.0",
+        "@olivierzal/melcloud-api": "51.0.0",
         "source-map-support": "^0.5.21",
         "temporal-polyfill": "^1.0.1"
       },
@@ -1117,9 +1117,9 @@
       }
     },
     "node_modules/@olivierzal/melcloud-api": {
-      "version": "50.0.0",
-      "resolved": "https://npm.pkg.github.com/download/@olivierzal/melcloud-api/50.0.0/6e20266cb7aa7c6e704031675f2221a2b74008ba",
-      "integrity": "sha512-+myXGLSwg6p4hQbpJVm/tqqVjEzLsRHhe2rIktWYC4bJM3od3YNasGWt7rlh2mSg9RElicBwxSayYVEmT0Wt6w==",
+      "version": "51.0.0",
+      "resolved": "https://npm.pkg.github.com/download/@olivierzal/melcloud-api/51.0.0/8f400a0a80912c0eb69924709ac6afc39c03d91f",
+      "integrity": "sha512-6H32MoSV/qjQmM2Kvf4FNqdAE5Jy31cPAZmn1PMHFFmrU7VDjxgc3nx3JrQ+YuJQ1k1GeW3VNmYysq/e4oQ0xQ==",
       "license": "MIT",
       "dependencies": {
         "temporal-polyfill": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.melcloud",
-  "version": "46.5.0",
+  "version": "46.6.0",
   "description": "MELCloud for Homey",
   "homepage": "https://github.com/OlivierZal/com.melcloud/",
   "bugs": {
@@ -33,7 +33,7 @@
   "prettier": "@olivierzal/configs/prettier",
   "dependencies": {
     "@olivierzal/homey-kit": "5.0.0",
-    "@olivierzal/melcloud-api": "50.0.0",
+    "@olivierzal/melcloud-api": "51.0.0",
     "source-map-support": "^0.5.21",
     "temporal-polyfill": "^1.0.1"
   },

--- a/public/zones.mts
+++ b/public/zones.mts
@@ -1,6 +1,5 @@
+import type { HomeBuildingZone, HomeDeviceZone } from '@olivierzal/melcloud-api'
 import type * as Classic from '@olivierzal/melcloud-api/classic'
-
-import type { HomeBuildingZone, HomeDeviceZone } from '../types/zone.mts'
 
 // Everything the zone pickers can list: a Classic zone at any level, or
 // a Home building and its devices.

--- a/settings/index.mts
+++ b/settings/index.mts
@@ -1,6 +1,8 @@
 import type { DriverSetting } from '@olivierzal/homey-kit/manifest'
 import type {
   HolidayModeState,
+  HomeBuildingZone,
+  HomeDeviceZone,
   LoginCredentials,
 } from '@olivierzal/melcloud-api'
 import type * as Classic from '@olivierzal/melcloud-api/classic'
@@ -58,7 +60,6 @@ import type {
   FormattedErrorDetails,
   FormattedErrorLog,
 } from '../types/error-log.mts'
-import type { HomeBuildingZone, HomeDeviceZone } from '../types/zone.mts'
 import {
   populateZoneOptions as populateZoneSelect,
   translateAriaLabels,

--- a/tests/unit/api.test.ts
+++ b/tests/unit/api.test.ts
@@ -5,6 +5,8 @@ import type { Homey } from 'homey/lib/Homey'
 import {
   type HolidayModeState,
   type HolidayModeUpdate,
+  type HomeBuildingZone,
+  type HomeDeviceZone,
   type LoginCredentials,
   type ProtectionState,
   AuthenticationError,
@@ -17,7 +19,6 @@ import type {
   ErrorLogQueryParams,
   FormattedErrorLog,
 } from '../../types/error-log.mts'
-import type { HomeBuildingZone, HomeDeviceZone } from '../../types/zone.mts'
 import { mock } from '../helpers.ts'
 
 const mockGetBuildings =

--- a/tests/unit/ata-group-setting-api.test.ts
+++ b/tests/unit/ata-group-setting-api.test.ts
@@ -1,3 +1,4 @@
+import type { HomeBuildingZone, HomeDeviceZone } from '@olivierzal/melcloud-api'
 import type * as Classic from '@olivierzal/melcloud-api/classic'
 import type { Homey } from 'homey/lib/Homey'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -5,12 +6,7 @@ import * as Home from '@olivierzal/melcloud-api/home'
 
 import type { GroupAtaStates } from '../../types/classic-ata.mts'
 import type { DriverCapabilitiesOptions } from '../../types/driver-settings.mts'
-import type {
-  DeviceOrZoneData,
-  HomeBuildingZone,
-  HomeDeviceZone,
-  ZoneData,
-} from '../../types/zone.mts'
+import type { DeviceOrZoneData, ZoneData } from '../../types/zone.mts'
 import { mock } from '../helpers.ts'
 
 const mockGetBuildings = vi.fn<() => Classic.BuildingZone[]>()

--- a/tests/unit/ata-group-setting.test.ts
+++ b/tests/unit/ata-group-setting.test.ts
@@ -1,10 +1,10 @@
 // @vitest-environment happy-dom
 // @vitest-environment-options {"settings": {"disableCSSFileLoading": true, "disableJavaScriptFileLoading": true, "navigation": {"disableMainFrameNavigation": true}}}
 
+import type { HomeDeviceZone } from '@olivierzal/melcloud-api'
 import { getButton, getSelect } from '@olivierzal/homey-kit/dom'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { HomeDeviceZone } from '../../types/zone.mts'
 import { start } from '../../widgets/ata-group-setting/public/index.mts'
 import {
   type WidgetHarness,

--- a/tests/unit/ata-values.test.ts
+++ b/tests/unit/ata-values.test.ts
@@ -1,10 +1,10 @@
 // @vitest-environment happy-dom
 // @vitest-environment-options {"settings": {"disableCSSFileLoading": true, "disableJavaScriptFileLoading": true, "navigation": {"disableMainFrameNavigation": true}}}
 
+import type { HomeDeviceZone } from '@olivierzal/melcloud-api'
 import { getFieldset, getInput, getSelect } from '@olivierzal/homey-kit/dom'
 import { beforeEach, describe, expect, it } from 'vitest'
 
-import type { HomeDeviceZone } from '../../types/zone.mts'
 import { AtaValueManager } from '../../widgets/ata-group-setting/public/ata-values.mts'
 import {
   type WidgetHarness,

--- a/tests/unit/melcloud-atw-device.test.ts
+++ b/tests/unit/melcloud-atw-device.test.ts
@@ -82,7 +82,8 @@ const mockAtwFacade = (
       zone1: overrides.zone1 ?? {
         operationalState: Classic.OperationModeStateZone.idle,
       },
-      ...('zone2' in overrides && { zone2: overrides.zone2 }),
+      // The 51.0.0 contract: zone2 is a nullable read, never absent.
+      zone2: overrides.zone2 ?? null,
     },
   })
 }

--- a/tests/unit/zones.test.ts
+++ b/tests/unit/zones.test.ts
@@ -1,7 +1,7 @@
+import type { HomeDeviceZone } from '@olivierzal/melcloud-api'
 import type * as Classic from '@olivierzal/melcloud-api/classic'
 import { describe, expect, it } from 'vitest'
 
-import type { HomeDeviceZone } from '../../types/zone.mts'
 import {
   getHomeBuildingId,
   getHomeDeviceId,

--- a/types/widgets.mts
+++ b/types/widgets.mts
@@ -1,8 +1,11 @@
-import type { Hour } from '@olivierzal/melcloud-api'
+import type {
+  HomeBuildingZone,
+  HomeDeviceZone,
+  Hour,
+} from '@olivierzal/melcloud-api'
 import type * as Classic from '@olivierzal/melcloud-api/classic'
 
 import type { BaseSettings } from './bases.mts'
-import type { HomeBuildingZone, HomeDeviceZone } from './zone.mts'
 
 // Report-history cap shared by the charts widget API validation, the
 // widget day picker and the settings manifest bound: a full year.

--- a/types/zone.mts
+++ b/types/zone.mts
@@ -16,40 +16,6 @@ export interface DeviceOrZoneData {
   readonly zoneType: 'areas' | 'buildings' | 'devices' | 'floors'
 }
 
-// MELCloud-Home targets: each `/context` building (the account-level
-// group) is a selectable root entry, its devices one level below. The
-// models are camelCase because option values split `${model}_${id}` at
-// the FIRST underscore — a Home id may itself contain underscores.
-// `buildingName` mirrors `Classic.FlatZone`: it names the owning building
-// (a building carries its own) so a flat picker can suffix leaves and keep
-// same-named devices on different buildings apart.
-export interface HomeBuildingZone {
-  readonly buildingName: string
-  /**
-   * Whether the building holds at least one air-to-air unit — gates the
-   * per-building overheat panel without a positional scan.
-   */
-  readonly hasAta: boolean
-  /**
-   * Whether the building holds at least one air-to-water unit — with
-   * `hasAta`, qualifies a mixed building's bulk-write scope.
-   */
-  readonly hasAtw: boolean
-  readonly id: string
-  readonly level: 0
-  readonly model: 'homeBuildings'
-  readonly name: string
-}
-
-export interface HomeDeviceZone {
-  readonly buildingName: string
-  readonly deviceType: 'ata' | 'atw'
-  readonly id: string
-  readonly level: 1
-  readonly model: 'homeDevices'
-  readonly name: string
-}
-
 export interface ZoneData {
   readonly zoneId: string
   readonly zoneType: 'areas' | 'buildings' | 'floors'

--- a/widgets/ata-group-setting/api.mts
+++ b/widgets/ata-group-setting/api.mts
@@ -1,3 +1,4 @@
+import type { HomeBuildingZone, HomeDeviceZone } from '@olivierzal/melcloud-api'
 import type * as Classic from '@olivierzal/melcloud-api/classic'
 import type { Homey } from 'homey/lib/Homey'
 import * as Home from '@olivierzal/melcloud-api/home'
@@ -5,12 +6,7 @@ import * as Home from '@olivierzal/melcloud-api/home'
 import type { GroupAtaStates } from '../../types/classic-ata.mts'
 import type { DriverCapabilitiesOptions } from '../../types/driver-settings.mts'
 import type { GetAtaOptions } from '../../types/widgets.mts'
-import type {
-  DeviceOrZoneData,
-  HomeBuildingZone,
-  HomeDeviceZone,
-  ZoneData,
-} from '../../types/zone.mts'
+import type { DeviceOrZoneData, ZoneData } from '../../types/zone.mts'
 import { getClassicBuildings } from '../../lib/classic-facade-manager.mts'
 import { toDeviceType } from '../../lib/to-device-type.mts'
 import { toDeviceOrZoneData, toZoneData } from '../../lib/validation.mts'

--- a/widgets/ata-group-setting/public/index.mts
+++ b/widgets/ata-group-setting/public/index.mts
@@ -1,3 +1,4 @@
+import type { HomeBuildingZone, HomeDeviceZone } from '@olivierzal/melcloud-api'
 import type * as Classic from '@olivierzal/melcloud-api/classic'
 import {
   getButton,
@@ -13,7 +14,6 @@ import {
 } from '@olivierzal/homey-kit/webview'
 
 import type { AtaGroupSettingWidgetSettings as HomeySettings } from '../../../types/widgets.mts'
-import type { HomeBuildingZone, HomeDeviceZone } from '../../../types/zone.mts'
 import {
   hideInitError,
   showInitError,

--- a/widgets/charts/api.mts
+++ b/widgets/charts/api.mts
@@ -1,4 +1,5 @@
 import type {
+  HomeDeviceZone,
   ReportChartLineOptions,
   ReportChartPieOptions,
 } from '@olivierzal/melcloud-api'
@@ -6,7 +7,6 @@ import type * as Classic from '@olivierzal/melcloud-api/classic'
 import type * as Home from '@olivierzal/melcloud-api/home'
 import type { Homey } from 'homey/lib/Homey'
 
-import type { HomeDeviceZone } from '../../types/zone.mts'
 import { toDeviceType, toHomeDeviceType } from '../../lib/to-device-type.mts'
 import { toHour, toNonNegativeInt } from '../../lib/validation.mts'
 import { getWebviewHashes } from '../../lib/webview-hashes.mts'

--- a/widgets/charts/public/index.mts
+++ b/widgets/charts/public/index.mts
@@ -1,4 +1,5 @@
 import type {
+  HomeDeviceZone,
   ReportChartBand,
   ReportChartLineOptions,
   ReportChartPieOptions,
@@ -39,7 +40,6 @@ import {
 } from 'chart.js'
 import { Temporal } from 'temporal-polyfill'
 
-import type { HomeDeviceZone } from '../../../types/zone.mts'
 import {
   hideInitError,
   showInitError,


### PR DESCRIPTION
## Vague 3, chantiers 2+3 — adoption (store 46.6.0)

Adopts [melcloud-api 51.0.0](https://github.com/OlivierZal/melcloud-api/releases/tag/v51.0.0):

- **Zone 2 is a nullable read**: `hasClassicZone2` died with the library's dual-zone type; the ATW driver reads `facade.zone2` and guards on `null` — the same shape the Home driver always had. The state stubs now carry `zone2: null` per the contract.
- **Zone types come from the library** (chantier 2): `types/zone.mts` keeps only the app routing shapes (`DeviceGroup`, `DeviceOrZoneData`, `ZoneData`); `HomeBuildingZone`/`HomeDeviceZone` — and the cross-dialect `FlatZone` union — are melcloud-api's, imported type-only across the 14 former mirror importers (erased at runtime, webview bundles untouched).
- **Chantier 3 lands as a recorded verdict** (CLAUDE.md): the Home ATA composed read tables stay — they compose ONLY published bijections with `invertEnum`; routing through `toClassicAtaGroupState` would trade enum hops for group-sentinel null handling, and a Classic-numbered Home read surface would mint a second neutral vocabulary (the exact move the ClassicGroupState precedent forbids). The ATW side already needs no conversion.

943 tests / 52 files, coverage 100 % ×4, `homey:validate` publish-level green, store changelog 46.6.0 in all 13 locales.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKsbttD4wLTrZnZDwKK1Fn