### PR TITLE
build: adopt @olivierzal/melcloud-api 52.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "GPL-3.0-only",
       "dependencies": {
         "@olivierzal/homey-kit": "5.0.0",
-        "@olivierzal/melcloud-api": "51.0.1",
+        "@olivierzal/melcloud-api": "52.0.0",
         "source-map-support": "^0.5.21",
         "temporal-polyfill": "^1.0.1"
       },
@@ -1117,9 +1117,9 @@
       }
     },
     "node_modules/@olivierzal/melcloud-api": {
-      "version": "51.0.1",
-      "resolved": "https://npm.pkg.github.com/download/@olivierzal/melcloud-api/51.0.1/93fc3eb0fc9d7a1225a987a5a5be1a71b8487de1",
-      "integrity": "sha512-xyYqYFrgV6pOGAAcI42Y2zltxX/hZS/kkDX8KRZ6xuMGIWpjbEYYcWZIDSkK1LthrO3uZerGkTb5sHh63sPgQQ==",
+      "version": "52.0.0",
+      "resolved": "https://npm.pkg.github.com/download/@olivierzal/melcloud-api/52.0.0/e4a1d029ef39dd2b27c635fb8e3c295645ea9807",
+      "integrity": "sha512-yZADF6Z6a4aBUqj1qhAuc2vJzVBcXr6ttyua0WgbOnDtEwxFKXUMz7KGyPV5RSM1HOasruLZGmcP5gYBjBQBNA==",
       "license": "MIT",
       "dependencies": {
         "temporal-polyfill": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "prettier": "@olivierzal/configs/prettier",
   "dependencies": {
     "@olivierzal/homey-kit": "5.0.0",
-    "@olivierzal/melcloud-api": "51.0.1",
+    "@olivierzal/melcloud-api": "52.0.0",
     "source-map-support": "^0.5.21",
     "temporal-polyfill": "^1.0.1"
   },


### PR DESCRIPTION
## What this adopts

Exact pin of `@olivierzal/melcloud-api` from 51.0.1 to 52.0.0 (never a caret — the library's breaking changes are self-published and adoption is an explicit reviewed PR per release).

## Why it matters to this app's users

Two of the three fixes in 52.0.0 land directly on code paths this app runs.

**1. Credentials no longer leak into the app log.** This app logs caught errors as objects (`this.error('...', error)` — `app.mts:903`, `app.mts:1120`, `drivers/base-device.mts:195`, `:439`, `:532`). Node prints an error's own enumerable properties, so a thrown `HttpError` carried its request headers, body and query parameters plus the response headers and body straight into the Homey app log — and from there into the diagnostic reports users paste into support threads. One such report, on 2026-08-21, carried a live bearer token; the Classic `X-MitsContextKey` and the sign-in password were exposed the same way. 52.0.0 redacts both halves in the `HttpError` constructor, so the same log line now reads `******` where a secret used to sit.

**2. A successful sync no longer writes the account's email address to the log.** `OwnerEmail` is present on every device of every Classic list response and is now redacted.

**3. A MELCloud Home account with no home settles quietly.** A `404` on Home's `/context` means the signed-in account has no MELCloud Home home, not a stale session. It used to escalate to a full sign-in, fail, arm a 15-minute backoff and report an authentication loss — looping for hours, which is exactly what that user's report showed.

## Contract verification

Both changes in the release that could require app-side work were checked against this app's code. Neither needs any:

- **`HttpError` loses its `T` parameter and `response.data` becomes `unknown`** (breaking, type-level). The app never references `HttpError`, `error.response.data`, or any narrowing of a failed body — no occurrence anywhere in the tree. The break cannot bite.
- **`isAuthenticated()` no longer implies an identity** — for a home-less account it reads `true` while `user` and `context` stay `null`. The app has exactly three consumers (`app.mts:1057`, `drivers/base-driver.mts:54`, and `api.mts:222`/`:230` via `ensureAuthenticated`), and every one of them consumes the boolean directly: gating a pairing view, answering a settings route, or skipping a Classic error-log fetch. Nothing derives an identity after the check — there is no `getUser`, `.user` or `.context` access anywhere in the app — so no null guard is needed. On the Home pairing path a home-less account reads an empty registry, so `getDeviceModels()` returns `[]` and `toDeviceDetails` is never reached.

No code changes were required beyond the pin.

## Gates

All run with explicit exit codes; every one `0`.

| Gate | Exit |
| --- | --- |
| `npm run format` | 0 |
| `npm run lint` | 0 |
| `npm run typecheck` | 0 |
| `npm run test:coverage` | 0 — 52 files, 942 tests, **100%** statements (2684/2684), branches (1059/1059), functions (920/920), lines (2653/2653) |
| `npm run build` | 0 |
| `npm run homey:validate` | 0 — `publish` level, rewrote nothing |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKsbttD4wLTrZnZDwKK1Fn
