### PR TITLE
build: adopt @olivierzal/melcloud-api 52.0.1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,10 +24,10 @@ caught real failures that the others miss:
   `no-whitespace-only-children`, plus the quality rules.
 - `npm run typecheck` — TypeScript 7, reached by its explicit path,
   `node ./node_modules/@typescript/native/bin/tsc`. The path is
-  load-bearing: the native compiler ships NO `.bin` shim, and the `tsc`
-  slot belongs to the `@typescript/typescript6` compat package (which
-  itself depends on `npm:typescript@^6` under the name
-  `@typescript/old`), so a bare `tsc` — or `tsc6` — would silently
+  load-bearing: the native compiler declares a `tsc` bin of its own but
+  LOSES the `.bin/tsc` slot to `@typescript/old` (the TS 6 the
+  `@typescript/typescript6` compat package depends on) under npm's
+  bin-conflict resolution, so a bare `tsc` — or `tsc6` — would silently
   typecheck with TypeScript 6 instead. Never shorten it.
 - `npm test` / `npm run test:coverage` — vitest; branches are at 100%,
   keep them there.
@@ -219,6 +219,14 @@ coverage.
   (a class list silently missed renamed buttons).
   The kit's own suite locks the behavior — a change to the gate is a kit
   release, adopted here by an exact-pin bump.
+- The credentials prompt is for accounts IN USE only (#1608): an
+  account with no paired device never takes the credentials form nor
+  keeps the settings panel open — residual credentials on it are
+  nothing to fix, the same rule that gates the session-lost timeline
+  notification (a form offered for an unused account is where a user
+  types the wrong password). Among the accounts in use, signed-out
+  outranks incomplete (missing half the credential pair): the first
+  stopped serving devices, the second still does.
 - Settings-CSS sharing — VERDICT (2026-08, after the `./dom` adoption):
   the cascade fixes STAY LOCAL, in all three apps. Two independent
   reasons, either sufficient. (1) The kit ships no stylesheet and
@@ -313,6 +321,14 @@ coverage.
   (live-observed: a legionella cycle shows the zone idle), which is
   exactly what `operationalStateZone1/2` derive API-side — the Classic
   flag refinements do not exist on the Home wire.
+- `isAuthenticated()` on the Home API answers "can this session serve
+  requests", never "is there an identity" (melcloud-api ≥ 52.0.0): an
+  account with no MELCloud Home home settles authenticated with
+  `user`/`context` null and an empty registry. Pairing routes on that
+  answer — such an account gets the empty device list, not the login
+  form, which is correct: its session is valid and simply has nothing
+  to offer. Anything deriving a name or email from `getUser()` must
+  handle the `null`.
 - Home drivers compute capabilities per device from the facade — at
   pairing (`toDeviceDetails`) and again at device init
   (`getRequiredCapabilities`). `isOwner` gates NOTHING, on any driver:

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "GPL-3.0-only",
       "dependencies": {
         "@olivierzal/homey-kit": "5.0.0",
-        "@olivierzal/melcloud-api": "52.0.0",
+        "@olivierzal/melcloud-api": "52.0.1",
         "source-map-support": "^0.5.21",
         "temporal-polyfill": "^1.0.4"
       },
@@ -1117,9 +1117,9 @@
       }
     },
     "node_modules/@olivierzal/melcloud-api": {
-      "version": "52.0.0",
-      "resolved": "https://npm.pkg.github.com/download/@olivierzal/melcloud-api/52.0.0/e4a1d029ef39dd2b27c635fb8e3c295645ea9807",
-      "integrity": "sha512-yZADF6Z6a4aBUqj1qhAuc2vJzVBcXr6ttyua0WgbOnDtEwxFKXUMz7KGyPV5RSM1HOasruLZGmcP5gYBjBQBNA==",
+      "version": "52.0.1",
+      "resolved": "https://npm.pkg.github.com/download/@olivierzal/melcloud-api/52.0.1/517416e11a6f9f6c8c9e28d5cbec3bf0f1f67f83",
+      "integrity": "sha512-2VxEN5Cr1oYsFmfDkiDCHnMRj8nWFJcJfHKQAcGD8BfwGIJVU0aYm2+bJSOPUNo3efPE2a8qVUquJ4Bae+08EQ==",
       "license": "MIT",
       "dependencies": {
         "temporal-polyfill": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "prettier": "@olivierzal/configs/prettier",
   "dependencies": {
     "@olivierzal/homey-kit": "5.0.0",
-    "@olivierzal/melcloud-api": "52.0.0",
+    "@olivierzal/melcloud-api": "52.0.1",
     "source-map-support": "^0.5.21",
     "temporal-polyfill": "^1.0.4"
   },


### PR DESCRIPTION
## What

Exact pin bump `52.0.0` → `52.0.1` — the library's security patch completing the 52.0.0 redaction work:

- the OIDC token endpoint's JSON failure text is now actually redacted (the raw-text path passed a token-bearing field through verbatim into the thrown `HttpError`, which this app's logger prints on "Refresh token exchange failed:");
- the `HttpError` snapshot also redacts the query-string portion of the request URL (`?code=…`).

No app-side code change: the fix lives entirely inside the library's shared redaction vocabulary.

## Doctrine traces (companion-docs rule)

Same PR, the two CLAUDE.md entries the retrospective flagged as missing:

- **Driver conventions** — `isAuthenticated()` on the Home API answers "can this session serve requests", never "is there an identity" (melcloud-api ≥ 52.0.0): a home-less account settles authenticated with `user`/`context` null and an empty registry, which is why pairing shows the empty device list rather than a login form for such an account.
- **Settings page** — the #1608 rule: the credentials prompt is for accounts IN USE only — an account with no paired device never takes the credentials form nor keeps the panel open, the same rule that gates the session-lost timeline notification; among accounts in use, signed-out outranks incomplete.

Also corrects the bin-shim sentence to the measured truth: `@typescript/native` declares a `tsc` bin but loses the `.bin/tsc` slot to `@typescript/old` under npm's bin-conflict resolution (the conclusion — only the explicit path is reliable — stands).

## Release

No store release with this PR: 46.6.2's review is still pending at Athom, so the next store release carries this pin.

## Gates

`format` / `lint` / `typecheck` / `test:coverage` (100 % × 4) / `build` — all exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKsbttD4wLTrZnZDwKK1Fn