### PR TITLE
build: adopt @olivierzal/melcloud-api 52.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "GPL-3.0-only",
       "dependencies": {
         "@olivierzal/homey-kit": "5.0.0",
-        "@olivierzal/melcloud-api": "52.0.1",
+        "@olivierzal/melcloud-api": "52.0.2",
         "source-map-support": "^0.5.21",
         "temporal-polyfill": "^1.0.4"
       },
@@ -1117,9 +1117,9 @@
       }
     },
     "node_modules/@olivierzal/melcloud-api": {
-      "version": "52.0.1",
-      "resolved": "https://npm.pkg.github.com/download/@olivierzal/melcloud-api/52.0.1/517416e11a6f9f6c8c9e28d5cbec3bf0f1f67f83",
-      "integrity": "sha512-2VxEN5Cr1oYsFmfDkiDCHnMRj8nWFJcJfHKQAcGD8BfwGIJVU0aYm2+bJSOPUNo3efPE2a8qVUquJ4Bae+08EQ==",
+      "version": "52.0.2",
+      "resolved": "https://npm.pkg.github.com/download/@olivierzal/melcloud-api/52.0.2/0e0ee23da073d949e6b59c61c1f68a76eaf6781a",
+      "integrity": "sha512-MWzjShb5TJw3XEb69R4BBWb5ertTYpBz4Ta6y2a/reXjpv4owRY369Ou3JDZtYW+xH2iinzOSKeQmamEqTK03A==",
       "license": "MIT",
       "dependencies": {
         "temporal-polyfill": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "prettier": "@olivierzal/configs/prettier",
   "dependencies": {
     "@olivierzal/homey-kit": "5.0.0",
-    "@olivierzal/melcloud-api": "52.0.1",
+    "@olivierzal/melcloud-api": "52.0.2",
     "source-map-support": "^0.5.21",
     "temporal-polyfill": "^1.0.4"
   },


### PR DESCRIPTION
Exact-pin bump 52.0.1 → 52.0.2 ([release](https://github.com/OlivierZal/melcloud-api/releases/tag/v52.0.2)): restores the 2024 zone→device fallback of the Classic frost-protection and holiday-mode reads, regressed by a 2026-03 library refactor. For this app's users: a shared building whose zone-level settings read is refused (the Dutch report of 2026-08-26) now silently falls back to the device level instead of failing the settings panel. No app-side code change; both contract kernels in the library pin the restored clause.

Verified: typecheck, lint, format, build, homey:validate, 942 tests — all exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKsbttD4wLTrZnZDwKK1Fn