### PR TITLE
refactor: post-wave cleanup sweep

### DIFF
--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -28,10 +28,6 @@
       "method": "GET",
       "path": "/logs/errors"
     },
-    "getHomeDevices": {
-      "method": "GET",
-      "path": "/home/devices"
-    },
     "getHomeTargets": {
       "method": "GET",
       "path": "/home/targets"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,10 +94,12 @@ caught real failures that the others miss:
   vendored-JSON key sort in `scripts/sort-keys-deep.mts`), unit-tested
   against a temp packaging tree; `bundle.mts` and
   `sync-capability-definitions.mts` keep only their tables and the
-  esbuild/fs calls consuming them — the two named, file-scoped coverage
-  exclusions left in `vitest.config.ts` and `sonar-project.properties`
-  (never a directory sweep, and `npm run build` plus the drift test
-  exercise them end to end). esbuild runs in a service process with its
+  esbuild/fs calls consuming them, unit-tested directly
+  (`tests/unit/bundle.test.ts`,
+  `tests/unit/sync-capability-definitions.test.ts`) — no file-scoped
+  coverage exclusion remains in `vitest.config.ts` or
+  `sonar-project.properties`, and `npm run build` plus the drift test
+  exercise them end to end. esbuild runs in a service process with its
   own cwd, so both the build and the stamping anchor on an explicit
   repo root (`absWorkingDir`), never the launcher's.
 - `npm run homey:validate` — Homey validation at publish level; may

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Architecture notes:
 - The API layer lives in [@olivierzal/melcloud-api](https://github.com/OlivierZal/melcloud-api), a sibling repository with its own tooling; API bugs are fixed there, not worked around here.
 - Browser code (both widgets' `public/` and the `settings/` page) is bundled by `scripts/bundle.mts` into a compat pair per entry — `index.js` (IIFE, what the shipped HTML loads) and `index.mjs` (for HTMLs cached by phones from earlier app versions) — emitted into `.homeybuild`, the packaged app, never into the source tree. `npm run build` produces them, and the Homey CLI runs it automatically on validate/publish. Shared helpers live in `public/` and are imported directly by widgets and settings.
 - Both the build and `npm run typecheck` use the native TypeScript 7 compiler (`typescript@7` aliased as `@typescript/native`) for speed; `typescript@6` remains alongside it for tools that need the JS API (typescript-eslint) until TypeScript 7.1 ships its stable programmatic API.
-- Test coverage is enforced at 100% for backend code; browser glue (`public/`, `settings/`, widget `public/`) is excluded from coverage, so the badge covers drivers, app and API layers only.
+- Test coverage is enforced at 100% on branches, functions, lines and statements across every `.mts` source — webview pages and widgets included; only the packaged `.homeybuild` output is excluded.
 
 ## Disclaimer
 

--- a/api.mts
+++ b/api.mts
@@ -159,8 +159,6 @@ const api = {
       ...(to !== undefined && { to }),
     })
   },
-  getHomeDevices: ({ homey: { app } }: { homey: Homey }): HomeDeviceZone[] =>
-    app.getHomeDeviceZones(),
   getHomeTargets: ({
     homey: { app },
   }: {

--- a/app.json
+++ b/app.json
@@ -29,10 +29,6 @@
       "method": "GET",
       "path": "/logs/errors"
     },
-    "getHomeDevices": {
-      "method": "GET",
-      "path": "/home/devices"
-    },
     "getHomeTargets": {
       "method": "GET",
       "path": "/home/targets"

--- a/app.mts
+++ b/app.mts
@@ -14,6 +14,7 @@ import {
 } from '@olivierzal/homey-kit/manifest'
 import {
   type DeviceType,
+  type FlatZone,
   type HolidayModeUpdate,
   type HomeBuildingZone,
   type HomeDeviceZone,
@@ -173,18 +174,13 @@ interface FlatZoneItem {
   readonly name: string
 }
 
-// A node from either zone source: a Classic zone (carrying its building
-// name) or a Home building/device (same shape). The single vocabulary
-// every picker draws from.
-type PickerNode = Classic.FlatZone | HomeBuildingZone | HomeDeviceZone
-
 // A flat picker lists every node at one level, so a leaf's bare name can
 // collide with a same-named leaf on another building; suffixing it with its
 // owning building keeps them apart. Building nodes locate themselves and
 // keep the bare name — as do tree-shaped lists, where the hierarchy already
 // places each node. The one suffix rule for every flat surface (holiday
 // flow, chart and group widget pickers).
-const toFlatName = ({ buildingName, model, name }: PickerNode): string => {
+const toFlatName = ({ buildingName, model, name }: FlatZone): string => {
   const trimmed = name.trim()
   return model === 'buildings' || model === 'homeBuildings'
     ? trimmed
@@ -193,7 +189,7 @@ const toFlatName = ({ buildingName, model, name }: PickerNode): string => {
 
 // Flat autocomplete items over the given nodes, name-sorted. The selected
 // item's `id` carries the `${model}_${id}` routing value run listeners parse.
-const toFlatZoneItems = (nodes: readonly PickerNode[]): FlatZoneItem[] =>
+const toFlatZoneItems = (nodes: readonly FlatZone[]): FlatZoneItem[] =>
   nodes
     .map((node) => ({
       id: getZoneId(node.id, node.model),
@@ -224,11 +220,6 @@ const parseErrorDate = (date: string, timeZone: string): Temporal.Instant => {
 // The webview always asks for 29-day pages; mirrored here for the synthetic
 // window served when Classic is signed out.
 const DEFAULT_ERROR_LOG_PERIOD_DAYS = 29
-const HOME_ERROR_DEVICE_TYPES: readonly Home.DeviceType[] = [
-  Home.DeviceType.Ata,
-  Home.DeviceType.Atw,
-]
-
 interface RawErrorEntry {
   readonly device: string
   readonly error: string
@@ -336,14 +327,9 @@ export default class MELCloudApp extends App {
     // initialized — the discriminators for 2018-hardware
     // `ready_timeout` diagnostics.
     this.log('Boot: onInit after', process.uptime().toFixed(1), 's')
-    const language = this.homey.i18n.getLanguage()
-    await this.#initClassicApi({
-      language,
-      locale: language,
-      timezone: getTimeZone(this.homey),
-    })
+    await this.#initClassicApi()
     await this.#initHomeApi()
-    this.#createNotification(language)
+    this.#createNotification(this.homey.i18n.getLanguage())
     this.#registerWidgetListeners()
     this.#registerFlowListeners()
     // Poke any open webview to re-run its freshness handshake: an app
@@ -394,17 +380,17 @@ export default class MELCloudApp extends App {
     if (devices.length === 0) {
       throw new NotFoundError(this.homey.__('errors.deviceNotFound'))
     }
+    const ataData = devices
+      .filter((device) =>
+        Classic.isDeviceOfType(device, Classic.DeviceType.Ata),
+      )
+      .map(({ data }) => data)
+      .filter((data) => status !== 'on' || data.Power)
     // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- narrowing generic Classic.GroupState to typed GroupAtaStates
     return typedFromEntries(
-      this.getClassicAtaCapabilities().map(([key]) => [
+      this.#getAtaCapabilityConfigs().map(({ key }) => [
         key,
-        devices
-          .filter((device) =>
-            Classic.isDeviceOfType(device, Classic.DeviceType.Ata),
-          )
-          .map(({ data }) => data)
-          .filter((data) => status !== 'on' || data.Power)
-          .map((data) => data[key]),
+        ataData.map((data) => data[key]),
       ]),
     ) as GroupAtaStates
   }
@@ -462,15 +448,15 @@ export default class MELCloudApp extends App {
     zoneType: DeviceOrZoneData['zoneType'],
     id: number | string,
   ): Classic.Facade {
-    const instance = this.#classicRegistry[zoneType].getById(Number(id))
-    if (instance === undefined) {
+    const facade = this.#facadeManager.getById(zoneType, Number(id))
+    if (facade === null) {
       throw new NotFoundError(
         this.homey.__(
           `errors.${zoneType === 'devices' ? 'device' : 'zone'}NotFound`,
         ),
       )
     }
-    return this.#facadeManager.get(instance)
+    return facade
   }
 
   public async getClassicHourlyTemperatures({
@@ -518,7 +504,7 @@ export default class MELCloudApp extends App {
   // narrowed to one device type. Every flat Classic picker draws from
   // here with the filters it needs.
   public getClassicTargets(type?: Classic.DeviceType): Classic.FlatZone[] {
-    return this.#facadeManager.getZones(type === undefined ? {} : { type })
+    return this.#facadeManager.getZones({ type })
   }
 
   public async getClassicTemperatures({
@@ -719,7 +705,7 @@ export default class MELCloudApp extends App {
   // The flattened Home picker list — name-sorted buildings (level 0) each
   // followed by its own devices (level 1); `type` narrows to one
   // connection type (the ATA group widget), omitted spans both (the
-  // settings selector). The tree itself now comes from the library.
+  // settings selector).
   public getHomeTargets(
     type?: Home.DeviceType,
   ): (HomeBuildingZone | HomeDeviceZone)[] {
@@ -761,7 +747,7 @@ export default class MELCloudApp extends App {
   public async getTargetOverheatProtection(
     targetId: string,
   ): Promise<TargetProtectionState> {
-    const target = this.#getOverheatTarget(targetId)
+    const target = this.#getHomeTarget(targetId)
     return target === null
       ? null
       : unwrapResult(await target.getOverheatProtection())
@@ -853,7 +839,7 @@ export default class MELCloudApp extends App {
     targetId: string,
     settings: ProtectionUpdate,
   ): Promise<void> {
-    const target = this.#getOverheatTarget(targetId)
+    const target = this.#getHomeTarget(targetId)
     if (target === null) {
       // Overheat protection does not exist on the Classic wire: a write
       // addressed to a Classic target is a caller error, not a no-op.
@@ -920,8 +906,8 @@ export default class MELCloudApp extends App {
   }
 
   // One clock for every entry point: the Homey's. An absent bound means
-  // "now" — the settings page no longer stamps the phone's clock, whose
-  // divergence from the flow cards' Homey clock was #1595.
+  // "now" — stamping here keeps the settings page and the flow cards on
+  // the same clock whatever timezone the phone sits in.
   #completeHolidayModeWindow({
     endDate,
     isEnabled,
@@ -1004,6 +990,9 @@ export default class MELCloudApp extends App {
     options: ManifestDriverCapabilitiesOptions
     enumType?: Record<string, number | string>
   }[] {
+    const ataOptions = this.homey.manifest.drivers.find(
+      ({ id }) => id === 'melcloud',
+    )?.capabilitiesOptions
     return [
       { key: 'Power', options: power },
       {
@@ -1015,8 +1004,7 @@ export default class MELCloudApp extends App {
         // honest — and why neither API's increment is read instead.
         options: {
           ...targetTemperature,
-          ...this.homey.manifest.drivers.find(({ id }) => id === 'melcloud')
-            ?.capabilitiesOptions?.target_temperature,
+          ...ataOptions?.target_temperature,
           step: getCapabilityFlowStep(targetTemperature),
         },
       },
@@ -1040,11 +1028,9 @@ export default class MELCloudApp extends App {
         key: 'OperationMode',
         options: {
           ...thermostatMode,
-          values: this.homey.manifest.drivers
-            .find(({ id }) => id === 'melcloud')
-            ?.capabilitiesOptions?.thermostat_mode?.values?.filter(
-              ({ id }) => id !== 'off',
-            ),
+          values: ataOptions?.thermostat_mode?.values?.filter(
+            ({ id }) => id !== 'off',
+          ),
         },
       },
     ]
@@ -1068,7 +1054,7 @@ export default class MELCloudApp extends App {
     query: Classic.ErrorLogQuery,
     timeZone: string,
   ): Promise<Classic.ErrorLog> {
-    if (!this.classicApi.isAuthenticated()) {
+    if (!this.#classicApi.isAuthenticated()) {
       // A Home-only account pages the same windows the Classic API
       // would have answered: the library publishes its own tiling.
       const { fromDate, nextFromDate, nextToDate } = resolveErrorLogWindow(
@@ -1113,11 +1099,12 @@ export default class MELCloudApp extends App {
       : drivers.filter((driver) => driver.id === driverId)
   }
 
-  // The ids of every device (ATA and ATW) in a `/context` building.
+  // A Home building is a zone in the picker vocabulary, so a missing
+  // one answers the same error class as its Classic counterpart.
   #getHomeBuildingFacade(buildingId: string): Home.BuildingFacade {
     const facade = this.#homeFacadeManager.getBuilding(buildingId)
     if (facade === null) {
-      throw new NotFoundError(this.homey.__('errors.deviceNotFound'))
+      throw new NotFoundError(this.homey.__('errors.zoneNotFound'))
     }
     return facade
   }
@@ -1147,32 +1134,28 @@ export default class MELCloudApp extends App {
     deviceId: string,
     type?: Home.DeviceType,
   ): Home.DeviceAtaFacade | Home.DeviceAtwFacade {
-    const model = this.#homeRegistry.getById(deviceId)
-    if (type === undefined || model?.type === type) {
-      if (model?.isAta() === true) {
-        return this.#homeFacadeManager.get(model)
-      }
-      if (model?.isAtw() === true) {
-        return this.#homeFacadeManager.get(model)
-      }
+    const facade = this.#homeFacadeManager.getById(deviceId)
+    if (facade === null || (type !== undefined && facade.type !== type)) {
+      throw new NotFoundError(this.homey.__('errors.deviceNotFound'))
     }
-    throw new NotFoundError(this.homey.__('errors.deviceNotFound'))
+    return facade
   }
 
   async #getHomeErrorEntries(timeZone: string): Promise<RawErrorEntry[]> {
     const logs = await Promise.all(
-      HOME_ERROR_DEVICE_TYPES.flatMap((type) =>
-        this.getHomeDevicesByType(type),
-      ).map(async (device) =>
-        this.#getHomeDeviceErrorEntries(device, timeZone),
-      ),
+      this.#homeRegistry
+        .getDevices()
+        .map(async (device) =>
+          this.#getHomeDeviceErrorEntries(device, timeZone),
+        ),
     )
     return logs.flat()
   }
 
-  // Overheat protection exists on Home targets only; a Classic value
-  // resolves to `null` rather than a facade.
-  #getOverheatTarget(
+  // The Home target for a picker value, or `null` when the value
+  // addresses the Classic family. Doubles as the overheat resolver:
+  // overheat protection exists on Home targets only.
+  #getHomeTarget(
     targetId: string,
   ): Home.BuildingFacade | Home.DeviceAtaFacade | Home.DeviceAtwFacade | null {
     if (isHomeBuildingValue(targetId)) {
@@ -1187,11 +1170,9 @@ export default class MELCloudApp extends App {
   // targetId is the picker value verbatim (`${model}_${id}`), so
   // addressing is the only family-visible step left.
   #getSettingsTarget(targetId: string): SettingsTarget {
-    if (isHomeBuildingValue(targetId)) {
-      return this.#getHomeBuildingFacade(getHomeBuildingId(targetId))
-    }
-    if (isHomeDeviceValue(targetId)) {
-      return this.#getHomeDeviceFacade(getHomeDeviceId(targetId))
+    const homeTarget = this.#getHomeTarget(targetId)
+    if (homeTarget !== null) {
+      return homeTarget
     }
     const { zoneId, zoneType } = toZoneValueData(targetId)
     return this.getClassicFacade(zoneType, zoneId)
@@ -1228,15 +1209,6 @@ export default class MELCloudApp extends App {
     return Temporal.PlainTime.from(time)
   }
 
-  // Disabling holiday mode: both APIs ignore the window when off, so the
-  // bounds are stamped at now for a valid, self-consistent payload.
-  #holidayModeOff(): HolidayModeUpdate {
-    const now = Temporal.Now.plainDateTimeISO(
-      getTimeZone(this.homey),
-    ).toString()
-    return { endDate: now, isEnabled: false, startDate: now }
-  }
-
   // The window a holiday card applies: start = now, end = `days` calendar
   // days after today at `endTime` (default 00:00 — the start of that day,
   // not 24:00). The end is rejected when it is not after now (e.g. 0 days
@@ -1257,13 +1229,9 @@ export default class MELCloudApp extends App {
     }
   }
 
-  async #initClassicApi(config: {
-    language: string
-    locale: string
-    timezone: string
-  }): Promise<void> {
+  async #initClassicApi(): Promise<void> {
+    const language = this.homey.i18n.getLanguage()
     this.#classicApi = await Classic.API.create({
-      ...config,
       abortSignal: this.#abortController.signal,
       events: {
         onSyncComplete: this.#onSync,
@@ -1274,9 +1242,12 @@ export default class MELCloudApp extends App {
           this.#notifySessionRestored('classic')
         },
       },
+      language,
+      locale: language,
       logger: this,
       settingManager: this.#createSettingManager(),
       shouldResumeSessionInBackground: true,
+      timezone: getTimeZone(this.homey),
     })
     this.#facadeManager = new Classic.FacadeManager(this.#classicApi)
     setClassicFacadeManager(this.#facadeManager)
@@ -1372,7 +1343,7 @@ export default class MELCloudApp extends App {
       const days = this.#holidayModeDays(duration)
       return days > HOLIDAY_MODE_OFF_DURATION
         ? this.#holidayModeWindow(days)
-        : this.#holidayModeOff()
+        : { isEnabled: false }
     })
     this.#registerHolidayModeCard(
       'holiday_mode_with_time_action',
@@ -1382,22 +1353,22 @@ export default class MELCloudApp extends App {
           this.#holidayModeEndTime(time),
         ),
     )
-    this.#registerHolidayModeCard('holiday_mode_false_action', () =>
-      this.#holidayModeOff(),
-    )
+    this.#registerHolidayModeCard('holiday_mode_false_action', () => ({
+      isEnabled: false,
+    }))
     this.#registerHolidayModeCondition()
   }
 
   #registerHolidayModeCard(
     id: string,
-    toSettings: (args: HolidayModeActionArgs) => HolidayModeUpdate,
+    toSettings: (args: HolidayModeActionArgs) => HolidayModeSettings,
   ): void {
     const card = this.homey.flow.getActionCard(id)
     card.registerArgumentAutocompleteListener('zone', (query) =>
       this.#searchHolidayModeTargets(query),
     )
     card.registerRunListener(async (args: HolidayModeActionArgs) => {
-      await this.#updateHolidayModeTarget(args.zone.id, toSettings(args))
+      await this.updateTargetHolidayMode(args.zone.id, toSettings(args))
     })
   }
 
@@ -1466,14 +1437,5 @@ export default class MELCloudApp extends App {
     this.#sessionLossStates.delete(api)
     this.log('Session lost on', api, 'ignored: no paired device')
     return false
-  }
-
-  // Route a holiday-mode write from a flat target value: the option
-  // value IS the targetId the neutral write takes.
-  async #updateHolidayModeTarget(
-    value: string,
-    settings: HolidayModeUpdate,
-  ): Promise<void> {
-    await this.updateTargetHolidayMode(value, settings)
   }
 }

--- a/drivers/home-melcloud_atw/device.mts
+++ b/drivers/home-melcloud_atw/device.mts
@@ -2,15 +2,16 @@ import type * as Home from '@olivierzal/melcloud-api/home'
 
 import type { HomeEnergyMeasureName } from '../../types/device.mts'
 import type {
-  HomeCapabilitiesAtw,
-  HomeSetCapabilitiesAtw,
-} from '../../types/home-atw.mts'
-import type {
   HomeConvertFromDevice,
   HomeConvertToDevice,
 } from '../../types/home.mts'
 import type { EnergyReportConfig } from '../base-report.mts'
 import { HotWaterMode } from '../../types/atw.mts'
+import {
+  type HomeCapabilitiesAtw,
+  type HomeSetCapabilitiesAtw,
+  hasAtwEnergyDirection,
+} from '../../types/home-atw.mts'
 import { HomeMELCloudDevice } from '../home-device.mts'
 import { HomeEnergyReportAtw } from '../home-report-atw.mts'
 
@@ -89,10 +90,6 @@ export default class HomeMELCloudDeviceAtw extends HomeMELCloudDevice<AtwType> {
     if (capabilities === undefined) {
       return true
     }
-    return measure === 'consumed'
-      ? capabilities.hasEstimatedEnergyConsumption ||
-          capabilities.hasMeasuredEnergyConsumption
-      : capabilities.hasEstimatedEnergyProduction ||
-          capabilities.hasMeasuredEnergyProduction
+    return hasAtwEnergyDirection(capabilities, measure)
   }
 }

--- a/drivers/home-melcloud_atw/driver.mts
+++ b/drivers/home-melcloud_atw/driver.mts
@@ -3,6 +3,7 @@ import * as Home from '@olivierzal/melcloud-api/home'
 import {
   type HomeAtwDeviceProfile,
   type HomeCapabilitiesAtw,
+  hasAtwEnergyDirection,
   homeGetCapabilitiesOptionsAtw,
   homeTagMappingsAtw,
 } from '../../types/home-atw.mts'
@@ -12,22 +13,15 @@ import { HomeMELCloudDriver } from '../home-driver.mts'
 // user toggle: each capability appears when the unit can report its
 // direction. Consumed power/meters need a consumption estimate or
 // meter; produced ones a production one; COP needs both.
-const hasEnergyDirection = (
-  capabilities: HomeAtwDeviceProfile['capabilities'] | undefined,
-  flags: readonly (keyof NonNullable<HomeAtwDeviceProfile['capabilities']>)[],
-): boolean => flags.some((flag) => capabilities?.[flag] === true)
-
 const energyCapabilities = (
   capabilities: HomeAtwDeviceProfile['capabilities'] | undefined,
 ): string[] => {
-  const hasConsumed = hasEnergyDirection(capabilities, [
-    'hasEstimatedEnergyConsumption',
-    'hasMeasuredEnergyConsumption',
-  ])
-  const hasProduced = hasEnergyDirection(capabilities, [
-    'hasEstimatedEnergyProduction',
-    'hasMeasuredEnergyProduction',
-  ])
+  const hasConsumed =
+    capabilities !== undefined &&
+    hasAtwEnergyDirection(capabilities, 'consumed')
+  const hasProduced =
+    capabilities !== undefined &&
+    hasAtwEnergyDirection(capabilities, 'produced')
   return [
     ...(hasConsumed
       ? ['measure_power', 'meter_power', 'meter_power.daily']

--- a/lib/classic-facade-manager.mts
+++ b/lib/classic-facade-manager.mts
@@ -17,4 +17,4 @@ export const setClassicFacadeManager = (value: Classic.FacadeManager): void => {
 export const getClassicBuildings = ({
   type,
 }: { type?: Classic.DeviceType | undefined } = {}): Classic.BuildingZone[] =>
-  getClassicFacadeManager().getBuildings(type === undefined ? {} : { type })
+  getClassicFacadeManager().getBuildings({ type })

--- a/settings/index.mts
+++ b/settings/index.mts
@@ -1699,7 +1699,7 @@ class ZoneSettingsManager {
   }
 
   // The picker value IS the targetId of the neutral settings routes:
-  // addressing needs no family branch at all anymore.
+  // addressing needs no family branch.
   #getZoneSettingsBase(): string {
     return `/targets/${this.#zone.value}`
   }

--- a/tests/unit/api.test.ts
+++ b/tests/unit/api.test.ts
@@ -34,8 +34,6 @@ vi.mock(import('../../lib/classic-facade-manager.mts'), () => ({
 
 const { default: api } = await import('../../api.mts')
 
-const mockIsAuthenticated = vi.fn<() => boolean>()
-const mockIsHomeAuthenticated = vi.fn<() => boolean>()
 const mockEnsureClassicAuthenticated = vi.fn<() => Promise<boolean>>()
 const mockEnsureHomeAuthenticated = vi.fn<() => Promise<boolean>>()
 const mockGetHomeBuildings = vi.fn<Home.Registry['getBuildings']>()
@@ -48,14 +46,12 @@ const mockApp = {
   classicApi: {
     authenticate: mockClassicAuthenticate,
     ensureAuthenticated: mockEnsureClassicAuthenticated,
-    isAuthenticated: mockIsAuthenticated,
     logOut: mockClassicLogOut,
   },
   error: vi.fn<(...args: readonly unknown[]) => void>(),
   getDeviceSettings: vi.fn<() => DeviceSettings>(),
   getDriverSettings: vi.fn<() => Partial<Record<string, DriverSetting[]>>>(),
   getErrorLog: vi.fn<() => Promise<FormattedErrorLog>>(),
-  getHomeDeviceZones: vi.fn<() => HomeDeviceZone[]>(),
   getHomeTargets: vi.fn<() => (HomeBuildingZone | HomeDeviceZone)[]>(),
   getTargetFrostProtection: vi.fn<() => Promise<ProtectionState | null>>(),
   getTargetHolidayMode: vi.fn<() => Promise<HolidayModeState | null>>(),
@@ -63,7 +59,6 @@ const mockApp = {
   homeApi: {
     authenticate: mockHomeAuthenticate,
     ensureAuthenticated: mockEnsureHomeAuthenticated,
-    isAuthenticated: mockIsHomeAuthenticated,
     logOut: mockHomeLogOut,
     registry: { getBuildings: mockGetHomeBuildings },
   },
@@ -253,15 +248,6 @@ describe('api', () => {
     })
   })
 
-  describe('home devices retrieval', () => {
-    it('should delegate to app.getHomeDeviceZones', () => {
-      const devices = [mock<HomeDeviceZone>({ id: 'guid-1' })]
-      mockApp.getHomeDeviceZones.mockReturnValue(devices)
-
-      expect(api.getHomeDevices({ homey })).toBe(devices)
-    })
-  })
-
   describe('home targets retrieval', () => {
     it('should delegate to app.getHomeTargets', () => {
       const targets = [mock<HomeBuildingZone>({ id: 'b1' })]
@@ -276,7 +262,7 @@ describe('api', () => {
       'getTargetFrostProtection',
       'getTargetHolidayMode',
       'getTargetOverheatProtection',
-    ] as const)('delegates %s with the raw targetId', async (handler) => {
+    ] as const)('should delegate %s with the raw targetId', async (handler) => {
       const value = mock<HolidayModeState & ProtectionState>()
       mockApp[handler].mockResolvedValue(value)
 
@@ -294,16 +280,19 @@ describe('api', () => {
     it.each([
       'updateTargetFrostProtection',
       'updateTargetOverheatProtection',
-    ] as const)('delegates %s with targetId and body', async (handler) => {
-      const body = { isEnabled: true, max: 16, min: 4 }
-      mockApp[handler].mockResolvedValue()
+    ] as const)(
+      'should delegate %s with targetId and body',
+      async (handler) => {
+        const body = { isEnabled: true, max: 16, min: 4 }
+        mockApp[handler].mockResolvedValue()
 
-      await api[handler]({ body, homey, params: { targetId: 'buildings_1' } })
+        await api[handler]({ body, homey, params: { targetId: 'buildings_1' } })
 
-      expect(mockApp[handler]).toHaveBeenCalledWith('buildings_1', body)
-    })
+        expect(mockApp[handler]).toHaveBeenCalledWith('buildings_1', body)
+      },
+    )
 
-    it('delegates updateTargetHolidayMode with targetId and body', async () => {
+    it('should delegate updateTargetHolidayMode with targetId and body', async () => {
       const body = mock<HolidayModeUpdate>()
       mockApp.updateTargetHolidayMode.mockResolvedValue()
 
@@ -336,14 +325,6 @@ describe('api', () => {
 
       expect(result).toBe('en')
       expect(mockI18n.getLanguage).toHaveBeenCalledTimes(1)
-    })
-
-    it('should return non-English language', () => {
-      mockI18n.getLanguage.mockReturnValue('fr')
-
-      const result = api.getLanguage({ homey })
-
-      expect(result).toBe('fr')
     })
   })
 

--- a/tests/unit/app.test.ts
+++ b/tests/unit/app.test.ts
@@ -71,17 +71,16 @@ vi.mock(import('../../files.mts'), async (importOriginal) => {
   })
 })
 
+// The registry mocks model only what app.mts still reads directly:
+// device names for the error log and the per-type device listings —
+// facade lookups go through the facade managers.
 const mockApiInstance = {
   authenticate: vi.fn<() => Promise<void>>(),
   clearSync: vi.fn<() => void>(),
   getErrorLog: vi.fn<() => Promise<Result<Classic.ErrorLog>>>(),
   isAuthenticated: vi.fn<() => boolean>().mockReturnValue(true),
   registry: {
-    areas: { getById: vi.fn<(id: number) => unknown>() },
-    buildings: { getById: vi.fn<(id: number) => unknown>() },
     devices: { getById: vi.fn<(id: number) => unknown>() },
-    floors: { getById: vi.fn<(id: number) => unknown>() },
-    getDevices: vi.fn<() => unknown[]>().mockReturnValue([]),
     getDevicesByType: vi
       .fn<(type: Classic.DeviceType) => unknown[]>()
       .mockReturnValue([]),
@@ -89,16 +88,9 @@ const mockApiInstance = {
 }
 
 const mockHomeRegistry = {
-  getBuildings: vi
-    .fn<(params?: { type?: Home.DeviceType }) => unknown[]>()
-    .mockReturnValue([]),
-  getById: vi.fn<(id: string) => unknown>(),
   getDevices: vi.fn<() => unknown[]>().mockReturnValue([]),
   getDevicesByType: vi
     .fn<(type: Home.DeviceType) => unknown[]>()
-    .mockReturnValue([]),
-  getZones: vi
-    .fn<(params?: { type?: Home.DeviceType }) => unknown[]>()
     .mockReturnValue([]),
 }
 
@@ -109,20 +101,16 @@ const mockHomeApiInstance = {
   registry: mockHomeRegistry,
 }
 
-const mockFacadeManagerGet = vi.fn<(instance: unknown) => unknown>()
+const mockFacadeManagerGetById =
+  vi.fn<(zoneType: string, id: number) => unknown>()
 const mockFacadeManagerGetZones = vi
   .fn<(options?: { type?: Classic.DeviceType }) => unknown[]>()
   .mockReturnValue([])
 const mockHomeFacadeManagerGet = vi.fn<(model: unknown) => unknown>()
+const mockHomeFacadeManagerGetById = vi.fn<(id: string) => unknown>()
 const mockHomeFacadeManagerGetZones =
   vi.fn<(params?: { type?: Home.DeviceType }) => unknown[]>()
 const mockHomeFacadeManagerGetBuilding = vi.fn<(id: string) => unknown>()
-const mockHomeFacadeManagerUpdateFrostProtection =
-  vi.fn<Home.FacadeManager['updateFrostProtection']>()
-const mockHomeFacadeManagerUpdateHolidayMode =
-  vi.fn<Home.FacadeManager['updateHolidayMode']>()
-const mockHomeFacadeManagerUpdateOverheatProtection =
-  vi.fn<Home.FacadeManager['updateOverheatProtection']>()
 
 const {
   mockCreate,
@@ -289,7 +277,7 @@ const mockManifestDrivers: ManifestDriver[] = [
 const newMockFacadeManager =
   function newMockFacadeManager(): Classic.FacadeManager {
     return mock<Classic.FacadeManager>({
-      get: mockFacadeManagerGet,
+      getById: mockFacadeManagerGetById,
       getZones: mockFacadeManagerGetZones,
     })
   }
@@ -299,10 +287,8 @@ const newMockHomeFacadeManager =
     return mock<Home.FacadeManager>({
       get: mockHomeFacadeManagerGet,
       getBuilding: mockHomeFacadeManagerGetBuilding,
+      getById: mockHomeFacadeManagerGetById,
       getZones: mockHomeFacadeManagerGetZones,
-      updateFrostProtection: mockHomeFacadeManagerUpdateFrostProtection,
-      updateHolidayMode: mockHomeFacadeManagerUpdateHolidayMode,
-      updateOverheatProtection: mockHomeFacadeManagerUpdateOverheatProtection,
     })
   }
 
@@ -375,8 +361,7 @@ const initWithFacade = async (
   app: InstanceType<typeof MelCloudApp>,
   facade: Classic.BuildingFacade | Classic.ZoneFacade,
 ): Promise<void> => {
-  mockFacadeManagerGet.mockReturnValue(facade)
-  mockApiInstance.registry.buildings.getById.mockReturnValue({ id: 1 })
+  mockFacadeManagerGetById.mockReturnValue(facade)
   await app.onInit()
 }
 
@@ -385,14 +370,13 @@ const initWithDeviceFacade = async (
   method: string,
   mockData: unknown,
 ): Promise<void> => {
-  mockFacadeManagerGet.mockReturnValue(
+  mockFacadeManagerGetById.mockReturnValue(
     mock({
       [method]: vi
         .fn<() => Promise<Result<unknown>>>()
         .mockResolvedValue(ok(mockData)),
     }),
   )
-  mockApiInstance.registry.devices.getById.mockReturnValue({ id: 1 })
   await app.onInit()
 }
 
@@ -407,19 +391,15 @@ const initWithHomeDeviceFacade = async ({
   mockData: unknown
   type?: Home.DeviceType
 }): Promise<void> => {
-  mockHomeFacadeManagerGet.mockReturnValue(
+  // The facade carries its own `type`: the typed routes gate on it.
+  mockHomeFacadeManagerGetById.mockReturnValue(
     mock({
       [method]: vi
         .fn<() => Promise<Result<unknown>>>()
         .mockResolvedValue(ok(mockData)),
+      type,
     }),
   )
-  mockHomeRegistry.getById.mockReturnValue({
-    id: 'guid-1',
-    type,
-    isAta: (): boolean => type === Home.DeviceType.Ata,
-    isAtw: (): boolean => type === Home.DeviceType.Atw,
-  })
   await app.onInit()
 }
 
@@ -539,12 +519,16 @@ const stubHomeZones = (
 }
 
 const stubHomeDevice = (facade: unknown): void => {
-  mockHomeRegistry.getById.mockReturnValue({
-    id: 'guid-1',
-    isAta: (): boolean => true,
-    isAtw: (): boolean => false,
-  })
-  mockHomeFacadeManagerGet.mockReturnValue(facade)
+  mockHomeFacadeManagerGetById.mockReturnValue(facade)
+}
+
+// The ATA routes gate on the facade's own `type`.
+const setupHomeAtaFacade = (
+  overrides: Partial<Record<keyof Home.DeviceAtaFacade, unknown>>,
+): void => {
+  mockHomeFacadeManagerGetById.mockReturnValue(
+    mock<Home.DeviceAtaFacade>({ type: Home.DeviceType.Ata, ...overrides }),
+  )
 }
 
 const getSyncCallbackFrom = (
@@ -585,8 +569,10 @@ describe('melCloudApp', () => {
     setupMocks()
     mockSettingsGet.mockReturnValue(null)
     mockGetDrivers.mockReturnValue({})
+    mockFacadeManagerGetById.mockReturnValue(null)
     mockFacadeManagerGetZones.mockReturnValue([])
     mockApiInstance.isAuthenticated.mockReturnValue(true)
+    mockHomeFacadeManagerGetById.mockReturnValue(null)
     mockHomeRegistry.getDevices.mockReturnValue([])
     mockHomeRegistry.getDevicesByType.mockReturnValue([])
     app = createApp()
@@ -1116,8 +1102,7 @@ describe('melCloudApp', () => {
           .mockResolvedValue(ok(mockGroupState)),
         type: Classic.DeviceType.Ata,
       })
-      mockFacadeManagerGet.mockReturnValue(mockFacade)
-      mockApiInstance.registry.devices.getById.mockReturnValue({ id: 1 })
+      mockFacadeManagerGetById.mockReturnValue(mockFacade)
       await app.onInit()
 
       const groupState = await app.getClassicAtaState({
@@ -1126,16 +1111,15 @@ describe('melCloudApp', () => {
       })
 
       expect(groupState).toBe(mockGroupState)
-      expect(mockApiInstance.registry.devices.getById).toHaveBeenCalledWith(1)
+      expect(mockFacadeManagerGetById).toHaveBeenCalledWith('devices', 1)
     })
 
     it('should reject a non-ata device as group target', async () => {
-      mockFacadeManagerGet.mockReturnValue(
+      mockFacadeManagerGetById.mockReturnValue(
         mock<Classic.DeviceFacade<typeof Classic.DeviceType.Atw>>({
           type: Classic.DeviceType.Atw,
         }),
       )
-      mockApiInstance.registry.devices.getById.mockReturnValue({ id: 1 })
       await app.onInit()
 
       await expect(
@@ -1292,18 +1276,12 @@ describe('melCloudApp', () => {
         message?: string
       }[],
     ): void => {
-      mockHomeRegistry.getDevicesByType.mockImplementation((type) =>
-        type === Home.DeviceType.Ata ? [homeAtaDevice] : [],
-      )
-      mockHomeRegistry.getById.mockReturnValue({
-        type: Home.DeviceType.Ata,
-        isAta: () => true,
-        isAtw: () => false,
-      })
-      mockHomeFacadeManagerGet.mockReturnValue({
+      mockHomeRegistry.getDevices.mockReturnValue([homeAtaDevice])
+      mockHomeFacadeManagerGetById.mockReturnValue({
         getErrorLog: vi
           .fn<() => Promise<unknown>>()
           .mockResolvedValue(ok(entries)),
+        type: Home.DeviceType.Ata,
       })
     }
 
@@ -1407,18 +1385,12 @@ describe('melCloudApp', () => {
       mockApiInstance.registry.devices.getById.mockReturnValue({
         name: 'Living Room',
       })
-      mockHomeRegistry.getDevicesByType.mockImplementation((type) =>
-        type === Home.DeviceType.Ata ? [homeAtaDevice] : [],
-      )
-      mockHomeRegistry.getById.mockReturnValue({
-        type: Home.DeviceType.Ata,
-        isAta: () => true,
-        isAtw: () => false,
-      })
-      mockHomeFacadeManagerGet.mockReturnValue({
+      mockHomeRegistry.getDevices.mockReturnValue([homeAtaDevice])
+      mockHomeFacadeManagerGetById.mockReturnValue({
         getErrorLog: vi
           .fn<() => Promise<unknown>>()
           .mockResolvedValue(err({ kind: 'network' })),
+        type: Home.DeviceType.Ata,
       })
       const errorSpy = vi.fn<(...args: unknown[]) => void>()
       await app.onInit()
@@ -1437,6 +1409,10 @@ describe('melCloudApp', () => {
       )
     })
 
+    // The window tiling itself is melcloud-api's (resolveErrorLogWindow,
+    // kernel-pinned there since 50.0.0); what belongs here is the wiring:
+    // signed out, the app skips the Classic fetch, filters the Home
+    // entries into the queried window and keeps the paging fields.
     it('should serve a synthetic window with Home errors when Classic is signed out', async () => {
       mockApiInstance.isAuthenticated.mockReturnValue(false)
       stubHomeAtaDevice([
@@ -1457,11 +1433,13 @@ describe('melCloudApp', () => {
       expect(errorLog.errors.map(({ device }) => device)).toStrictEqual([
         'Studeerkamer',
       ])
-      expect(errorLog.nextToDate).toBe('2026-03-01')
-      expect(errorLog.nextFromDate).toBe('2026-01-31')
+      expect(errorLog.nextToDate).toMatch(/^\d{4}-\d{2}-\d{2}$/v)
+      expect(errorLog.nextFromDate).toMatch(/^\d{4}-\d{2}-\d{2}$/v)
     })
 
-    it('should anchor the synthetic window on today when no upper bound is given', async () => {
+    // An empty `to` is the webview's "no upper bound": the window stays
+    // open-ended and the synthetic page still carries its paging fields.
+    it('should serve an open-ended synthetic window for an empty upper bound', async () => {
       mockApiInstance.isAuthenticated.mockReturnValue(false)
       await app.onInit()
 
@@ -1472,34 +1450,6 @@ describe('melCloudApp', () => {
       expect(mockApiInstance.getErrorLog).not.toHaveBeenCalled()
       expect(errorLog.errors).toStrictEqual([])
       expect(errorLog.nextToDate).toMatch(/^\d{4}-\d{2}-\d{2}$/v)
-    })
-
-    it('should pin the synthetic window on a user-picked "since" date', async () => {
-      mockApiInstance.isAuthenticated.mockReturnValue(false)
-      stubHomeAtaDevice([
-        {
-          at: '2026-01-05T10:00:00Z',
-          code: 'E101',
-          deviceId: 'guid-1',
-          message: 'Sensor failure',
-        },
-      ])
-      await app.onInit()
-
-      const errorLog = await app.getErrorLog(
-        mock<Classic.ErrorLogQuery>({
-          from: '2026-01-01',
-          period: 29,
-          to: '2026-03-31',
-        }),
-      )
-
-      // The window starts at the picked date — mirroring the library's
-      // Classic path — so older-than-default Home errors still show.
-      expect(errorLog.errors.map(({ device }) => device)).toStrictEqual([
-        'Studeerkamer',
-      ])
-      expect(errorLog.nextToDate).toBe('2025-12-31')
     })
 
     it('should format dates and resolve device names from api error log', async () => {
@@ -1560,19 +1510,17 @@ describe('melCloudApp', () => {
 
   describe('facade retrieval', () => {
     it('should return facade for a valid zone', async () => {
-      const mockInstance = { id: 1 }
       const mockFacade = mock<Classic.BuildingFacade>()
-      mockApiInstance.registry.buildings.getById.mockReturnValue(mockInstance)
-      mockFacadeManagerGet.mockReturnValue(mockFacade)
+      mockFacadeManagerGetById.mockReturnValue(mockFacade)
       await app.onInit()
 
       const facade = app.getClassicFacade('buildings', '1')
 
       expect(facade).toBe(mockFacade)
+      expect(mockFacadeManagerGetById).toHaveBeenCalledWith('buildings', 1)
     })
 
     it('should throw for zone not found', async () => {
-      mockApiInstance.registry.buildings.getById.mockReset()
       await app.onInit()
 
       expect(() => app.getClassicFacade('buildings', '999')).toThrow(
@@ -1582,7 +1530,6 @@ describe('melCloudApp', () => {
     })
 
     it('should throw with device error for device type', async () => {
-      mockApiInstance.registry.devices.getById.mockReset()
       await app.onInit()
 
       expect(() => app.getClassicFacade('devices', '999')).toThrow(
@@ -1623,49 +1570,32 @@ describe('melCloudApp', () => {
   })
 
   describe('home facade retrieval', () => {
-    const mockAtaModel = {
-      id: 'device-1',
-      name: 'Living Room',
-      type: Home.DeviceType.Ata,
-      isAta: (): boolean => true,
-      isAtw: (): boolean => false,
-    }
-
-    const mockAtwModel = {
-      id: 'device-1',
-      name: 'Heat Pump',
-      type: Home.DeviceType.Atw,
-      isAta: (): boolean => false,
-      isAtw: (): boolean => true,
-    }
-
     it('should return an ATA facade for a matching ATA device', async () => {
-      const mockFacade = mock<Home.DeviceAtaFacade>()
-      mockHomeRegistry.getById.mockReturnValue(mockAtaModel)
-      mockHomeFacadeManagerGet.mockReturnValue(mockFacade)
+      const mockFacade = mock<Home.DeviceAtaFacade>({
+        type: Home.DeviceType.Ata,
+      })
+      mockHomeFacadeManagerGetById.mockReturnValue(mockFacade)
       await app.onInit()
 
       const facade = app.getHomeFacade('device-1', Home.DeviceType.Ata)
 
       expect(facade).toBe(mockFacade)
-      expect(mockHomeFacadeManagerGet).toHaveBeenCalledWith(mockAtaModel)
-      expect(mockHomeRegistry.getById).toHaveBeenCalledWith('device-1')
+      expect(mockHomeFacadeManagerGetById).toHaveBeenCalledWith('device-1')
     })
 
     it('should return an ATW facade for a matching ATW device', async () => {
-      const mockFacade = mock<Home.DeviceAtwFacade>()
-      mockHomeRegistry.getById.mockReturnValue(mockAtwModel)
-      mockHomeFacadeManagerGet.mockReturnValue(mockFacade)
+      const mockFacade = mock<Home.DeviceAtwFacade>({
+        type: Home.DeviceType.Atw,
+      })
+      mockHomeFacadeManagerGetById.mockReturnValue(mockFacade)
       await app.onInit()
 
       const facade = app.getHomeFacade('device-1', Home.DeviceType.Atw)
 
       expect(facade).toBe(mockFacade)
-      expect(mockHomeFacadeManagerGet).toHaveBeenCalledWith(mockAtwModel)
     })
 
-    it('should throw when device is not found in registry', async () => {
-      mockHomeRegistry.getById.mockReset()
+    it('should throw when the device is unknown', async () => {
       await app.onInit()
 
       expect(() => app.getHomeFacade('device-1', Home.DeviceType.Ata)).toThrow(
@@ -1675,19 +1605,9 @@ describe('melCloudApp', () => {
     })
 
     it('should throw when the device type does not match', async () => {
-      mockHomeRegistry.getById.mockReturnValue(mockAtwModel)
-      await app.onInit()
-
-      expect(() => app.getHomeFacade('device-1', Home.DeviceType.Ata)).toThrow(
-        'errors.deviceNotFound',
+      mockHomeFacadeManagerGetById.mockReturnValue(
+        mock<Home.DeviceAtwFacade>({ type: Home.DeviceType.Atw }),
       )
-    })
-
-    it('should throw when the model matches neither ATA nor ATW', async () => {
-      mockHomeRegistry.getById.mockReturnValue({
-        ...mockAtaModel,
-        isAta: (): boolean => false,
-      })
       await app.onInit()
 
       expect(() => app.getHomeFacade('device-1', Home.DeviceType.Ata)).toThrow(
@@ -1726,14 +1646,6 @@ describe('melCloudApp', () => {
   })
 
   describe('home ata state', () => {
-    const mockAtaModel = {
-      id: 'device-1',
-      name: 'Living Room',
-      type: Home.DeviceType.Ata,
-      isAta: (): boolean => true,
-      isAtw: (): boolean => false,
-    }
-
     const groupState = {
       FanSpeed: Classic.FanSpeed.slow,
       OperationMode: Classic.OperationMode.cool,
@@ -1743,19 +1655,12 @@ describe('melCloudApp', () => {
       VaneVerticalDirection: Classic.Vertical.swing,
     }
 
-    const setupHomeAtaFacade = (facade: Home.DeviceAtaFacade): void => {
-      mockHomeRegistry.getById.mockReturnValue(mockAtaModel)
-      mockHomeFacadeManagerGet.mockReturnValue(facade)
-    }
-
     it('should return the facade group state', async () => {
-      setupHomeAtaFacade(
-        mock<Home.DeviceAtaFacade>({
-          getGroup: vi
-            .fn<() => Promise<unknown>>()
-            .mockResolvedValue({ ok: true, value: groupState }),
-        }),
-      )
+      setupHomeAtaFacade({
+        getGroup: vi
+          .fn<() => Promise<unknown>>()
+          .mockResolvedValue({ ok: true, value: groupState }),
+      })
       await app.onInit()
 
       await expect(app.getHomeAtaState('device-1')).resolves.toStrictEqual(
@@ -1767,9 +1672,7 @@ describe('melCloudApp', () => {
       const mockUpdateGroupState = vi
         .fn<(state: unknown) => Promise<unknown>>()
         .mockResolvedValue({ AttributeErrors: null, Success: true })
-      setupHomeAtaFacade(
-        mock<Home.DeviceAtaFacade>({ updateGroupState: mockUpdateGroupState }),
-      )
+      setupHomeAtaFacade({ updateGroupState: mockUpdateGroupState })
       await app.onInit()
 
       await app.updateHomeAtaState({
@@ -1784,13 +1687,11 @@ describe('melCloudApp', () => {
     })
 
     it('should swallow a no-changes rejection', async () => {
-      setupHomeAtaFacade(
-        mock<Home.DeviceAtaFacade>({
-          updateGroupState: vi
-            .fn<(state: unknown) => Promise<unknown>>()
-            .mockRejectedValue(new NoChangesError('device-1')),
-        }),
-      )
+      setupHomeAtaFacade({
+        updateGroupState: vi
+          .fn<(state: unknown) => Promise<unknown>>()
+          .mockRejectedValue(new NoChangesError('device-1')),
+      })
       await app.onInit()
 
       await expect(
@@ -1802,13 +1703,11 @@ describe('melCloudApp', () => {
     })
 
     it('should propagate other update failures', async () => {
-      setupHomeAtaFacade(
-        mock<Home.DeviceAtaFacade>({
-          updateGroupState: vi
-            .fn<(state: unknown) => Promise<unknown>>()
-            .mockRejectedValue(new Error('BFF failure')),
-        }),
-      )
+      setupHomeAtaFacade({
+        updateGroupState: vi
+          .fn<(state: unknown) => Promise<unknown>>()
+          .mockRejectedValue(new Error('BFF failure')),
+      })
       await app.onInit()
 
       await expect(
@@ -1878,8 +1777,10 @@ describe('melCloudApp', () => {
       mockHomeFacadeManagerGetBuilding.mockReturnValue(null)
       await app.onInit()
 
+      // A Home building is a zone in the picker vocabulary, so a missing
+      // one answers the same error class as its Classic counterpart.
       await expect(app.getHomeBuildingAtaState('missing')).rejects.toThrow(
-        'errors.deviceNotFound',
+        'errors.zoneNotFound',
       )
     })
   })
@@ -2006,8 +1907,7 @@ describe('melCloudApp', () => {
         const getEnergyReport = vi
           .fn<() => Promise<Result<unknown>>>()
           .mockResolvedValue(ok(mock<ReportChartLineOptions>()))
-        mockFacadeManagerGet.mockReturnValue(mock({ getEnergyReport }))
-        mockApiInstance.registry.devices.getById.mockReturnValue({ id: 1 })
+        mockFacadeManagerGetById.mockReturnValue(mock({ getEnergyReport }))
         await app.onInit()
 
         await app.getClassicEnergyReport({ days: 2, deviceId: '1' })
@@ -2035,13 +1935,7 @@ describe('melCloudApp', () => {
         const getEnergyReport = vi
           .fn<() => Promise<Result<unknown>>>()
           .mockResolvedValue(ok(mock<ReportChartLineOptions>()))
-        mockHomeFacadeManagerGet.mockReturnValue(mock({ getEnergyReport }))
-        mockHomeRegistry.getById.mockReturnValue({
-          id: 'guid-1',
-          type: Home.DeviceType.Ata,
-          isAta: (): boolean => true,
-          isAtw: (): boolean => false,
-        })
+        mockHomeFacadeManagerGetById.mockReturnValue(mock({ getEnergyReport }))
         await app.onInit()
 
         await app.getHomeEnergyReport({ days: 0, deviceId: 'guid-1' })
@@ -2103,7 +1997,7 @@ describe('melCloudApp', () => {
     })
 
     it('should reject an unknown Home device', async () => {
-      mockHomeRegistry.getById.mockReturnValue(undefined)
+      mockHomeFacadeManagerGetById.mockReturnValue(null)
       await app.onInit()
 
       await expect(app.getHomeSignal({ deviceId: 'missing' })).rejects.toThrow(
@@ -3373,20 +3267,6 @@ describe('melCloudApp', () => {
       const callback = getMockCallArg<() => Promise<void>>(mockSetTimeout, 0, 0)
 
       await expect(callback()).resolves.toBeUndefined()
-    })
-  })
-
-  describe('device filtering by ids', () => {
-    it('should filter devices by ids', async () => {
-      setupDriver([
-        createClassicDevice({ id: 1 }),
-        createClassicDevice({ id: 2 }),
-      ])
-      await app.onInit()
-
-      const deviceSettings = app.getDeviceSettings()
-
-      expect(deviceSettings).toBeDefined()
     })
   })
 

--- a/tests/unit/classic-device.test.ts
+++ b/tests/unit/classic-device.test.ts
@@ -578,6 +578,32 @@ describe(ClassicMELCloudDevice, () => {
 
       expect(superRemoveCapabilityMock).toHaveBeenCalledWith('fan_speed')
     })
+
+    // The opt-in rule at the init-reconciliation call site: the raw
+    // required list carries measure_signal_strength (and the manifest
+    // declares it), yet only the shared options setting may add it.
+    it('should not add the opt-in measure_signal_strength from the required list', async () => {
+      const driverWithSignal = Object.create(mockDriver) as typeof mockDriver
+      Object.assign(driverWithSignal, {
+        getRequiredCapabilities: vi
+          .fn<() => string[]>()
+          .mockReturnValue(['onoff', 'measure_signal_strength']),
+        manifest: mock({
+          capabilities: ['onoff', 'measure_signal_strength'],
+          id: 'test',
+        }),
+      })
+      setDriver(device, driverWithSignal)
+      vi.spyOn(device, 'getSettings').mockReturnValue({})
+      vi.spyOn(device, 'getCapabilities').mockReturnValue([])
+      vi.spyOn(device, 'hasCapability').mockReturnValue(false)
+      await device.onInit()
+
+      expect(superAddCapabilityMock).toHaveBeenCalledWith('onoff')
+      expect(superAddCapabilityMock).not.toHaveBeenCalledWith(
+        'measure_signal_strength',
+      )
+    })
   })
 
   describe('capability options setup', () => {

--- a/tests/unit/classic-driver.test.ts
+++ b/tests/unit/classic-driver.test.ts
@@ -85,6 +85,26 @@ vi.mock(import('homey'), async () => {
   })
 })
 
+const createListDevicesSession = (): {
+  listHandler: ReturnType<typeof vi.fn<(...args: unknown[]) => unknown>>
+  session: PairSession
+} => {
+  const listHandler = vi.fn<(...args: unknown[]) => unknown>()
+  const session = mock<PairSession>({
+    setHandler: vi
+      .fn<(event: string, handler: (...args: unknown[]) => unknown) => void>()
+      .mockImplementation(
+        (event: string, handler: (...args: unknown[]) => unknown) => {
+          if (event === 'list_devices') {
+            listHandler.mockImplementation(handler)
+          }
+        },
+      ),
+    showView: showViewMock,
+  })
+  return { listHandler, session }
+}
+
 describe(ClassicMELCloudDriver, () => {
   let driver: TestDriver
 
@@ -93,6 +113,16 @@ describe(ClassicMELCloudDriver, () => {
 
     driver = createTestDriver()
   })
+
+  const stubDiscoverableDevice = (): void => {
+    vi.spyOn(driver.homey.app, 'getDevicesByType').mockReturnValue([
+      mock<Classic.Device<TestDriverType>>({
+        data: { Power: true },
+        id: 1,
+        name: 'Device 1',
+      }),
+    ])
+  }
 
   describe('initialization', () => {
     it('should set produced and consumed tag mappings', async () => {
@@ -114,34 +144,36 @@ describe(ClassicMELCloudDriver, () => {
 
   describe('device discovery', () => {
     it('should discover devices on list_devices handler', async () => {
-      const listHandler = vi.fn<(...args: unknown[]) => unknown>()
-      const session = mock<PairSession>({
-        setHandler: vi
-          .fn<
-            (event: string, handler: (...args: unknown[]) => unknown) => void
-          >()
-          .mockImplementation(
-            (event: string, handler: (...args: unknown[]) => unknown) => {
-              if (event === 'list_devices') {
-                listHandler.mockImplementation(handler)
-              }
-            },
-          ),
-        showView: showViewMock,
-      })
-      vi.spyOn(driver.homey.app, 'getDevicesByType').mockReturnValue([
-        mock<Classic.Device<TestDriverType>>({
-          data: { Power: true },
-          id: 1,
-          name: 'Device 1',
-        }),
-      ])
+      const { listHandler, session } = createListDevicesSession()
+      stubDiscoverableDevice()
       await driver.onPair(session)
       const devices = await listHandler()
 
       expect(devices).toStrictEqual([
         {
           capabilities: ['onoff', 'thermostat_mode'],
+          capabilitiesOptions: {},
+          data: { id: 1 },
+          name: 'Device 1',
+        },
+      ])
+    })
+
+    // The opt-in rule at the pairing-details call site: the raw required
+    // list carries measure_signal_strength, the listed device must not.
+    it('should exclude the opt-in measure_signal_strength from pairing details', async () => {
+      const { listHandler, session } = createListDevicesSession()
+      stubDiscoverableDevice()
+      vi.spyOn(driver, 'getRequiredCapabilities').mockReturnValue([
+        'onoff',
+        'measure_signal_strength',
+      ])
+      await driver.onPair(session)
+      const devices = await listHandler()
+
+      expect(devices).toStrictEqual([
+        {
+          capabilities: ['onoff'],
           capabilitiesOptions: {},
           data: { id: 1 },
           name: 'Device 1',

--- a/tests/unit/classic-facade-manager.test.ts
+++ b/tests/unit/classic-facade-manager.test.ts
@@ -19,20 +19,9 @@ const mockBuildings = [
   },
 ]
 
-const mockZones = [
-  { id: 10, level: 0, model: 'buildings' as const, name: 'ClassicBuilding 1' },
-  { id: 1, level: 1, model: 'devices' as const, name: 'Device 1' },
-]
-
-const mockFacadeManager = {
-  get: vi.fn<(instance: unknown) => unknown>().mockReturnValue(null),
-  getBuildings: vi
-    .fn<(options?: { type?: Classic.DeviceType }) => unknown[]>()
-    .mockReturnValue(mockBuildings),
-  getZones: vi
-    .fn<(options?: { type?: Classic.DeviceType }) => unknown[]>()
-    .mockReturnValue(mockZones),
-}
+const mockGetBuildings = vi
+  .fn<(options?: { type?: Classic.DeviceType }) => unknown[]>()
+  .mockReturnValue(mockBuildings)
 
 describe('classic-facade-manager', () => {
   describe('when Classic.FacadeManager is not initialized', () => {
@@ -50,15 +39,10 @@ describe('classic-facade-manager', () => {
   describe('when Classic.FacadeManager is initialized', () => {
     beforeEach(() => {
       setClassicFacadeManager(
-        mock<Classic.FacadeManager>({
-          get: mockFacadeManager.get,
-          getBuildings: mockFacadeManager.getBuildings,
-          getZones: mockFacadeManager.getZones,
-        }),
+        mock<Classic.FacadeManager>({ getBuildings: mockGetBuildings }),
       )
       vi.clearAllMocks()
-      mockFacadeManager.getBuildings.mockReturnValue(mockBuildings)
-      mockFacadeManager.getZones.mockReturnValue(mockZones)
+      mockGetBuildings.mockReturnValue(mockBuildings)
     })
 
     describe(getClassicBuildings, () => {
@@ -66,13 +50,13 @@ describe('classic-facade-manager', () => {
         const result = getClassicBuildings()
 
         expect(result).toBe(mockBuildings)
-        expect(mockFacadeManager.getBuildings).toHaveBeenCalledWith({})
+        expect(mockGetBuildings).toHaveBeenCalledWith({ type: undefined })
       })
 
       it('should pass type filter', () => {
         getClassicBuildings({ type: Classic.DeviceType.Ata })
 
-        expect(mockFacadeManager.getBuildings).toHaveBeenCalledWith({
+        expect(mockGetBuildings).toHaveBeenCalledWith({
           type: Classic.DeviceType.Ata,
         })
       })

--- a/tests/unit/driver-compose.test.ts
+++ b/tests/unit/driver-compose.test.ts
@@ -10,22 +10,33 @@ import { describe, expect, it } from 'vitest'
 // the defaults or lean on the template precedence CLAUDE.md forbids.
 // The twins stay; this pin is what turns an edit to one without the
 // other into a failure instead of a silent drift.
-const readThermostatModeOptions = async (driver: string): Promise<unknown> => {
-  const compose = JSON.parse(
-    await readFile(`drivers/${driver}/driver.compose.json`, 'utf8'),
-  ) as { capabilitiesOptions: Record<string, unknown> }
-  return compose.capabilitiesOptions.thermostat_mode
+//
+// Raw text, not parsed JSON: byte identity is the pin (the widget-styles
+// twin pattern), so formatting or key-order drift fails too. The slice
+// is stable because `thermostat_mode` closes at the only 4-space `}` of
+// the block in these prettier-formatted files.
+const readThermostatModeBlock = async (driver: string): Promise<string> => {
+  const compose = await readFile(
+    `drivers/${driver}/driver.compose.json`,
+    'utf8',
+  )
+  const lines = compose.split('\n')
+  const start = lines.indexOf('    "thermostat_mode": {')
+  const end = lines.indexOf('    }', start)
+  return start === -1 || end === -1
+    ? ''
+    : lines.slice(start, end + 1).join('\n')
 }
 
 describe('ata driver compose twins', () => {
   it('should keep the thermostat_mode options byte-identical', async () => {
     const [classic, home] = await Promise.all(
       ['melcloud', 'home-melcloud'].map(async (driver) =>
-        readThermostatModeOptions(driver),
+        readThermostatModeBlock(driver),
       ),
     )
 
-    expect(classic).toBeDefined()
-    expect(classic).toStrictEqual(home)
+    expect(classic).not.toBe('')
+    expect(classic).toBe(home)
   })
 })

--- a/tests/unit/melcloud-atw-device.test.ts
+++ b/tests/unit/melcloud-atw-device.test.ts
@@ -210,11 +210,11 @@ describe(ClassicMELCloudDeviceAtw, () => {
   })
 
   describe('operation mode state mapping', () => {
+    // One row per code path: the hot-water, zone1 and zone2 reads each
+    // pass their facade state through unmapped.
     it.each([
       ['hot_water', 'hotWater', Classic.OperationModeStateHotWater.dhw],
-      ['hot_water', 'hotWater', Classic.OperationModeStateHotWater.prohibited],
       ['zone1', 'zone1', Classic.OperationModeStateZone.prohibited],
-      ['zone1', 'zone1', Classic.OperationModeStateZone.idle],
       ['zone2', 'zone2', Classic.OperationModeStateZone.heating],
     ] as const)(
       'should set operational_state.%s from facade %s state %s',

--- a/tests/unit/typed-object.test.ts
+++ b/tests/unit/typed-object.test.ts
@@ -1,9 +1,29 @@
 import { describe, expect, it } from 'vitest'
 
-import { typedEntries, typedFromEntries } from '../../lib/typed-object.mts'
+import {
+  invertEnum,
+  typedEntries,
+  typedFromEntries,
+} from '../../lib/typed-object.mts'
 
 describe('typed-object', () => {
   const testObject = { bar: 2, foo: 1 }
+
+  describe(invertEnum, () => {
+    it('should map each enum value back to its key', () => {
+      expect(invertEnum({ auto: 0, heat: 1 })).toStrictEqual({
+        0: 'auto',
+        1: 'heat',
+      })
+    })
+
+    it('should invert string-valued enums too', () => {
+      expect(invertEnum({ cool: 'Cool', dry: 'Dry' })).toStrictEqual({
+        Cool: 'cool',
+        Dry: 'dry',
+      })
+    })
+  })
 
   describe(typedEntries, () => {
     it('should return typed entries', () => {

--- a/types/api.mts
+++ b/types/api.mts
@@ -22,9 +22,8 @@ export interface AuthenticationAPI {
 /**
  * Holiday-mode window as the settings webview submits it: an absent
  * bound means "start (or end) now", completed app-side on the HOMEY's
- * clock — the one clock every entry point shares. The page used to
- * stamp the PHONE's clock instead, which diverges from the flow cards'
- * whenever the two sit in different timezones (#1595).
+ * clock — the one clock every entry point shares, whatever timezone
+ * the phone sits in.
  */
 export interface HolidayModeSettings {
   readonly isEnabled: boolean

--- a/types/atw.mts
+++ b/types/atw.mts
@@ -108,7 +108,7 @@ const thermostatModeValuesAtw = [
   createCoolObject(flow),
 ]
 
-export const getThermostatModeValuesAtw = (
+const getThermostatModeValuesAtw = (
   canCool: boolean,
 ): CapabilitiesOptionsValues<keyof typeof Classic.OperationModeZone>[] =>
   canCool
@@ -134,9 +134,7 @@ const thermostatModeZone2TitleAtw: LocalizedStrings = addSuffixToTitle(
   },
 )
 
-//
 // The runtime `thermostat_mode` options both ATW dialects compute.
-//
 export interface ThermostatModeOptionsAtw {
   readonly thermostat_mode: {
     readonly values: readonly CapabilitiesOptionsValues<

--- a/types/home-atw.mts
+++ b/types/home-atw.mts
@@ -5,11 +5,13 @@ import type {
   BaseGetCapabilities,
   BaseListCapabilities,
   BaseSetCapabilities,
-  CapabilitiesOptionsValues,
-  LocalizedStrings,
 } from './bases.mts'
 import type { HomeEnergyMeasureName } from './device.mts'
-import { type HotWaterMode, buildAtwThermostatModeOptions } from './atw.mts'
+import {
+  type HotWaterMode,
+  type ThermostatModeOptionsAtw,
+  buildAtwThermostatModeOptions,
+} from './atw.mts'
 
 interface HomeGetCapabilitiesAtw extends BaseGetCapabilities {
   readonly 'measure_temperature.tank_water': number
@@ -73,16 +75,6 @@ export const homeTagMappingsAtw: {
   set: homeSetCapabilityTagMappingAtw,
 }
 
-interface HomeCapabilitiesOptionsAtw {
-  readonly thermostat_mode: {
-    readonly values: readonly CapabilitiesOptionsValues<Home.AtwZoneMode>[]
-  }
-  readonly 'thermostat_mode.zone2': {
-    readonly title: LocalizedStrings
-    readonly values: readonly CapabilitiesOptionsValues<Home.AtwZoneMode>[]
-  }
-}
-
 /**
  * Structural slice of {@link Home.DeviceAtwFacade} driving which capabilities
  * a Home ATW device gets and their options. Satisfied by the facade itself;
@@ -96,8 +88,22 @@ export type HomeAtwDeviceProfile = Pick<
   'capabilities' | 'hasCoolingMode'
 >
 
+// One spelling of "the unit can report this energy direction": a
+// consumption estimate or meter for `consumed`, a production one for
+// `produced`. Shared by the driver's capability derivation and the
+// device's measure gate.
+export const hasAtwEnergyDirection = (
+  capabilities: HomeAtwDeviceProfile['capabilities'],
+  measure: HomeEnergyMeasureName,
+): boolean =>
+  measure === 'consumed'
+    ? capabilities.hasEstimatedEnergyConsumption ||
+      capabilities.hasMeasuredEnergyConsumption
+    : capabilities.hasEstimatedEnergyProduction ||
+      capabilities.hasMeasuredEnergyProduction
+
 export const homeGetCapabilitiesOptionsAtw = ({
   capabilities: { hasZone2 },
   hasCoolingMode,
-}: HomeAtwDeviceProfile): Partial<HomeCapabilitiesOptionsAtw> =>
+}: HomeAtwDeviceProfile): Partial<ThermostatModeOptionsAtw> =>
   buildAtwThermostatModeOptions(hasCoolingMode, hasZone2)

--- a/types/manifest.mts
+++ b/types/manifest.mts
@@ -1,5 +1,19 @@
 import type { CapabilitiesOptionsValues, LocalizedStrings } from './bases.mts'
 
+interface LoginSetting extends PairSetting {
+  readonly id: 'login'
+  readonly options: {
+    readonly passwordLabel: LocalizedStrings
+    readonly usernameLabel: LocalizedStrings
+    readonly usernamePlaceholder: string
+    // A password has no format to illustrate and the label already names the
+    // field, so it carries no placeholder. The username placeholder is a
+    // single neutral ASCII example (an email is ASCII), not per-locale
+    // strings — the labels hold the localization.
+    readonly passwordPlaceholder?: string
+  }
+}
+
 interface ManifestDriverSetting {
   readonly label: LocalizedStrings
   readonly children?: readonly ManifestDriverSettingData[]
@@ -21,20 +35,6 @@ interface ManifestDriverSettingData {
 
 interface PairSetting {
   readonly id: string
-}
-
-export interface LoginSetting extends PairSetting {
-  readonly id: 'login'
-  readonly options: {
-    readonly passwordLabel: LocalizedStrings
-    readonly usernameLabel: LocalizedStrings
-    readonly usernamePlaceholder: string
-    // A password has no format to illustrate and the label already names the
-    // field, so it carries no placeholder. The username placeholder is a
-    // single neutral ASCII example (an email is ASCII), not per-locale
-    // strings — the labels hold the localization.
-    readonly passwordPlaceholder?: string
-  }
 }
 
 export interface Manifest {


### PR DESCRIPTION
## Summary

The com.melcloud half of the post-wave cleanup (the melcloud-api half shipped as [51.0.1](https://github.com/OlivierZal/melcloud-api/releases/tag/v51.0.1)): 43 findings confirmed by an adversarial verify pass over the wave 0–3 diff, all implemented. No store version bump — behavior-neutral for users (one internal error-message alignment aside).

### Factorings (app.mts, lib, types, drivers)
- The three facade lookups ride the library instead of re-deriving it: `getClassicFacade` → `FacadeManager.getById(kind, id)`, `#getHomeDeviceFacade` → Home `getById` + `facade.type` gate, and `#getSettingsTarget` composes the renamed `#getHomeTarget` (`homeTarget ?? classic`) instead of re-spelling its branches.
- Holiday: `#holidayModeOff` and the `#updateHolidayModeTarget` passthrough are gone — the off-cards send a bare `{ isEnabled: false }` and `#completeHolidayModeWindow` remains the ONE clock stamping any window, so no payload is stamped twice.
- `#getHomeErrorEntries` iterates `registry.getDevices()` (the enumerated type list died with it); dead `type === undefined ? {} : { type }` forks dropped (app + lib); `getClassicAtaDetailedStates` filters devices once and no longer builds localized options to throw them away; `#initClassicApi` derives its own config like its Home mirror; `#getAtaCapabilityConfigs` scans the manifest once.
- One `hasAtwEnergyDirection` predicate in types/home-atw.mts now feeds both the driver's energy-capability derivation and the device's measure gate; `HomeCapabilitiesOptionsAtw` collapsed into the builder's own `ThermostatModeOptionsAtw`.

### Dead surface
- The app-surface route `GET /home/devices` (orphan since the widgets took their own surfaces) is removed from api.mts and the manifest — the charts widget's same-named route on its own surface is untouched.
- `PickerNode` replaced by the published `FlatZone` union; `getThermostatModeValuesAtw` and `LoginSetting` un-exported (no external consumers).
- A missing Home building now answers `errors.zoneNotFound` like its Classic counterpart — a building is a zone in the picker vocabulary; only the message text changes.

### Tests
- Scaffolding follows the new internals (manager `getById` mocks, `getDevices` for the error log); dead mocks deleted (`mockHomeFacadeManagerUpdate*`, `mockIsAuthenticated`, facade-manager `get`/`getZones`, `mockZones`).
- The `withoutOptInCapabilities` exclusion is now pinned at all three call sites; the resolveErrorLogWindow value-for-value re-pins yield to the library kernel (one wiring assertion each stays); vacuous/duplicate tests deleted; the five-row ATW operation-state table collapsed to its three real paths; `invertEnum` covered in its module's own test file; the driver-compose twin pin strengthened to raw-byte slices (widget-styles pattern).

### Docs
- README's coverage note and CLAUDE.md's stamping-pass paragraph now describe the real coverage shape (100 % on every `.mts`, no file-scoped exclusions); history-narrating comments rewritten as intent (app.mts, types/api.mts, settings/index.mts, types/atw.mts).

## Verification
- format / lint / typecheck / build / `homey:validate`: clean.
- `test:coverage`: 52 files, 940 tests, **100 % statements / branches / functions / lines**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKsbttD4wLTrZnZDwKK1Fn