### PR TITLE
chore(release): 46.6.1

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -1858,5 +1858,20 @@
     "pl": "Wewnętrzne ulepszenia obsługi stref i niezawodności.",
     "ru": "Внутренние улучшения поддержки зон и надёжности.",
     "sv": "Interna förbättringar av zonstöd och tillförlitlighet."
+  },
+  "46.6.1": {
+    "ar": "صيانة داخلية وتحسينات في الاستقرار.",
+    "da": "Intern vedligeholdelse og stabilitetsforbedringer.",
+    "de": "Interne Wartung und Stabilitätsverbesserungen.",
+    "en": "Internal maintenance and stability improvements.",
+    "es": "Mantenimiento interno y mejoras de estabilidad.",
+    "fr": "Maintenance interne et améliorations de stabilité.",
+    "it": "Manutenzione interna e miglioramenti di stabilità.",
+    "ko": "내부 유지 보수 및 안정성 개선.",
+    "nl": "Intern onderhoud en stabiliteitsverbeteringen.",
+    "no": "Internt vedlikehold og stabilitetsforbedringer.",
+    "pl": "Wewnętrzna konserwacja i poprawa stabilności.",
+    "ru": "Внутреннее обслуживание и повышение стабильности.",
+    "sv": "Internt underhåll och stabilitetsförbättringar."
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -298,5 +298,5 @@
       "värmeåtervinning"
     ]
   },
-  "version": "46.6.0"
+  "version": "46.6.1"
 }

--- a/app.json
+++ b/app.json
@@ -299,7 +299,7 @@
       "värmeåtervinning"
     ]
   },
-  "version": "46.6.0",
+  "version": "46.6.1",
   "flow": {
     "triggers": [
       {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "com.melcloud",
-  "version": "46.6.0",
+  "version": "46.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "com.melcloud",
-      "version": "46.6.0",
+      "version": "46.6.1",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@olivierzal/homey-kit": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.melcloud",
-  "version": "46.6.0",
+  "version": "46.6.1",
   "description": "MELCloud for Homey",
   "homepage": "https://github.com/OlivierZal/com.melcloud/",
   "bugs": {


### PR DESCRIPTION
Store release aligning the App Store with `main`: carries the [post-wave cleanup sweep](https://github.com/OlivierZal/com.melcloud/pull/1604) and the [@olivierzal/melcloud-api 51.0.1 adoption](https://github.com/OlivierZal/com.melcloud/pull/1603) — behavior-neutral for users. Changelog entry (13 locales), `.homeycompose` version bump, `package.json` aligned, `homey:validate` clean at publish level.

After merge: tag `v46.6.1` + GitHub release → `publish.yml` (environment `homey`) submits to the App Store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKsbttD4wLTrZnZDwKK1Fn