### PR TITLE
chore(release): 46.6.2

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -1873,5 +1873,20 @@
     "pl": "Wewnętrzna konserwacja i poprawa stabilności.",
     "ru": "Внутреннее обслуживание и повышение стабильности.",
     "sv": "Internt underhåll och stabilitetsförbättringar."
+  },
+  "46.6.2": {
+    "ar": "إصلاح أمني: كان من الممكن أن تُكتب بيانات تسجيل دخولك في سجل التطبيق، ومنه إلى تقرير تشخيصي تشاركه. ولم تعد الحسابات التي لا تملك منزلًا في MELCloud Home تسبب فشل تسجيل دخول متكررًا.",
+    "da": "Sikkerhedsrettelse: dine loginoplysninger kunne blive skrevet til appens log og derfra havne i en diagnostikrapport, du deler. Konti uden et MELCloud Home-hjem giver ikke længere gentagne loginfejl.",
+    "de": "Sicherheitskorrektur: Deine Anmeldedaten konnten in das Protokoll der App geschrieben werden und von dort in einen von dir geteilten Diagnosebericht gelangen. Konten ohne ein MELCloud Home-Zuhause führen nicht mehr zu wiederholten Anmeldefehlern.",
+    "en": "Security fix: your sign-in details could be written to the app’s log, and from there end up in a diagnostic report you share. Accounts without a MELCloud Home home no longer cause repeated sign-in failures.",
+    "es": "Corrección de seguridad: tus datos de inicio de sesión podían escribirse en el registro de la app y, desde ahí, acabar en un informe de diagnóstico que compartes. Las cuentas sin un hogar en MELCloud Home ya no provocan fallos de inicio de sesión repetidos.",
+    "fr": "Correctif de sécurité : vos identifiants de connexion pouvaient être écrits dans le journal de l’app et, de là, se retrouver dans un rapport de diagnostic que vous partagez. Les comptes sans domicile MELCloud Home ne provoquent plus d’échecs de connexion répétés.",
+    "it": "Correzione di sicurezza: le tue credenziali di accesso potevano essere scritte nel registro dell’app e finire da lì in un rapporto diagnostico che condividi. Gli account senza una casa MELCloud Home non causano più errori di accesso ripetuti.",
+    "ko": "보안 수정: 로그인 정보가 앱 로그에 기록되어 공유하는 진단 보고서에까지 포함될 수 있었습니다. MELCloud Home 집이 없는 계정에서 더 이상 로그인 실패가 반복되지 않습니다.",
+    "nl": "Beveiligingsfix: je inloggegevens konden in het logboek van de app terechtkomen en van daaruit in een diagnoserapport dat je deelt. Accounts zonder een MELCloud Home-huis veroorzaken niet langer herhaalde aanmeldfouten.",
+    "no": "Sikkerhetsfiks: påloggingsinformasjonen din kunne bli skrevet til appens logg og derfra havne i en diagnoserapport du deler. Kontoer uten et MELCloud Home-hjem gir ikke lenger gjentatte påloggingsfeil.",
+    "pl": "Poprawka bezpieczeństwa: Twoje dane logowania mogły trafić do dziennika aplikacji, a stamtąd do udostępnianego raportu diagnostycznego. Konta bez domu w MELCloud Home nie powodują już powtarzających się błędów logowania.",
+    "ru": "Исправление безопасности: ваши данные для входа могли попасть в журнал приложения, а оттуда — в диагностический отчёт, которым вы делитесь. Учётные записи без дома в MELCloud Home больше не вызывают повторяющихся ошибок входа.",
+    "sv": "Säkerhetsfix: dina inloggningsuppgifter kunde skrivas till appens logg och därifrån hamna i en diagnosrapport som du delar. Konton utan ett MELCloud Home-hem orsakar inte längre upprepade inloggningsfel."
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -298,5 +298,5 @@
       "värmeåtervinning"
     ]
   },
-  "version": "46.6.1"
+  "version": "46.6.2"
 }

--- a/app.json
+++ b/app.json
@@ -299,7 +299,7 @@
       "värmeåtervinning"
     ]
   },
-  "version": "46.6.1",
+  "version": "46.6.2",
   "flow": {
     "triggers": [
       {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "com.melcloud",
-  "version": "46.6.1",
+  "version": "46.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "com.melcloud",
-      "version": "46.6.1",
+      "version": "46.6.2",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@olivierzal/homey-kit": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.melcloud",
-  "version": "46.6.1",
+  "version": "46.6.2",
   "description": "MELCloud for Homey",
   "homepage": "https://github.com/OlivierZal/com.melcloud/",
   "bugs": {


### PR DESCRIPTION
## Store release 46.6.2

Ships the security fixes adopted in #1609 (`@olivierzal/melcloud-api` 52.0.0) to the Homey App Store.

## Why this release exists

Two user-visible problems are fixed, both in the library this app depends on:

1. **Account credentials could reach the app log.** This app logs caught errors as objects, and Node prints an error's own enumerable properties — so a thrown `HttpError` carried request headers, body and query parameters plus the response headers and body into the Homey app log, and from there into the diagnostic reports users paste into support threads. A report on 2026-08-21 carried a live bearer token; the Classic `X-MitsContextKey` and the sign-in password were exposed the same way. `OwnerEmail` — present on every device of every Classic list response — went the same route on a routine successful sync. 52.0.0 redacts all of it.
2. **A MELCloud Home account with no home looped on sign-in failures.** A `404` on Home's `/context` means the account has no MELCloud Home home, not a stale session. It used to escalate to a full sign-in, fail, arm a 15-minute backoff and report an authentication loss for hours. Such an account now settles quietly.

## Changes

- `.homeychangelog.json` — new `46.6.2` entry in all **thirteen** locales (`ar`, `da`, `de`, `en`, `es`, `fr`, `it`, `ko`, `nl`, `no`, `pl`, `ru`, `sv`), matching the existing key order and store-facing tone.
- `.homeycompose/app.json` — `version` → `46.6.2`.
- `package.json` / `package-lock.json` — aligned via `npm version 46.6.2 --no-git-tag-version`.
- `app.json` — regenerated by `homey:validate` (version line only; committed verbatim, trailing newline absent as the CLI writes it).

English entry:

> Security fix: your sign-in details could be written to the app’s log, and from there end up in a diagnostic report you share. Accounts without a MELCloud Home home no longer cause repeated sign-in failures.

## Gates

All run with explicit exit codes; every one `0`.

| Gate | Exit |
| --- | --- |
| `npm run format` | 0 |
| `npm run lint` | 0 |
| `npm run typecheck` | 0 |
| `npm run test:coverage` | 0 — 52 files, 942 tests, **100%** statements (2684/2684), branches (1059/1059), functions (920/920), lines (2653/2653) |
| `npm run build` | 0 |
| `npm run homey:validate` | 0 — `publish` level; re-run after staging rewrote nothing further |

Once merged, release `v46.6.2` triggers `publish.yml` and the store submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKsbttD4wLTrZnZDwKK1Fn
