### PR TITLE
build: official TypeScript 6/7 side-by-side layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Architecture notes:
 
 - The API layer lives in [@olivierzal/melcloud-api](https://github.com/OlivierZal/melcloud-api), a sibling repository with its own tooling; API bugs are fixed there, not worked around here.
 - Browser code (both widgets' `public/` and the `settings/` page) is bundled by `scripts/bundle.mts` into a compat pair per entry — `index.js` (IIFE, what the shipped HTML loads) and `index.mjs` (for HTMLs cached by phones from earlier app versions) — emitted into `.homeybuild`, the packaged app, never into the source tree. `npm run build` produces them, and the Homey CLI runs it automatically on validate/publish. Shared helpers live in `public/` and are imported directly by widgets and settings.
-- Both the build and `npm run typecheck` use the native TypeScript 7 compiler (`typescript@7` aliased as `@typescript/native`) for speed; `typescript@6` remains alongside it for tools that need the JS API (typescript-eslint) until TypeScript 7.1 ships its stable programmatic API.
+- Both the build and `npm run typecheck` use the native TypeScript 7 compiler (`@typescript/native`, the npm `typescript` package at 7.x) for speed; the TypeScript 6 JS API continues as `@typescript/typescript6`, aliased under the `typescript` name for tools with a `typescript` peer (typescript-eslint), until TypeScript 7.1 ships its stable programmatic API.
 - Test coverage is enforced at 100% on branches, functions, lines and statements across every `.mts` source — webview pages and widgets included; only the packaged `.homeybuild` output is excluded.
 
 ## Disclaimer

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "homey-lib": "^2.51.4",
         "jiti": "^2.7.0",
         "prettier": "^3.9.6",
-        "typescript": "~6.0.3",
+        "typescript": "npm:@typescript/typescript6@^6.0.2",
         "vitest": "^4.1.2"
       },
       "engines": {
@@ -2257,6 +2257,21 @@
         "@typescript/typescript-sunos-x64": "7.0.2",
         "@typescript/typescript-win32-arm64": "7.0.2",
         "@typescript/typescript-win32-x64": "7.0.2"
+      }
+    },
+    "node_modules/@typescript/old": {
+      "name": "typescript",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/@typescript/typescript-aix-ppc64": {
@@ -7269,17 +7284,17 @@
       }
     },
     "node_modules/typescript": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
-      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "name": "@typescript/typescript6",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript6/-/typescript6-6.0.2.tgz",
+      "integrity": "sha512-mbCddXd+jm7hfx7w2YU64/Av4/NqqeG3GoRZgxPcgoTxYjhrcfJRw9ULch71SS4G+Q3bOXFhRvPqjguN0Hyp5w==",
       "dev": true,
       "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
+      "dependencies": {
+        "@typescript/old": "npm:typescript@^6"
       },
-      "engines": {
-        "node": ">=14.17"
+      "bin": {
+        "tsc6": "bin/tsc6"
       }
     },
     "node_modules/typescript-eslint": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "homey-lib": "^2.51.4",
     "jiti": "^2.7.0",
     "prettier": "^3.9.6",
-    "typescript": "~6.0.3",
+    "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vitest": "^4.1.2"
   },
   "engines": {


### PR DESCRIPTION
## What

Adopts the official TypeScript 6/7 side-by-side npm layout from the TS 7.0 announcement, in `devDependencies` only:

- `"typescript": "~6.0.3"` → `"typescript": "npm:@typescript/typescript6@^6.0.2"`

## Why

The announcement makes the npm `typescript` package at 7.x the native compiler, and the TS6 JS API officially continues as `@typescript/typescript6` — aliased under the `typescript` name for tools with a `typescript` peer (typescript-eslint). We had the aliasing inverted: our `~6.0.3` pin sat on the plain `typescript` package, a dead line under the official layout. The existing `@typescript/native: npm:typescript@^7.0.2` alias already matches the announcement's recommended spelling and stays untouched, as do all npm scripts.

Nominal 6.0.3 → 6.0.2 step (the compat package's latest); future 6.x maintenance lands on the compat package, which this spec now tracks.

README.md's architecture note is rewritten to describe the official layout. CLAUDE.md and CONTRIBUTING.md were grepped: their mentions (`tsc` from `@typescript/native` (TypeScript 7); CLI detection via `devDependencies.typescript`; command comments) remain accurate as written.

## Verification

- `npm ls typescript` → `typescript@npm:@typescript/typescript6@6.0.2`, deduped through typescript-eslint's whole tree
- `node ./node_modules/@typescript/native/bin/tsc --version` → `Version 7.0.2`
- Full suite green in order: `npm run format`, `npm run lint`, `npm run typecheck`, `npm test` (940 tests, 52 files), `npm run build`, `npm run homey:validate`
- Homey CLI TS detection re-proven after the flip: `✓ Typescript detected. Compiling...` → `✓ Typescript compilation successful` → `✓ App validated successfully against level 'publish'` (the detection key `devDependencies.typescript` still exists — only its resolution changed); validate rewrote no files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKsbttD4wLTrZnZDwKK1Fn