### PR TITLE
build: adopt @olivierzal/melcloud-api 51.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "GPL-3.0-only",
       "dependencies": {
         "@olivierzal/homey-kit": "5.0.0",
-        "@olivierzal/melcloud-api": "51.0.0",
+        "@olivierzal/melcloud-api": "51.0.1",
         "source-map-support": "^0.5.21",
         "temporal-polyfill": "^1.0.1"
       },
@@ -1117,9 +1117,9 @@
       }
     },
     "node_modules/@olivierzal/melcloud-api": {
-      "version": "51.0.0",
-      "resolved": "https://npm.pkg.github.com/download/@olivierzal/melcloud-api/51.0.0/8f400a0a80912c0eb69924709ac6afc39c03d91f",
-      "integrity": "sha512-6H32MoSV/qjQmM2Kvf4FNqdAE5Jy31cPAZmn1PMHFFmrU7VDjxgc3nx3JrQ+YuJQ1k1GeW3VNmYysq/e4oQ0xQ==",
+      "version": "51.0.1",
+      "resolved": "https://npm.pkg.github.com/download/@olivierzal/melcloud-api/51.0.1/93fc3eb0fc9d7a1225a987a5a5be1a71b8487de1",
+      "integrity": "sha512-xyYqYFrgV6pOGAAcI42Y2zltxX/hZS/kkDX8KRZ6xuMGIWpjbEYYcWZIDSkK1LthrO3uZerGkTb5sHh63sPgQQ==",
       "license": "MIT",
       "dependencies": {
         "temporal-polyfill": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "prettier": "@olivierzal/configs/prettier",
   "dependencies": {
     "@olivierzal/homey-kit": "5.0.0",
-    "@olivierzal/melcloud-api": "51.0.0",
+    "@olivierzal/melcloud-api": "51.0.1",
     "source-map-support": "^0.5.21",
     "temporal-polyfill": "^1.0.1"
   },


### PR DESCRIPTION
Exact-pin bump 51.0.0 → 51.0.1 ([release](https://github.com/OlivierZal/melcloud-api/releases/tag/v51.0.1)): post-wave cleanup sweep, internal factorings and test/doc fixes only — no public-surface change, so no app-side code change.

Verified locally: typecheck, lint, format, build, 943 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKsbttD4wLTrZnZDwKK1Fn