### PR TITLE
fix: leave an unused account out of the credentials prompt

### DIFF
--- a/settings/index.mts
+++ b/settings/index.mts
@@ -146,6 +146,15 @@ const CLASSIC_DRIVER_IDS: readonly string[] = [
 // order when auto-selecting an account whose credentials are missing.
 const API_VALUES: readonly Api[] = ['classic', 'home']
 
+// What deciding "which account needs attention" takes: who is signed
+// out, and where the devices are — the second known only to the page,
+// the first only meaningful together with the credential state the
+// authentication manager owns.
+interface AttentionInputs {
+  readonly unauthenticatedApis: readonly Api[]
+  readonly hasDevices: (api: Api) => boolean
+}
+
 class NoDeviceError extends Error {
   public override name = 'NoDeviceError'
 
@@ -522,8 +531,7 @@ class AuthManager {
   public createCredentialFields(
     driverSettings: Partial<Record<string, DriverSetting[]>>,
     credentials: Record<Api, Partial<LoginCredentials>>,
-    unauthenticatedApis: readonly Api[],
-    hasDevices: (api: Api) => boolean,
+    attention: AttentionInputs,
   ): void {
     this.#credentialsByApi = credentials
     this.#usernameInput = this.#createCredentialInput(
@@ -537,9 +545,7 @@ class AuthManager {
     // Open on the account that needs attention so what the user sees
     // first is the account to fix; the caller owns which accounts
     // qualify, because only it knows where the devices are.
-    this.#selectApiNeedingAttention(
-      this.getApisNeedingAttention(unauthenticatedApis, hasDevices),
-    )
+    this.#selectApiNeedingAttention(this.getApisNeedingAttention(attention))
     this.#syncInputsFromCredentials()
     this.#gate.markSaved()
   }
@@ -552,10 +558,10 @@ class AuthManager {
   // never steals the form from the one in use. A signed-out account
   // outranks one that merely lost half its pair: the first stopped
   // serving devices, the second still does.
-  public getApisNeedingAttention(
-    unauthenticatedApis: readonly Api[],
-    hasDevices: (api: Api) => boolean,
-  ): Api[] {
+  public getApisNeedingAttention({
+    hasDevices,
+    unauthenticatedApis,
+  }: AttentionInputs): Api[] {
     const apisInUse = API_VALUES.filter((api) => hasDevices(api))
     const incompleteApis = new Set(this.getIncompleteApis())
     return [
@@ -1911,6 +1917,13 @@ class SettingsApp {
     })
   }
 
+  #attentionInputs(): AttentionInputs {
+    return {
+      unauthenticatedApis: API_VALUES.filter((api) => !this.#authState[api]),
+      hasDevices: (api) => this.#hasDevices(api),
+    }
+  }
+
   async #ensureDevicesForApi(api: Api): Promise<void> {
     if (api === 'classic') {
       await this.#fetchClassicBuildings()
@@ -1996,8 +2009,7 @@ class SettingsApp {
           ...(typeof homeUsername === 'string' && { username: homeUsername }),
         },
       },
-      API_VALUES.filter((api) => !this.#authState[api]),
-      (api) => this.#hasDevices(api),
+      this.#attentionInputs(),
     )
   }
 
@@ -2042,10 +2054,8 @@ class SettingsApp {
     // open on its empty fields, but only while it still has devices:
     // an account the user never paired anything to is not a chore.
     this.#authManager.collapseAuthenticationSection(
-      this.#authManager.getApisNeedingAttention(
-        API_VALUES.filter((api) => !this.#authState[api]),
-        (api) => this.#hasDevices(api),
-      ).length === 0,
+      this.#authManager.getApisNeedingAttention(this.#attentionInputs())
+        .length === 0,
     )
     hide(this.#contentSection, !isClassicAuthenticated && !isHomeAuthenticated)
     toggleZoneDeviceSettings(isClassicAuthenticated || isHomeAuthenticated)

--- a/settings/index.mts
+++ b/settings/index.mts
@@ -134,6 +134,14 @@ const HOME_DRIVER_IDS: readonly string[] = [
   'home-melcloud_atw',
 ]
 
+// Classic counterpart of HOME_DRIVER_IDS: a Classic account counts as
+// "has devices" when any of its three drivers paired one.
+const CLASSIC_DRIVER_IDS: readonly string[] = [
+  'melcloud',
+  'melcloud_atw',
+  'melcloud_erv',
+]
+
 // The two APIs, in the order the picker offers them; also the priority
 // order when auto-selecting an account whose credentials are missing.
 const API_VALUES: readonly Api[] = ['classic', 'home']
@@ -515,6 +523,7 @@ class AuthManager {
     driverSettings: Partial<Record<string, DriverSetting[]>>,
     credentials: Record<Api, Partial<LoginCredentials>>,
     unauthenticatedApis: readonly Api[],
+    hasDevices: (api: Api) => boolean,
   ): void {
     this.#credentialsByApi = credentials
     this.#usernameInput = this.#createCredentialInput(
@@ -526,12 +535,35 @@ class AuthManager {
       driverSettings,
     )
     // Open on the account that needs attention so what the user sees
-    // first is the account to fix: a signed-out one before anything
-    // else — stored-but-refused credentials included — then one whose
-    // stored pair lost a field.
-    this.#selectApiNeedingAttention(unauthenticatedApis)
+    // first is the account to fix; the caller owns which accounts
+    // qualify, because only it knows where the devices are.
+    this.#selectApiNeedingAttention(
+      this.getApisNeedingAttention(unauthenticatedApis, hasDevices),
+    )
     this.#syncInputsFromCredentials()
     this.#gate.markSaved()
+  }
+
+  // The accounts the user actually relies on and that cannot serve them
+  // right now: signed out, or holding half a credential pair, while
+  // they have paired devices. Residual credentials on an account with
+  // no device are nothing to fix — the same rule the app applies before
+  // nagging the timeline about a lost session — so such an account
+  // never steals the form from the one in use. A signed-out account
+  // outranks one that merely lost half its pair: the first stopped
+  // serving devices, the second still does.
+  public getApisNeedingAttention(
+    unauthenticatedApis: readonly Api[],
+    hasDevices: (api: Api) => boolean,
+  ): Api[] {
+    const apisInUse = API_VALUES.filter((api) => hasDevices(api))
+    const incompleteApis = new Set(this.getIncompleteApis())
+    return [
+      ...apisInUse.filter((api) => unauthenticatedApis.includes(api)),
+      ...apisInUse.filter(
+        (api) => !unauthenticatedApis.includes(api) && incompleteApis.has(api),
+      ),
+    ]
   }
 
   // APIs whose stored credentials are missing a username or password —
@@ -626,11 +658,8 @@ class AuthManager {
     return (username ?? '') !== '' && (password ?? '') !== ''
   }
 
-  #selectApiNeedingAttention(unauthenticatedApis: readonly Api[]): void {
-    const [needsAttention] = [
-      ...unauthenticatedApis,
-      ...this.getIncompleteApis(),
-    ]
+  #selectApiNeedingAttention(apisNeedingAttention: readonly Api[]): void {
+    const [needsAttention] = apisNeedingAttention
     if (needsAttention !== undefined) {
       this.#apiSelect.value = needsAttention
     }
@@ -1934,10 +1963,15 @@ class SettingsApp {
     }
   }
 
-  #hasHomeDevices(): boolean {
-    return HOME_DRIVER_IDS.some((driverId) =>
-      Object.hasOwn(this.#deviceSettingsManager.deviceSettings, driverId),
+  #hasDevices(api: Api): boolean {
+    return (api === 'classic' ? CLASSIC_DRIVER_IDS : HOME_DRIVER_IDS).some(
+      (driverId) =>
+        Object.hasOwn(this.#deviceSettingsManager.deviceSettings, driverId),
     )
+  }
+
+  #hasHomeDevices(): boolean {
+    return this.#hasDevices('home')
   }
 
   async #initCredentialFields({
@@ -1963,6 +1997,7 @@ class SettingsApp {
         },
       },
       API_VALUES.filter((api) => !this.#authState[api]),
+      (api) => this.#hasDevices(api),
     )
   }
 
@@ -2002,14 +2037,15 @@ class SettingsApp {
   #refreshVisibility(): void {
     const { classic: isClassicAuthenticated, home: isHomeAuthenticated } =
       this.#authState
-    // Fold only when nothing needs attention: both accounts signed in
-    // AND both still hold complete credentials. A reset account (signed
-    // out immediately, credentials deleted) keeps the panel open on the
-    // empty fields.
+    // Fold when no account in use needs attention. A reset account
+    // (signed out immediately, credentials deleted) keeps the panel
+    // open on its empty fields, but only while it still has devices:
+    // an account the user never paired anything to is not a chore.
     this.#authManager.collapseAuthenticationSection(
-      isClassicAuthenticated &&
-        isHomeAuthenticated &&
-        this.#authManager.getIncompleteApis().length === 0,
+      this.#authManager.getApisNeedingAttention(
+        API_VALUES.filter((api) => !this.#authState[api]),
+        (api) => this.#hasDevices(api),
+      ).length === 0,
     )
     hide(this.#contentSection, !isClassicAuthenticated && !isHomeAuthenticated)
     toggleZoneDeviceSettings(isClassicAuthenticated || isHomeAuthenticated)

--- a/tests/unit/settings.test.ts
+++ b/tests/unit/settings.test.ts
@@ -984,6 +984,7 @@ describe('settings page', () => {
 
     it('should alert after a home sign-in with no home device', async () => {
       const harness = await bootPage()
+      commit(getSelect('api'), 'home')
       commit(getInput('username'), 'home@example.com')
       commit(getInput('password'), 'secret')
       swapRoutes(harness, { ...defaultRoutes(), 'GET /home/sessions': true })
@@ -1022,11 +1023,11 @@ describe('settings page', () => {
           username: 'classic@example.com',
         },
       })
-      // Both accounts signed in? classic yes, home no: the picker opened
-      // on home (needs attention), so switch back and forth.
+      // Home holds no device here, so it never grabs the form: select it
+      // and switch back, checking each account keeps its own pair.
       const api = getSelect('api')
+      commit(api, 'home')
 
-      expect(api.value).toBe('home')
       expect(getInput('username').value).toBe('home@example.com')
 
       commit(api, 'classic')
@@ -1051,7 +1052,15 @@ describe('settings page', () => {
 
     it('should open the picker on an incomplete stored account', async () => {
       await bootPage({
-        routes: { ...defaultRoutes(), 'GET /home/sessions': true },
+        routes: {
+          ...defaultRoutes(),
+          'GET /home/sessions': true,
+          'GET /home/targets': homeTargetsFixture(),
+          'GET /settings/devices': {
+            ...deviceSettingsFixture(),
+            'home-melcloud': { always_on: true },
+          },
+        },
         storedSettings: {
           homeUsername: 'home@example.com',
           password: 'classic-secret',
@@ -1059,7 +1068,46 @@ describe('settings page', () => {
         },
       })
 
-      // Both signed in, but home lost its password: attention there.
+      // Both signed in and both in use, but home lost its password:
+      // attention there.
+      expect(getSelect('api').value).toBe('home')
+      expect(getDetails('authentication').open).toBe(true)
+    })
+
+    it('should leave an unused account alone', async () => {
+      // Classic signed in and in use, home signed out with nothing
+      // paired to it: the panel has no chore to show, and the form must
+      // not open on an account the user never adopted.
+      await bootPage({
+        routes: { ...defaultRoutes(), 'GET /home/sessions': false },
+        storedSettings: {
+          password: 'classic-secret',
+          username: 'classic@example.com',
+        },
+      })
+
+      expect(getSelect('api').value).toBe('classic')
+      expect(getDetails('authentication').open).toBe(false)
+    })
+
+    it('should open on a signed-out account that has devices', async () => {
+      await bootPage({
+        routes: {
+          ...defaultRoutes(),
+          'GET /home/sessions': false,
+          'GET /settings/devices': {
+            ...deviceSettingsFixture(),
+            'home-melcloud': { always_on: true },
+          },
+        },
+        storedSettings: {
+          homePassword: 'home-secret',
+          homeUsername: 'home@example.com',
+          password: 'classic-secret',
+          username: 'classic@example.com',
+        },
+      })
+
       expect(getSelect('api').value).toBe('home')
       expect(getDetails('authentication').open).toBe(true)
     })


### PR DESCRIPTION
## The report behind it

A user with two Classic air-to-air units could not add the second one: the app answered "credentials invalid". Their diagnostic report showed the Classic side perfectly healthy (a 200 `ListDevices` carrying their unit) and every failure on the **Home** side — an account they never wanted. Their own guess was right: the form they were typing into targeted MELCloud Home, not Classic.

Two things sent them there, and this PR fixes the app half.

## The change

The settings credentials panel opened, and pre-selected its account picker, on any account that was signed out or missing half a stored credential pair — including one the user has never paired a single device to. For someone who only uses Classic, that means the panel greets them with a Home form on every visit.

An account with no paired device now never takes the form and never keeps the panel open. That is not a new policy: the app already applies exactly this rule before notifying a lost session (*"Residual credentials on an API without any paired device only get a log line: the timeline nag is reserved for a loss that stops device updates."*) — the settings panel simply had not learned it.

The ordering the panel had is preserved: a signed-out account still outranks one that merely lost half its pair, because the first stopped serving devices while the second still does. The policy now lives in the manager that owns the credential state (it was briefly in the page, which consulted that state before it was populated — caught by the suite), with the caller injecting the one thing only it knows: where the devices are.

## Tests

Three existing cases assumed the picker auto-landed on Home; they now name the account they exercise, keeping their original intent. Two cases were added for the rule itself: an unused signed-out account leaves the panel folded on Classic, and a signed-out account **with** devices still takes the form and opens the panel.

## Verification

format, lint, typecheck, `homey:validate` (publish level): clean. `test:coverage`: 100 % statements / branches / functions / lines.

The library half of this report — a `404` on Home's `/context` read as a stale session, driving an endless re-login loop, plus a bearer token leaking into the diagnostic report itself — ships separately in melcloud-api 51.1.0 and will arrive here as its adoption PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKsbttD4wLTrZnZDwKK1Fn