### PR TITLE
build: adopt @olivierzal/melcloud-api 53.0.0

### DIFF
--- a/app.mts
+++ b/app.mts
@@ -408,8 +408,9 @@ export default class MELCloudApp extends App {
   // suffixed with its building, drawn from the shared zone source.
   public getClassicDeviceZones(type?: Classic.DeviceType): Classic.Zone[] {
     return this.getClassicTargets(type)
-      .filter(({ model }) => model === 'devices')
+      .filter((node) => node.model === 'devices')
       .map((node) => ({
+        deviceType: node.deviceType,
         id: node.id,
         level: node.level,
         model: 'devices' as const,

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "GPL-3.0-only",
       "dependencies": {
         "@olivierzal/homey-kit": "5.0.0",
-        "@olivierzal/melcloud-api": "52.0.2",
+        "@olivierzal/melcloud-api": "53.0.0",
         "source-map-support": "^0.5.21",
         "temporal-polyfill": "^1.0.4"
       },
@@ -1117,9 +1117,9 @@
       }
     },
     "node_modules/@olivierzal/melcloud-api": {
-      "version": "52.0.2",
-      "resolved": "https://npm.pkg.github.com/download/@olivierzal/melcloud-api/52.0.2/0e0ee23da073d949e6b59c61c1f68a76eaf6781a",
-      "integrity": "sha512-MWzjShb5TJw3XEb69R4BBWb5ertTYpBz4Ta6y2a/reXjpv4owRY369Ou3JDZtYW+xH2iinzOSKeQmamEqTK03A==",
+      "version": "53.0.0",
+      "resolved": "https://npm.pkg.github.com/download/@olivierzal/melcloud-api/53.0.0/ee6b481f4c5959ab152b07ee84f12637bb05597b",
+      "integrity": "sha512-wqpDgZJjLi+QPLxST1j3X9YJelILvLzKyGGLfJ7oEo6Ba+rZgGxf+xl1pC3psuX6DPa6wgF9fUvCT4EdqQtq8g==",
       "license": "MIT",
       "dependencies": {
         "temporal-polyfill": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "prettier": "@olivierzal/configs/prettier",
   "dependencies": {
     "@olivierzal/homey-kit": "5.0.0",
-    "@olivierzal/melcloud-api": "52.0.2",
+    "@olivierzal/melcloud-api": "53.0.0",
     "source-map-support": "^0.5.21",
     "temporal-polyfill": "^1.0.4"
   },

--- a/tests/unit/app.test.ts
+++ b/tests/unit/app.test.ts
@@ -1289,7 +1289,13 @@ describe('melCloudApp', () => {
       mockApiInstance.getErrorLog.mockResolvedValue(
         ok({
           entries: [
-            { at: '2026-03-28T14:30:00.000Z', deviceId: 42, message: 'test' },
+            {
+              at: '2026-03-28T14:30:00.000Z',
+              atEpochMs: Temporal.Instant.from('2026-03-28T14:30:00.000Z')
+                .epochMilliseconds,
+              deviceId: 42,
+              message: 'test',
+            },
           ],
           fromDate: '2026-03-01',
           nextFromDate: '2026-03-15',
@@ -1349,10 +1355,17 @@ describe('melCloudApp', () => {
           entries: [
             {
               at: '0001-01-01T00:09:00',
+              atEpochMs: null,
               deviceId: 42,
               message: 'Unknown Error',
             },
-            { at: '2026-03-28T14:30:00.000Z', deviceId: 42, message: 'test' },
+            {
+              at: '2026-03-28T14:30:00.000Z',
+              atEpochMs: Temporal.Instant.from('2026-03-28T14:30:00.000Z')
+                .epochMilliseconds,
+              deviceId: 42,
+              message: 'test',
+            },
           ],
           fromDate: '2026-03-01',
           nextFromDate: '2026-03-15',
@@ -1375,7 +1388,13 @@ describe('melCloudApp', () => {
       mockApiInstance.getErrorLog.mockResolvedValue(
         ok({
           entries: [
-            { at: '2026-03-28T14:30:00.000Z', deviceId: 42, message: 'test' },
+            {
+              at: '2026-03-28T14:30:00.000Z',
+              atEpochMs: Temporal.Instant.from('2026-03-28T14:30:00.000Z')
+                .epochMilliseconds,
+              deviceId: 42,
+              message: 'test',
+            },
           ],
           fromDate: '2026-03-01',
           nextFromDate: '2026-03-15',
@@ -1457,7 +1476,13 @@ describe('melCloudApp', () => {
       mockApiInstance.getErrorLog.mockResolvedValue(
         ok({
           entries: [
-            { at: '2026-03-28T14:30:00.000Z', deviceId: 42, message: 'test' },
+            {
+              at: '2026-03-28T14:30:00.000Z',
+              atEpochMs: Temporal.Instant.from('2026-03-28T14:30:00.000Z')
+                .epochMilliseconds,
+              deviceId: 42,
+              message: 'test',
+            },
           ],
           fromDate: '2026-03-01',
           nextFromDate: '2026-03-15',
@@ -1491,7 +1516,14 @@ describe('melCloudApp', () => {
       mockApiInstance.getErrorLog.mockResolvedValue(
         ok({
           entries: [
-            { at: '2026-03-28T14:30:00', deviceId: 999, message: 'test' },
+            {
+              at: '2026-03-28T14:30:00',
+              atEpochMs: Temporal.ZonedDateTime.from(
+                '2026-03-28T14:30:00[Europe/Paris]',
+              ).epochMilliseconds,
+              deviceId: 999,
+              message: 'test',
+            },
           ],
           fromDate: '2026-03-01',
           nextFromDate: '2026-03-15',
@@ -2124,6 +2156,7 @@ describe('melCloudApp', () => {
         },
         {
           buildingName: 'Verkstan',
+          deviceType: 'ata',
           id: 20,
           level: 1,
           model: 'devices',
@@ -2131,6 +2164,7 @@ describe('melCloudApp', () => {
         },
         {
           buildingName: 'Casa',
+          deviceType: 'atw',
           id: 10,
           level: 1,
           model: 'devices',
@@ -2140,8 +2174,20 @@ describe('melCloudApp', () => {
       await app.onInit()
 
       expect(app.getClassicDeviceZones()).toStrictEqual([
-        { id: 20, level: 1, model: 'devices', name: 'Garage (Verkstan)' },
-        { id: 10, level: 1, model: 'devices', name: 'Hydrobox (Casa)' },
+        {
+          deviceType: 'ata',
+          id: 20,
+          level: 1,
+          model: 'devices',
+          name: 'Garage (Verkstan)',
+        },
+        {
+          deviceType: 'atw',
+          id: 10,
+          level: 1,
+          model: 'devices',
+          name: 'Hydrobox (Casa)',
+        },
       ])
     })
 
@@ -2149,6 +2195,7 @@ describe('melCloudApp', () => {
       mockFacadeManagerGetZones.mockReturnValue([
         {
           buildingName: 'Huis',
+          deviceType: 'ata',
           id: 30,
           level: 1,
           model: 'devices',
@@ -2158,7 +2205,13 @@ describe('melCloudApp', () => {
       await app.onInit()
 
       expect(app.getClassicDeviceZones(Classic.DeviceType.Ata)).toStrictEqual([
-        { id: 30, level: 1, model: 'devices', name: 'AC (Huis)' },
+        {
+          deviceType: 'ata',
+          id: 30,
+          level: 1,
+          model: 'devices',
+          name: 'AC (Huis)',
+        },
       ])
       expect(mockFacadeManagerGetZones).toHaveBeenCalledWith({
         type: Classic.DeviceType.Ata,
@@ -3357,6 +3410,7 @@ describe('melCloudApp', () => {
       mockFacadeManagerGetZones.mockReturnValue([
         {
           buildingName: 'Casa',
+          deviceType: 'ata',
           id: 10,
           level: 1,
           model: 'devices',
@@ -3364,6 +3418,7 @@ describe('melCloudApp', () => {
         },
         {
           buildingName: 'Casa',
+          deviceType: 'ata',
           id: 11,
           level: 1,
           model: 'devices',
@@ -3393,7 +3448,13 @@ describe('melCloudApp', () => {
           model: 'homeDevices',
           name: 'Device 1 (Antwerpen)',
         },
-        { id: 10, level: 1, model: 'devices', name: 'Device 1 (Casa)' },
+        {
+          deviceType: 'ata',
+          id: 10,
+          level: 1,
+          model: 'devices',
+          name: 'Device 1 (Casa)',
+        },
       ])
     })
   })


### PR DESCRIPTION
Adopts `@olivierzal/melcloud-api` 53.0.0 (exact pin), covering the four breaking changes its CHANGELOG names:

- **`ClassicDeviceZone.deviceType` (required)** — `getClassicDeviceZones` in `app.mts` now carries `deviceType` through from the registry node (the filter moves to the inferred-predicate form so the union narrows); the chart-zones fixtures and expectations speak it.
- **`ErrorLogEntry.atEpochMs` (required)** — the five Classic error-log test fixtures constructing entries add it, spelled as `Temporal` projections of their own `at` (the sentinel entry reads `null`, matching the library's cannot-be-said discipline). App-side reading is unaffected — `getErrorLog` keeps its own parse.
- **`AtwHotWaterState.lastLegionellaActivationEpochMs` (required)** — no app-side construction exists; readers unaffected.
- **`ClassicZoneFacade`/`ClassicDeviceAtaFacade` require `getMemberOperationModes`** — no consumer-side implementation exists app-side (mocks are partial); nothing to migrate here. Consuming the new `getMemberOperationModes` is the route-wave PR's work, not this adoption's.

Gates: format 0, lint 0, typecheck 0, test:coverage 0 (942 tests, 100 % × 4), build 0, homey:validate 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKsbttD4wLTrZnZDwKK1Fn
