### PR TITLE
feat: target-neutral session, group and chart routes

### DIFF
--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -1,12 +1,8 @@
 {
   "api": {
-    "classicAuthenticate": {
+    "authenticate": {
       "method": "POST",
-      "path": "/classic/sessions"
-    },
-    "classicLogOut": {
-      "method": "DELETE",
-      "path": "/classic/sessions"
+      "path": "/sessions/:api"
     },
     "getClassicBuildings": {
       "method": "GET",
@@ -52,21 +48,13 @@
       "method": "GET",
       "path": "/webview-hashes"
     },
-    "homeAuthenticate": {
-      "method": "POST",
-      "path": "/home/sessions"
+    "isAuthenticated": {
+      "method": "GET",
+      "path": "/sessions/:api"
     },
-    "homeLogOut": {
+    "logOut": {
       "method": "DELETE",
-      "path": "/home/sessions"
-    },
-    "isClassicAuthenticated": {
-      "method": "GET",
-      "path": "/classic/sessions"
-    },
-    "isHomeAuthenticated": {
-      "method": "GET",
-      "path": "/home/sessions"
+      "path": "/sessions/:api"
     },
     "logWebviewBoot": {
       "method": "POST",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,21 +158,36 @@ coverage.
   design.
 - App-API surface conventions: paths are kebab-case REST (`get*` for
   GET — except `is*` for a boolean GET —, `update*` for PUT — never
-  `set*` —, and a business verb for POST: `*Authenticate` on
-  `/sessions`, `logWebviewBoot` on `/boot-error`); handler renames are
-  wire-invisible (routing is method+path), path renames are NOT (phone
-  webviews cache bundles across versions; stale callers now surface an
-  error — legacy aliases were dropped by decision, 2026-07, and the
-  settings routes migrated once more under the same policy, 2026-08).
-  The zone SETTINGS routes are target-neutral:
-  `/targets/:targetId/settings/{frost-protection,holiday-mode,overheat-protection}`,
-  where `targetId` is the picker value verbatim (`buildings_1`,
-  `homeDevices_<guid>` — split at the FIRST underscore) — one route
-  family for every dialect and level; the app model resolves the facade
-  (`#getSettingsTarget`) and the melcloud-api 50.0.0 facades answer the
-  same read/write methods on every target, so no per-family route or
-  aggregation code remains app-side. Overheat stays Home-only: a
-  Classic target reads `null` and refuses the write. The
+  `set*` —, and a business verb for POST: `authenticate` on
+  `/sessions/:api`, `logWebviewBoot` on `/boot-error`); handler renames
+  are wire-invisible (routing is method+path), path renames are NOT
+  (phone webviews cache bundles across versions; stale callers now
+  surface an error — legacy aliases were dropped by decision, 2026-07,
+  and the settings, session, ATA-group and chart routes migrated under
+  the same policy, 2026-08).
+  The session resource is ONE route for both accounts —
+  `GET/POST/DELETE /sessions/:api` (`classic` | `home`, resolved over a
+  client map on the `Api` union) — and every zone-addressed surface is
+  target-neutral under `/targets/:targetId/…`, where `targetId` is the
+  picker value verbatim (`buildings_1`, `homeDevices_<guid>` — split at
+  the FIRST underscore): the SETTINGS routes
+  (`…/settings/{frost-protection,holiday-mode,overheat-protection}`,
+  resolver `#getSettingsTarget`), the ATA GROUP routes (`…/ata` GET/PUT
+  and `…/ata/modes`, resolver `#getAtaGroupTarget`; the modes read is
+  the library's `getMemberOperationModes({poweredOnly: true})`) and the
+  CHART routes
+  (`…/logs/{report,hourly-temperatures,operation-modes,signal,temperatures}`,
+  resolvers `#getReportTarget`/`#getFullReportTarget` over the
+  melcloud-api `/report` interfaces — the ATW-only charts pin the Home
+  leg: a Home ATA target answers NotFoundError, nothing emulated). The
+  charts widget lists its pickers from ONE `GET /devices` route (both
+  dialects' device leaves merged, alpha-sorted, `deviceType`-tagged —
+  the widget filters per chart client-side). No-change group writes are
+  the LIBRARY's business: every melcloud-api `updateGroupState` leg
+  resolves an already-matching delta as success, so the app-side
+  handlers are plain delegations (verdict 2026-08, recorded on
+  `updateTargetAtaState`). Overheat stays Home-only: a Classic target
+  reads `null` and refuses the write. The
   inter-app grouping route is `GET /devices/groups` (the extension
   degrades to "no grouping" when it is absent).
   `@olivierzal/homey-kit/settings` is the settings pages' transport
@@ -354,10 +369,11 @@ coverage.
   whatever API served it, and `classicCoolModes` / `ClassicTemperature`
   (documented universal across ATA models) apply to both. Consumers
   therefore never branch on the family to READ or WRITE a group state;
-  the only family-visible step is ADDRESSING, because a Home building or
-  device id and a Classic zone type + id are reachable only through
-  distinct routes. The prefix has twice been misread as a missing
-  abstraction (2026-08) — it is the common surface.
+  the only family-visible step is ADDRESSING — the widget's
+  `${model}_${id}` option value rides `/targets/:targetId/ata`
+  verbatim and the app's `#getAtaGroupTarget` resolves the facade, so
+  even that step is app-side only. The prefix has twice been misread as
+  a missing abstraction (2026-08) — it is the common surface.
 - Flow-card device filters are `driver_id=<manifest owners>&capabilities=<cap>`,
   both parts mechanical: `capabilities=` is the card's real precondition
   (the run listeners are capability-generic and triggers fire through

--- a/api.mts
+++ b/api.mts
@@ -4,6 +4,7 @@ import type * as Home from '@olivierzal/melcloud-api/home'
 import type { Homey } from 'homey/lib/Homey'
 import { getErrorMessage } from '@olivierzal/homey-kit'
 import {
+  type BaseAPIAdapter,
   type HomeBuildingZone,
   type HomeDeviceZone,
   type LoginCredentials,
@@ -13,6 +14,7 @@ import {
 } from '@olivierzal/melcloud-api'
 
 import type {
+  Api,
   HolidayModeSettings,
   TargetHolidayModeState,
   TargetProtectionState,
@@ -33,6 +35,27 @@ const API_DISPLAY_NAMES = {
   classic: 'MELCloud Classic',
   home: 'MELCloud Home',
 } as const
+
+// The client behind each API id — the addressing map of the one
+// `/sessions/:api` resource, where the family is the only visible step.
+const API_CLIENTS: Record<Api, (app: Homey['app']) => BaseAPIAdapter> = {
+  classic: (app) => app.classicApi,
+  home: (app) => app.homeApi,
+}
+
+const isApi = (value: string): value is Api => Object.hasOwn(API_CLIENTS, value)
+
+// A session path names one of the two APIs; anything else is a stale
+// or hand-built address.
+const toApi = (value: string): Api => {
+  if (!isApi(value)) {
+    throw new RangeError(`Invalid API: ${value}`)
+  }
+  return value
+}
+
+const getApiClient = ({ app }: Homey, service: Api): BaseAPIAdapter =>
+  API_CLIENTS[service](app)
 
 // The webview only receives an error MESSAGE across the app bridge, so
 // login failures are classified here, where `instanceof` still works:
@@ -94,22 +117,21 @@ const toOptionalNonNegativeInt = (
   value === undefined ? undefined : toNonNegativeInt(value, { field })
 
 const api = {
-  classicAuthenticate: async ({
+  authenticate: async ({
     body,
     homey,
+    params,
   }: {
     body: LoginCredentials
     homey: Homey
+    params: { api: string }
   }): Promise<void> => {
+    const service = toApi(params.api)
     try {
-      await homey.app.classicApi.authenticate(body)
+      await getApiClient(homey, service).authenticate(body)
     } catch (error) {
-      throw toLoginFailure(homey, 'classic', error)
+      throw toLoginFailure(homey, service, error)
     }
-  },
-  classicLogOut: ({ homey: { app } }: { homey: Homey }): void => {
-    logSettingsRoute(app, 'DELETE /classic/sessions')
-    app.classicApi.logOut()
   },
   getClassicBuildings: (): Classic.BuildingZone[] => getClassicBuildings(),
   /**
@@ -196,38 +218,27 @@ const api = {
     logSettingsRoute(app, 'GET /webview-hashes')
     return getWebviewHashes()
   },
-  homeAuthenticate: async ({
-    body,
+  isAuthenticated: async ({
     homey,
-  }: {
-    body: LoginCredentials
-    homey: Homey
-  }): Promise<void> => {
-    try {
-      await homey.app.homeApi.authenticate(body)
-    } catch (error) {
-      throw toLoginFailure(homey, 'home', error)
-    }
-  },
-  homeLogOut: ({ homey: { app } }: { homey: Homey }): void => {
-    logSettingsRoute(app, 'DELETE /home/sessions')
-    app.homeApi.logOut()
-  },
-  isClassicAuthenticated: async ({
-    homey: { app },
+    params,
   }: {
     homey: Homey
+    params: { api: string }
   }): Promise<boolean> => {
-    logSettingsRoute(app, 'GET /classic/sessions')
-    return app.classicApi.ensureAuthenticated()
+    const service = toApi(params.api)
+    logSettingsRoute(homey.app, `GET /sessions/${service}`)
+    return getApiClient(homey, service).ensureAuthenticated()
   },
-  isHomeAuthenticated: async ({
-    homey: { app },
+  logOut: ({
+    homey,
+    params,
   }: {
     homey: Homey
-  }): Promise<boolean> => {
-    logSettingsRoute(app, 'GET /home/sessions')
-    return app.homeApi.ensureAuthenticated()
+    params: { api: string }
+  }): void => {
+    const service = toApi(params.api)
+    logSettingsRoute(homey.app, `DELETE /sessions/${service}`)
+    getApiClient(homey, service).logOut()
   },
   logWebviewBoot: ({
     body,

--- a/app.json
+++ b/app.json
@@ -1,13 +1,9 @@
 {
   "_comment": "This file is generated. Please edit .homeycompose/app.json instead.",
   "api": {
-    "classicAuthenticate": {
+    "authenticate": {
       "method": "POST",
-      "path": "/classic/sessions"
-    },
-    "classicLogOut": {
-      "method": "DELETE",
-      "path": "/classic/sessions"
+      "path": "/sessions/:api"
     },
     "getClassicBuildings": {
       "method": "GET",
@@ -53,21 +49,13 @@
       "method": "GET",
       "path": "/webview-hashes"
     },
-    "homeAuthenticate": {
-      "method": "POST",
-      "path": "/home/sessions"
+    "isAuthenticated": {
+      "method": "GET",
+      "path": "/sessions/:api"
     },
-    "homeLogOut": {
+    "logOut": {
       "method": "DELETE",
-      "path": "/home/sessions"
-    },
-    "isClassicAuthenticated": {
-      "method": "GET",
-      "path": "/classic/sessions"
-    },
-    "isHomeAuthenticated": {
-      "method": "GET",
-      "path": "/home/sessions"
+      "path": "/sessions/:api"
     },
     "logWebviewBoot": {
       "method": "POST",
@@ -11227,37 +11215,25 @@
           "method": "GET",
           "path": "/classic/capabilities/ata"
         },
-        "getClassicAtaDetailedStates": {
-          "method": "GET",
-          "path": "/classic/zones/:zoneType/:zoneId/ata/details"
-        },
-        "getClassicAtaState": {
-          "method": "GET",
-          "path": "/classic/zones/:zoneType/:zoneId/ata"
-        },
         "getClassicBuildings": {
           "method": "GET",
           "path": "/classic/buildings"
-        },
-        "getHomeAtaState": {
-          "method": "GET",
-          "path": "/home/devices/:deviceId/ata"
         },
         "getHomeAtaTargets": {
           "method": "GET",
           "path": "/home/targets/ata"
         },
-        "getHomeBuildingAtaModes": {
-          "method": "GET",
-          "path": "/home/buildings/:buildingId/ata/modes"
-        },
-        "getHomeBuildingAtaState": {
-          "method": "GET",
-          "path": "/home/buildings/:buildingId/ata"
-        },
         "getLanguage": {
           "method": "GET",
           "path": "/language"
+        },
+        "getTargetAtaModes": {
+          "method": "GET",
+          "path": "/targets/:targetId/ata/modes"
+        },
+        "getTargetAtaState": {
+          "method": "GET",
+          "path": "/targets/:targetId/ata"
         },
         "getWebviewHashes": {
           "method": "GET",
@@ -11267,17 +11243,9 @@
           "method": "POST",
           "path": "/boot-error"
         },
-        "updateClassicAtaState": {
+        "updateTargetAtaState": {
           "method": "PUT",
-          "path": "/classic/zones/:zoneType/:zoneId/ata"
-        },
-        "updateHomeAtaState": {
-          "method": "PUT",
-          "path": "/home/devices/:deviceId/ata"
-        },
-        "updateHomeBuildingAtaState": {
-          "method": "PUT",
-          "path": "/home/buildings/:buildingId/ata"
+          "path": "/targets/:targetId/ata"
         }
       },
       "name": {
@@ -11341,57 +11309,33 @@
     },
     "charts": {
       "api": {
-        "getClassicDevices": {
+        "getDevices": {
           "method": "GET",
-          "path": "/classic/devices"
-        },
-        "getClassicEnergyReport": {
-          "method": "GET",
-          "path": "/classic/devices/:deviceId/logs/report"
-        },
-        "getClassicHourlyTemperatures": {
-          "method": "GET",
-          "path": "/classic/devices/:deviceId/logs/hourly-temperatures"
-        },
-        "getClassicOperationModes": {
-          "method": "GET",
-          "path": "/classic/devices/:deviceId/logs/operation-modes"
-        },
-        "getClassicSignal": {
-          "method": "GET",
-          "path": "/classic/devices/:deviceId/logs/signal"
-        },
-        "getClassicTemperatures": {
-          "method": "GET",
-          "path": "/classic/devices/:deviceId/logs/temperatures"
-        },
-        "getHomeDevices": {
-          "method": "GET",
-          "path": "/home/devices"
-        },
-        "getHomeEnergyReport": {
-          "method": "GET",
-          "path": "/home/devices/:deviceId/logs/report"
-        },
-        "getHomeHourlyTemperatures": {
-          "method": "GET",
-          "path": "/home/devices/:deviceId/logs/hourly-temperatures"
-        },
-        "getHomeOperationModes": {
-          "method": "GET",
-          "path": "/home/devices/:deviceId/logs/operation-modes"
-        },
-        "getHomeSignal": {
-          "method": "GET",
-          "path": "/home/devices/:deviceId/logs/signal"
-        },
-        "getHomeTemperatures": {
-          "method": "GET",
-          "path": "/home/devices/:deviceId/logs/temperatures"
+          "path": "/devices"
         },
         "getLanguage": {
           "method": "GET",
           "path": "/language"
+        },
+        "getTargetEnergyReport": {
+          "method": "GET",
+          "path": "/targets/:targetId/logs/report"
+        },
+        "getTargetHourlyTemperatures": {
+          "method": "GET",
+          "path": "/targets/:targetId/logs/hourly-temperatures"
+        },
+        "getTargetOperationModes": {
+          "method": "GET",
+          "path": "/targets/:targetId/logs/operation-modes"
+        },
+        "getTargetSignal": {
+          "method": "GET",
+          "path": "/targets/:targetId/logs/signal"
+        },
+        "getTargetTemperatures": {
+          "method": "GET",
+          "path": "/targets/:targetId/logs/temperatures"
         },
         "getWebviewHashes": {
           "method": "GET",

--- a/app.mts
+++ b/app.mts
@@ -1,5 +1,9 @@
 import 'source-map-support/register.js'
 
+import type {
+  FullReportSurface,
+  ReportSurface,
+} from '@olivierzal/melcloud-api/report'
 import {
   fireAndForget,
   NotFoundError,
@@ -26,8 +30,6 @@ import {
   type SettingManager,
   type SyncCallback,
   isClassicAtaFacade,
-  NoChangesError,
-  operationModeToClassic,
   resolveErrorLogWindow,
 } from '@olivierzal/melcloud-api'
 import { Intl, Temporal } from 'temporal-polyfill'
@@ -41,7 +43,6 @@ import type {
   TargetProtectionState,
 } from './types/api.mts'
 import type { HomeySettings } from './types/app-settings.mts'
-import type { GroupAtaStates } from './types/classic-ata.mts'
 import type { DeviceSettings, Settings } from './types/device-settings.mts'
 import type { DriverCapabilitiesOptions } from './types/driver-settings.mts'
 import type {
@@ -51,8 +52,11 @@ import type {
 import type { HomeDeviceFacade } from './types/home.mts'
 import type { ManifestDriverCapabilitiesOptions } from './types/manifest.mts'
 import type { MELCloudDevice, MELCloudDriver } from './types/melcloud.mts'
-import type { GetAtaOptions } from './types/widgets.mts'
-import type { DeviceOrZoneData, ZoneData } from './types/zone.mts'
+import type {
+  DeviceOrZoneData,
+  FlatDeviceZone,
+  ZoneData,
+} from './types/zone.mts'
 import {
   changelog,
   fanSpeed,
@@ -66,7 +70,6 @@ import { getCapabilityFlowStep } from './lib/capability-flow-step.mts'
 import { setClassicFacadeManager } from './lib/classic-facade-manager.mts'
 import { type Homey, App } from './lib/homey.mts'
 import { getTimeZone } from './lib/temporal.mts'
-import { typedFromEntries } from './lib/typed-object.mts'
 import { unwrapResult } from './lib/unwrap-result.mts'
 import { toNonNegativeInt, toZoneValueData } from './lib/validation.mts'
 import {
@@ -158,12 +161,14 @@ const getLocalizedCapabilitiesOptions = (
   })),
 })
 
-// The ATA group surface shared by the zone facades and — per the
-// melcloud-api contract this feature tracks — the ATA device facade, which
-// emulates it as a group of one.
-type ClassicAtaGroupFacade = Pick<
+// The ATA group surface every target answers — Classic zone facades,
+// both families' ATA device facades (each a group of one) and the Home
+// building facade — per the melcloud-api contract this feature tracks:
+// state and member modes speak the ONE Classic-numbered vocabulary
+// whichever API serves the target.
+type AtaGroupTarget = Pick<
   Classic.ZoneFacade,
-  'getGroup' | 'updateGroupState'
+  'getGroup' | 'getMemberOperationModes' | 'updateGroupState'
 >
 
 // A flat autocomplete/select item: the `${model}_${id}` option value as
@@ -368,71 +373,6 @@ export default class MELCloudApp extends App {
     )
   }
 
-  public getClassicAtaDetailedStates({
-    status,
-    zoneId,
-    zoneType,
-  }: GetAtaOptions & ZoneData): GroupAtaStates {
-    // Annotated to collapse the BuildingFacade | ZoneFacade `devices` union
-    // into one array type, so the `.filter` type guard below can narrow.
-    const { devices }: { devices: readonly Classic.DeviceAny[] } =
-      this.getClassicFacade(zoneType, zoneId)
-    if (devices.length === 0) {
-      throw new NotFoundError(this.homey.__('errors.deviceNotFound'))
-    }
-    const ataData = devices
-      .filter((device) =>
-        Classic.isDeviceOfType(device, Classic.DeviceType.Ata),
-      )
-      .map(({ data }) => data)
-      .filter((data) => status !== 'on' || data.Power)
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- narrowing generic Classic.GroupState to typed GroupAtaStates
-    return typedFromEntries(
-      this.#getAtaCapabilityConfigs().map(({ key }) => [
-        key,
-        ataData.map((data) => data[key]),
-      ]),
-    ) as GroupAtaStates
-  }
-
-  public async getClassicAtaState({
-    zoneId,
-    zoneType,
-  }: DeviceOrZoneData): Promise<Classic.GroupState> {
-    return unwrapResult(
-      await this.#getClassicAtaGroupFacade({ zoneId, zoneType }).getGroup(),
-    )
-  }
-
-  // The chart pickers' Classic vocabulary: the flat device leaves, each
-  // suffixed with its building, drawn from the shared zone source.
-  public getClassicDeviceZones(type?: Classic.DeviceType): Classic.Zone[] {
-    return this.getClassicTargets(type)
-      .filter((node) => node.model === 'devices')
-      .map((node) => ({
-        deviceType: node.deviceType,
-        id: node.id,
-        level: node.level,
-        model: 'devices' as const,
-        name: toFlatName(node),
-      }))
-      .toSorted(byName)
-  }
-
-  public async getClassicEnergyReport({
-    days,
-    deviceId,
-  }: {
-    days: number
-    deviceId: string
-  }): Promise<ReportChartLineOptions> {
-    return unwrapResult(
-      await this.getClassicFacade('devices', deviceId).getEnergyReport(
-        this.#chartDaysQuery(days),
-      ),
-    )
-  }
-
   public getClassicFacade<T extends Classic.DeviceType>(
     zoneType: 'devices',
     id: number | string,
@@ -460,66 +400,12 @@ export default class MELCloudApp extends App {
     return facade
   }
 
-  public async getClassicHourlyTemperatures({
-    deviceId,
-    hour,
-  }: {
-    deviceId: string
-    hour?: Hour | undefined
-  }): Promise<ReportChartLineOptions> {
-    return unwrapResult(
-      await this.getClassicFacade('devices', deviceId).getHourlyTemperatures(
-        hour,
-      ),
-    )
-  }
-
-  public async getClassicOperationModes({
-    days,
-    deviceId,
-  }: {
-    days: number
-    deviceId: string
-  }): Promise<ReportChartPieOptions> {
-    return unwrapResult(
-      await this.getClassicFacade('devices', deviceId).getOperationModes(
-        this.#chartDaysQuery(days),
-      ),
-    )
-  }
-
-  public async getClassicSignal({
-    deviceId,
-    hour,
-  }: {
-    deviceId: string
-    hour?: Hour | undefined
-  }): Promise<ReportChartLineOptions> {
-    return unwrapResult(
-      await this.getClassicFacade('devices', deviceId).getSignalStrength(hour),
-    )
-  }
-
   // The Classic zone source: every zone (buildings, floors, areas, devices)
   // flattened, each stamped with its owning building name, optionally
   // narrowed to one device type. Every flat Classic picker draws from
   // here with the filters it needs.
   public getClassicTargets(type?: Classic.DeviceType): Classic.FlatZone[] {
     return this.#facadeManager.getZones({ type })
-  }
-
-  public async getClassicTemperatures({
-    days,
-    deviceId,
-  }: {
-    days: number
-    deviceId: string
-  }): Promise<ReportChartLineOptions> {
-    return unwrapResult(
-      await this.getClassicFacade('devices', deviceId).getTemperatures(
-        this.#chartDaysQuery(days),
-      ),
-    )
   }
 
   public getDeviceSettings(): DeviceSettings {
@@ -538,6 +424,27 @@ export default class MELCloudApp extends App {
     type: T,
   ): Classic.Device<T>[] {
     return this.#classicRegistry.getDevicesByType(type)
+  }
+
+  // The chart pickers' vocabulary: the flat device leaves of BOTH
+  // dialects as one alphabetical list, each suffixed with its building
+  // and carrying its `deviceType` tag, so the widget derives every
+  // per-chart line-up from a single fetch.
+  public getDeviceZones(): FlatDeviceZone[] {
+    return [
+      ...this.getClassicTargets()
+        .filter((node) => node.model === 'devices')
+        .map((node) => ({
+          deviceType: node.deviceType,
+          id: node.id,
+          level: node.level,
+          model: 'devices' as const,
+          name: toFlatName(node),
+        })),
+      ...this.getHomeTargets()
+        .filter((node): node is HomeDeviceZone => node.model === 'homeDevices')
+        .map((node) => ({ ...node, name: toFlatName(node) })),
+    ].toSorted(byName)
   }
 
   public getDriverSettings(): Partial<Record<string, DriverSetting[]>> {
@@ -596,59 +503,8 @@ export default class MELCloudApp extends App {
     }
   }
 
-  public async getHomeAtaState(deviceId: string): Promise<Classic.GroupState> {
-    return unwrapResult(
-      await this.getHomeFacade(deviceId, Home.DeviceType.Ata).getGroup(),
-    )
-  }
-
-  // Member operation modes in the Classic vocabulary — what the widget's
-  // mixed-mode scene resolver consumes.
-  public getHomeBuildingAtaModes(buildingId: string): number[] {
-    return this.#getHomeBuildingFacade(buildingId)
-      .devices.filter((device) => device.isAta())
-      .map(
-        (device) =>
-          operationModeToClassic[
-            this.#homeFacadeManager.get(device).operationMode
-          ],
-      )
-  }
-
-  public async getHomeBuildingAtaState(
-    buildingId: string,
-  ): Promise<Classic.GroupState> {
-    return unwrapResult(
-      await this.#getHomeBuildingFacade(buildingId).getGroup(),
-    )
-  }
-
   public getHomeDevicesByType(type: Home.DeviceType): Home.Device[] {
     return this.#homeRegistry.getDevicesByType(type)
-  }
-
-  // The charts widget vocabulary: Home devices as flat selectable entries
-  // (no building nodes), each suffixed with its building, alpha-sorted, both
-  // types by default — the device leaves of the shared Home source.
-  public getHomeDeviceZones(type?: Home.DeviceType): HomeDeviceZone[] {
-    return this.getHomeTargets(type)
-      .filter((node): node is HomeDeviceZone => node.model === 'homeDevices')
-      .map((node) => ({ ...node, name: toFlatName(node) }))
-      .toSorted(byName)
-  }
-
-  public async getHomeEnergyReport({
-    days,
-    deviceId,
-  }: {
-    days: number
-    deviceId: string
-  }): Promise<ReportChartLineOptions> {
-    return unwrapResult(
-      await this.#getHomeDeviceFacade(deviceId).getEnergyReport(
-        this.#chartDaysQuery(days),
-      ),
-    )
   }
 
   public getHomeFacade<T extends Home.DeviceType>(
@@ -662,47 +518,6 @@ export default class MELCloudApp extends App {
     return this.#getHomeDeviceFacade(deviceId, type)
   }
 
-  public async getHomeHourlyTemperatures({
-    deviceId,
-    hour,
-  }: {
-    deviceId: string
-    hour?: Hour | undefined
-  }): Promise<ReportChartLineOptions> {
-    return unwrapResult(
-      await this.getHomeFacade(
-        deviceId,
-        Home.DeviceType.Atw,
-      ).getHourlyTemperatures(hour),
-    )
-  }
-
-  public async getHomeOperationModes({
-    days,
-    deviceId,
-  }: {
-    days: number
-    deviceId: string
-  }): Promise<ReportChartPieOptions> {
-    return unwrapResult(
-      await this.getHomeFacade(deviceId, Home.DeviceType.Atw).getOperationModes(
-        this.#chartDaysQuery(days),
-      ),
-    )
-  }
-
-  public async getHomeSignal({
-    deviceId,
-    hour,
-  }: {
-    deviceId: string
-    hour?: Hour | undefined
-  }): Promise<ReportChartLineOptions> {
-    return unwrapResult(
-      await this.#getHomeDeviceFacade(deviceId).getSignalStrength(hour),
-    )
-  }
-
   // The flattened Home picker list — name-sorted buildings (level 0) each
   // followed by its own devices (level 1); `type` narrows to one
   // connection type (the ATA group widget), omitted spans both (the
@@ -713,15 +528,30 @@ export default class MELCloudApp extends App {
     return this.#homeFacadeManager.getZones({ type })
   }
 
-  public async getHomeTemperatures({
+  // Member operation modes for the widget's mixed-mode scene resolver —
+  // powered units only (an off unit paints no scene), Classic-numbered
+  // whichever API serves the members.
+  public getTargetAtaModes(targetId: string): Classic.OperationMode[] {
+    return this.#getAtaGroupTarget(targetId).getMemberOperationModes({
+      poweredOnly: true,
+    })
+  }
+
+  public async getTargetAtaState(
+    targetId: string,
+  ): Promise<Classic.GroupState> {
+    return unwrapResult(await this.#getAtaGroupTarget(targetId).getGroup())
+  }
+
+  public async getTargetEnergyReport({
     days,
-    deviceId,
+    targetId,
   }: {
     days: number
-    deviceId: string
+    targetId: string
   }): Promise<ReportChartLineOptions> {
     return unwrapResult(
-      await this.#getHomeDeviceFacade(deviceId).getTemperatures(
+      await this.#getReportTarget(targetId).getEnergyReport(
         this.#chartDaysQuery(days),
       ),
     )
@@ -743,6 +573,32 @@ export default class MELCloudApp extends App {
     )
   }
 
+  public async getTargetHourlyTemperatures({
+    hour,
+    targetId,
+  }: {
+    targetId: string
+    hour?: Hour | undefined
+  }): Promise<ReportChartLineOptions> {
+    return unwrapResult(
+      await this.#getFullReportTarget(targetId).getHourlyTemperatures(hour),
+    )
+  }
+
+  public async getTargetOperationModes({
+    days,
+    targetId,
+  }: {
+    days: number
+    targetId: string
+  }): Promise<ReportChartPieOptions> {
+    return unwrapResult(
+      await this.#getFullReportTarget(targetId).getOperationModes(
+        this.#chartDaysQuery(days),
+      ),
+    )
+  }
+
   // Overheat protection exists on Home targets only: a Classic target
   // reads `null`, like a Home target that never configured it.
   public async getTargetOverheatProtection(
@@ -754,13 +610,29 @@ export default class MELCloudApp extends App {
       : unwrapResult(await target.getOverheatProtection())
   }
 
-  public async updateClassicAtaState({
-    state,
-    zoneId,
-    zoneType,
-  }: DeviceOrZoneData & { state: Classic.GroupState }): Promise<void> {
-    await this.#getClassicAtaGroupFacade({ zoneId, zoneType }).updateGroupState(
-      state,
+  public async getTargetSignal({
+    hour,
+    targetId,
+  }: {
+    targetId: string
+    hour?: Hour | undefined
+  }): Promise<ReportChartLineOptions> {
+    return unwrapResult(
+      await this.#getReportTarget(targetId).getSignalStrength(hour),
+    )
+  }
+
+  public async getTargetTemperatures({
+    days,
+    targetId,
+  }: {
+    days: number
+    targetId: string
+  }): Promise<ReportChartLineOptions> {
+    return unwrapResult(
+      await this.#getReportTarget(targetId).getTemperatures(
+        this.#chartDaysQuery(days),
+      ),
     )
   }
 
@@ -791,33 +663,19 @@ export default class MELCloudApp extends App {
     )
   }
 
-  public async updateHomeAtaState({
-    deviceId,
-    state,
-  }: {
-    deviceId: string
-    state: Classic.GroupState
-  }): Promise<void> {
-    try {
-      await this.getHomeFacade(deviceId, Home.DeviceType.Ata).updateGroupState(
-        state,
-      )
-    } catch (error) {
-      // A delta the device already matches is fine by definition.
-      if (!(error instanceof NoChangesError)) {
-        throw error
-      }
-    }
-  }
-
-  public async updateHomeBuildingAtaState({
-    buildingId,
-    state,
-  }: {
-    buildingId: string
-    state: Classic.GroupState
-  }): Promise<void> {
-    await this.#getHomeBuildingFacade(buildingId).updateGroupState(state)
+  // VERDICT (2026-08): no app-side no-change handling, on any leg. The
+  // pre-unification handlers disagreed (the Home device leg swallowed
+  // `NoChangesError`, its twins propagated), but melcloud-api 53.0.0
+  // pins no-op tolerance in the library itself — every `updateGroupState`
+  // resolves a delta the target already matches as the success it is —
+  // so nothing can propagate and a catch here would re-derive a library
+  // invariant. The widget's arming gate blocks empty bodies, not bodies
+  // the device caught up with meanwhile; those are successes too.
+  public async updateTargetAtaState(
+    targetId: string,
+    state: Classic.GroupState,
+  ): Promise<void> {
+    await this.#getAtaGroupTarget(targetId).updateGroupState(state)
   }
 
   public async updateTargetFrostProtection(
@@ -1037,10 +895,23 @@ export default class MELCloudApp extends App {
     ]
   }
 
+  // The ATA group twin of `#getSettingsTarget`: the targetId is the
+  // picker value verbatim, and addressing is the only family-visible
+  // step — everything downstream speaks the one group vocabulary.
+  #getAtaGroupTarget(targetId: string): AtaGroupTarget {
+    if (isHomeBuildingValue(targetId)) {
+      return this.#getHomeBuildingFacade(getHomeBuildingId(targetId))
+    }
+    if (isHomeDeviceValue(targetId)) {
+      return this.getHomeFacade(getHomeDeviceId(targetId), Home.DeviceType.Ata)
+    }
+    return this.#getClassicAtaGroupFacade(toZoneValueData(targetId))
+  }
+
   #getClassicAtaGroupFacade({
     zoneId,
     zoneType,
-  }: DeviceOrZoneData): ClassicAtaGroupFacade {
+  }: DeviceOrZoneData): AtaGroupTarget {
     if (zoneType !== 'devices') {
       return this.getClassicFacade(zoneType, zoneId)
     }
@@ -1065,6 +936,16 @@ export default class MELCloudApp extends App {
       return { entries: [], fromDate, nextFromDate, nextToDate }
     }
     return unwrapResult(await this.#classicApi.getErrorLog(query))
+  }
+
+  // The Classic leg both chart resolvers share: only the flat device
+  // leaves chart, so any other zone level answers the device error.
+  #getClassicReportDevice(targetId: string): FullReportSurface {
+    const { zoneId, zoneType } = toZoneValueData(targetId)
+    if (zoneType !== 'devices') {
+      throw new NotFoundError(this.homey.__('errors.deviceNotFound'))
+    }
+    return this.getClassicFacade('devices', zoneId)
   }
 
   #getDevices({
@@ -1098,6 +979,17 @@ export default class MELCloudApp extends App {
     return driverId === undefined
       ? drivers
       : drivers.filter((driver) => driver.id === driverId)
+  }
+
+  // Chart-target resolver for the ATW-only reads (hourly temperatures,
+  // operation modes): the Home leg pins the ATW type — a Home ATA
+  // target answers NotFoundError, nothing emulated, because its wire
+  // has no such report — while every Classic device answers the full
+  // surface (non-ATW types resolve empty charts wire-side).
+  #getFullReportTarget(targetId: string): FullReportSurface {
+    return isHomeDeviceValue(targetId)
+      ? this.getHomeFacade(getHomeDeviceId(targetId), Home.DeviceType.Atw)
+      : this.#getClassicReportDevice(targetId)
   }
 
   // A Home building is a zone in the picker vocabulary, so a missing
@@ -1165,6 +1057,14 @@ export default class MELCloudApp extends App {
     return isHomeDeviceValue(targetId)
       ? this.#getHomeDeviceFacade(getHomeDeviceId(targetId))
       : null
+  }
+
+  // Chart-target resolver for the reads every device-level target
+  // answers, on either dialect.
+  #getReportTarget(targetId: string): ReportSurface {
+    return isHomeDeviceValue(targetId)
+      ? this.#getHomeDeviceFacade(getHomeDeviceId(targetId))
+      : this.#getClassicReportDevice(targetId)
   }
 
   // The one target resolver behind the neutral settings routes: the
@@ -1392,10 +1292,7 @@ export default class MELCloudApp extends App {
     this.homey.dashboards
       .getWidget('charts')
       .registerSettingAutocompleteListener('default_zone', (query) =>
-        [
-          ...filterZonesByName(this.getClassicDeviceZones(), query),
-          ...filterZonesByName(this.getHomeDeviceZones(), query),
-        ].toSorted(byName),
+        filterZonesByName(this.getDeviceZones(), query),
       )
   }
 

--- a/lib/to-device-type.mts
+++ b/lib/to-device-type.mts
@@ -1,18 +1,4 @@
 import * as Classic from '@olivierzal/melcloud-api/classic'
-import * as Home from '@olivierzal/melcloud-api/home'
-
-const assertHomeDeviceType: (
-  value: string,
-) => asserts value is Home.DeviceType = (value) => {
-  if (!(Object.values(Home.DeviceType) as string[]).includes(value)) {
-    throw new RangeError(`Invalid Home.DeviceType: ${value}`)
-  }
-}
-
-export const toHomeDeviceType = (value: string): Home.DeviceType => {
-  assertHomeDeviceType(value)
-  return value
-}
 
 const assertDeviceType: (
   value: number,

--- a/public/zones.mts
+++ b/public/zones.mts
@@ -16,8 +16,6 @@ export const getSubzones = (zone: PickerZone): Classic.Zone[] => [
 export const getZoneId = (id: number | string, model: string): string =>
   `${model}_${String(id)}`
 
-export const getZonePath = (value: string): string => value.replace('_', '/')
-
 export const getZoneName = (name: string, level: number): string =>
   `${'···'.repeat(level)} ${name}`
 

--- a/settings/index.mts
+++ b/settings/index.mts
@@ -594,7 +594,7 @@ class AuthManager {
     }
     await this.#gate.runBusy(async () => {
       try {
-        await homeyApiPost(this.#homey, `/${api}/sessions`, {
+        await homeyApiPost(this.#homey, `/sessions/${api}`, {
           password,
           username,
         } satisfies LoginCredentials)
@@ -626,7 +626,7 @@ class AuthManager {
         // The app-side logout owns the teardown (session, credentials,
         // backoff, sync timer, registry) — the webview never touches the
         // library's persisted keys.
-        await homeyApiDelete(this.#homey, `/${api}/sessions`)
+        await homeyApiDelete(this.#homey, `/sessions/${api}`)
         this.#credentialsByApi[api] = {}
         this.#syncInputsFromCredentials()
         this.#gate.markSaved()
@@ -1970,7 +1970,7 @@ class SettingsApp {
   // caller must not turn an accepted login into a failure alert.
   async #fetchSessionState(api: Api): Promise<boolean> {
     try {
-      return await homeyApiGet<boolean>(this.#homey, `/${api}/sessions`)
+      return await homeyApiGet<boolean>(this.#homey, `/sessions/${api}`)
     } catch {
       return false
     }
@@ -2065,8 +2065,8 @@ class SettingsApp {
     const [settings, isClassicAuthenticated, isHomeAuthenticated] =
       await Promise.all([
         SettingsApp.#fetchHomeySettings(this.#homey),
-        homeyApiGet<boolean>(this.#homey, '/classic/sessions'),
-        homeyApiGet<boolean>(this.#homey, '/home/sessions'),
+        homeyApiGet<boolean>(this.#homey, '/sessions/classic'),
+        homeyApiGet<boolean>(this.#homey, '/sessions/home'),
         SettingsApp.#setDocumentLanguage(this.#homey),
         this.#deviceSettingsManager.fetchDeviceSettings(),
       ])

--- a/tests/ata-group-harness.ts
+++ b/tests/ata-group-harness.ts
@@ -182,10 +182,10 @@ export const homeAtaTargetsFixture = (): unknown => [
 export const widgetRoutes = (): Record<string, unknown> => ({
   'GET /classic/buildings?type=0': classicAtaBuildingsFixture(),
   'GET /classic/capabilities/ata': ataCapabilitiesFixture(),
-  'GET /classic/zones/buildings/1/ata': groupStateFixture(),
   'GET /home/targets/ata': homeAtaTargetsFixture(),
   'GET /language': 'fr',
-  'PUT /classic/zones/buildings/1/ata': undefined,
+  'GET /targets/buildings_1/ata': groupStateFixture(),
+  'PUT /targets/buildings_1/ata': undefined,
 })
 
 // ── Widget SDK mock ──

--- a/tests/unit/animation.test.ts
+++ b/tests/unit/animation.test.ts
@@ -280,10 +280,8 @@ describe('animation controller', () => {
     const { container, controller } = createController({
       routes: {
         ...widgetRoutes(),
-        'GET /classic/zones/devices/11/ata/details?status=on': {
-          // The unknown vocabulary entry maps to no scene element.
-          OperationMode: [HEAT, COOL, 99],
-        },
+        // The unknown vocabulary entry maps to no scene element.
+        'GET /targets/devices_11/ata/modes': [HEAT, COOL, 99],
       },
     })
     addZone('devices_11')
@@ -301,7 +299,7 @@ describe('animation controller', () => {
     const { container, controller } = createController({
       routes: {
         ...widgetRoutes(),
-        'GET /home/buildings/b_1/ata/modes': [COOL],
+        'GET /targets/homeBuildings_b_1/ata/modes': [COOL],
       },
     })
     addZone('homeBuildings_b_1')
@@ -315,9 +313,7 @@ describe('animation controller', () => {
   it('should keep the running scene when the mode fetch fails', async () => {
     const { container, controller } = createController({
       failures: {
-        'GET /classic/zones/devices/11/ata/details?status=on': new Error(
-          'modes down',
-        ),
+        'GET /targets/devices_11/ata/modes': new Error('modes down'),
       },
     })
     addZone('devices_11')
@@ -335,14 +331,13 @@ describe('animation controller', () => {
     const modes = Promise.withResolvers<unknown>()
     const { container, controller } = createController({
       deferredRoutes: {
-        'GET /classic/zones/devices/11/ata/details?status=on': async () =>
-          modes.promise,
+        'GET /targets/devices_11/ata/modes': async () => modes.promise,
       },
     })
     addZone('devices_11')
     const slower = controller.applyAnimation(state({ OperationMode: MIXED }))
     await controller.applyAnimation(state({ OperationMode: HEAT }))
-    modes.resolve({ OperationMode: [COOL] })
+    modes.resolve([COOL])
     await slower
     await waitForSpawnTicks()
 

--- a/tests/unit/api.test.ts
+++ b/tests/unit/api.test.ts
@@ -328,23 +328,57 @@ describe('api', () => {
     })
   })
 
-  describe('home authentication', () => {
-    it('should delegate to app.homeApi.authenticate with body', async () => {
+  describe('authentication', () => {
+    it('should delegate the classic login to app.classicApi.authenticate', async () => {
+      const credentials = mock<LoginCredentials>({
+        password: 'pass',
+        username: 'user',
+      })
+      mockClassicAuthenticate.mockResolvedValue()
+
+      await api.authenticate({
+        body: credentials,
+        homey,
+        params: { api: 'classic' },
+      })
+
+      expect(mockClassicAuthenticate).toHaveBeenCalledWith(credentials)
+      expect(mockHomeAuthenticate).not.toHaveBeenCalled()
+    })
+
+    it('should delegate the home login to app.homeApi.authenticate', async () => {
       mockHomeAuthenticate.mockResolvedValue()
       const body = mock<LoginCredentials>()
 
-      await api.homeAuthenticate({ body, homey })
+      await api.authenticate({ body, homey, params: { api: 'home' } })
 
       expect(mockHomeAuthenticate).toHaveBeenCalledWith(body)
+      expect(mockClassicAuthenticate).not.toHaveBeenCalled()
     })
 
-    it('should propagate errors from app.homeApi.authenticate', async () => {
+    it('should propagate authenticate errors', async () => {
       const error = new Error('invalid credentials')
-      mockHomeAuthenticate.mockRejectedValue(error)
+      mockClassicAuthenticate.mockRejectedValue(error)
 
       await expect(
-        api.homeAuthenticate({ body: mock<LoginCredentials>(), homey }),
+        api.authenticate({
+          body: mock<LoginCredentials>(),
+          homey,
+          params: { api: 'classic' },
+        }),
       ).rejects.toThrow(error)
+    })
+
+    it('should reject an unknown API id before touching any client', async () => {
+      await expect(
+        api.authenticate({
+          body: mock<LoginCredentials>(),
+          homey,
+          params: { api: 'legacy' },
+        }),
+      ).rejects.toThrow('Invalid API: legacy')
+      expect(mockClassicAuthenticate).not.toHaveBeenCalled()
+      expect(mockHomeAuthenticate).not.toHaveBeenCalled()
     })
   })
 
@@ -355,7 +389,11 @@ describe('api', () => {
       )
 
       await expect(
-        api.classicAuthenticate({ body: mock<LoginCredentials>(), homey }),
+        api.authenticate({
+          body: mock<LoginCredentials>(),
+          homey,
+          params: { api: 'classic' },
+        }),
       ).rejects.toThrow('settings.authenticate.rejected')
       expect(mockTranslate).toHaveBeenCalledWith(
         'settings.authenticate.rejected',
@@ -369,7 +407,11 @@ describe('api', () => {
       )
 
       await expect(
-        api.homeAuthenticate({ body: mock<LoginCredentials>(), homey }),
+        api.authenticate({
+          body: mock<LoginCredentials>(),
+          homey,
+          params: { api: 'home' },
+        }),
       ).rejects.toThrow('settings.authenticate.throttled')
       expect(mockTranslate).toHaveBeenCalledWith(
         'settings.authenticate.throttled',
@@ -380,72 +422,45 @@ describe('api', () => {
 
   describe('logout', () => {
     it('should delegate the Classic logout to app.classicApi.logOut', () => {
-      api.classicLogOut({ homey })
+      api.logOut({ homey, params: { api: 'classic' } })
 
       expect(mockClassicLogOut).toHaveBeenCalledTimes(1)
+      expect(mockHomeLogOut).not.toHaveBeenCalled()
     })
 
     it('should delegate the Home logout to app.homeApi.logOut', () => {
-      api.homeLogOut({ homey })
+      api.logOut({ homey, params: { api: 'home' } })
 
       expect(mockHomeLogOut).toHaveBeenCalledTimes(1)
+      expect(mockClassicLogOut).not.toHaveBeenCalled()
     })
   })
 
-  describe('classic session retrieval', () => {
-    it('should delegate to app.classicApi.ensureAuthenticated', async () => {
+  describe('session retrieval', () => {
+    it('should delegate the classic probe to app.classicApi.ensureAuthenticated', async () => {
       mockEnsureClassicAuthenticated.mockResolvedValue(true)
 
-      await expect(api.isClassicAuthenticated({ homey })).resolves.toBe(true)
+      await expect(
+        api.isAuthenticated({ homey, params: { api: 'classic' } }),
+      ).resolves.toBe(true)
       expect(mockEnsureClassicAuthenticated).toHaveBeenCalledTimes(1)
     })
 
-    it('should return false when not authenticated', async () => {
-      mockEnsureClassicAuthenticated.mockResolvedValue(false)
-
-      await expect(api.isClassicAuthenticated({ homey })).resolves.toBe(false)
-    })
-  })
-
-  describe('home session retrieval', () => {
-    it('should delegate the lazy self-heal to the SDK contract', async () => {
+    it('should delegate the home lazy self-heal to the SDK contract', async () => {
       mockEnsureHomeAuthenticated.mockResolvedValue(true)
 
-      const isAuthenticated = await api.isHomeAuthenticated({ homey })
-
-      expect(isAuthenticated).toBe(true)
+      await expect(
+        api.isAuthenticated({ homey, params: { api: 'home' } }),
+      ).resolves.toBe(true)
       expect(mockEnsureHomeAuthenticated).toHaveBeenCalledTimes(1)
     })
 
     it('should return false when the SDK cannot restore the session', async () => {
       mockEnsureHomeAuthenticated.mockResolvedValue(false)
 
-      const isAuthenticated = await api.isHomeAuthenticated({ homey })
-
-      expect(isAuthenticated).toBe(false)
-    })
-  })
-
-  describe('authentication', () => {
-    it('should delegate to app.classicApi.authenticate with body', async () => {
-      const credentials = mock<LoginCredentials>({
-        password: 'pass',
-        username: 'user',
-      })
-      mockClassicAuthenticate.mockResolvedValue()
-
-      await api.classicAuthenticate({ body: credentials, homey })
-
-      expect(mockClassicAuthenticate).toHaveBeenCalledWith(credentials)
-    })
-
-    it('should propagate errors from app.classicApi.authenticate', async () => {
-      const error = new Error('invalid credentials')
-      mockClassicAuthenticate.mockRejectedValue(error)
-
       await expect(
-        api.classicAuthenticate({ body: mock<LoginCredentials>(), homey }),
-      ).rejects.toThrow(error)
+        api.isAuthenticated({ homey, params: { api: 'home' } }),
+      ).resolves.toBe(false)
     })
   })
 

--- a/tests/unit/app.test.ts
+++ b/tests/unit/app.test.ts
@@ -8,7 +8,6 @@ import {
   type Result,
   type SyncCallback,
   err,
-  NoChangesError,
   ok,
   UpdateRejectedError,
 } from '@olivierzal/melcloud-api'
@@ -106,7 +105,6 @@ const mockFacadeManagerGetById =
 const mockFacadeManagerGetZones = vi
   .fn<(options?: { type?: Classic.DeviceType }) => unknown[]>()
   .mockReturnValue([])
-const mockHomeFacadeManagerGet = vi.fn<(model: unknown) => unknown>()
 const mockHomeFacadeManagerGetById = vi.fn<(id: string) => unknown>()
 const mockHomeFacadeManagerGetZones =
   vi.fn<(params?: { type?: Home.DeviceType }) => unknown[]>()
@@ -285,7 +283,6 @@ const newMockFacadeManager =
 const newMockHomeFacadeManager =
   function newMockHomeFacadeManager(): Home.FacadeManager {
     return mock<Home.FacadeManager>({
-      get: mockHomeFacadeManagerGet,
       getBuilding: mockHomeFacadeManagerGetBuilding,
       getById: mockHomeFacadeManagerGetById,
       getZones: mockHomeFacadeManagerGetZones,
@@ -1013,70 +1010,36 @@ describe('melCloudApp', () => {
     })
   })
 
-  describe('ata detailed states', () => {
-    it('should return detailed states for ATA devices', async () => {
-      const mockFacade = mock<Classic.BuildingFacade>({
-        devices: [
-          {
-            data: { FanSpeed: 3, Power: true, SetTemperature: 21 },
-            type: Classic.DeviceType.Ata,
-          },
-        ],
-      })
-      await initWithFacade(app, mockFacade)
+  describe('target ata modes', () => {
+    it('should ask the classic zone facade for powered member modes', async () => {
+      const getMemberOperationModes = vi
+        .fn<() => Classic.OperationMode[]>()
+        .mockReturnValue([
+          Classic.OperationMode.cool,
+          Classic.OperationMode.heat,
+        ])
+      await initWithFacade(
+        app,
+        mock<Classic.ZoneFacade>({ getMemberOperationModes }),
+      )
 
-      const detailedValues = app.getClassicAtaDetailedStates({
-        zoneId: '1',
-        zoneType: 'buildings',
+      expect(app.getTargetAtaModes('buildings_1')).toStrictEqual([
+        Classic.OperationMode.cool,
+        Classic.OperationMode.heat,
+      ])
+      expect(getMemberOperationModes).toHaveBeenCalledWith({
+        poweredOnly: true,
       })
-
-      expect(detailedValues).toBeDefined()
-      expect(detailedValues.Power).toStrictEqual([true])
     })
 
-    it('should filter by power status when status is on', async () => {
-      const mockFacade = mock<Classic.BuildingFacade>({
-        devices: [
-          {
-            data: mock<Classic.ListDeviceDataAta>({
-              FanSpeed: 3,
-              Power: true,
-              SetTemperature: 21,
-            }),
-            type: Classic.DeviceType.Ata,
-          },
-          {
-            data: mock<Classic.ListDeviceDataAta>({
-              FanSpeed: 2,
-              Power: false,
-              SetTemperature: 19,
-            }),
-            type: Classic.DeviceType.Ata,
-          },
-        ],
-      })
-      await initWithFacade(app, mockFacade)
+    it('should reject an invalid classic zone type', async () => {
+      await app.onInit()
 
-      const detailedValues = app.getClassicAtaDetailedStates({
-        status: 'on',
-        zoneId: '1',
-        zoneType: 'buildings',
-      })
-
-      expect(detailedValues.Power).toStrictEqual([true])
-    })
-
-    it('should throw when no devices found', async () => {
-      const mockFacade = mock<Classic.BuildingFacade>({ devices: [] })
-      await initWithFacade(app, mockFacade)
-
-      expect(() =>
-        app.getClassicAtaDetailedStates({ zoneId: '1', zoneType: 'buildings' }),
-      ).toThrow('errors.deviceNotFound')
+      expect(() => app.getTargetAtaModes('constructor_1')).toThrow(RangeError)
     })
   })
 
-  describe('ata values', () => {
+  describe('target ata state', () => {
     it('should delegate to facade getGroup', async () => {
       const mockGroupState = mock<Classic.GroupState>()
       const mockFacade = mock<Classic.BuildingFacade>({
@@ -1086,10 +1049,7 @@ describe('melCloudApp', () => {
       })
       await initWithFacade(app, mockFacade)
 
-      const groupState = await app.getClassicAtaState({
-        zoneId: '1',
-        zoneType: 'buildings',
-      })
+      const groupState = await app.getTargetAtaState('buildings_1')
 
       expect(groupState).toBe(mockGroupState)
     })
@@ -1105,10 +1065,7 @@ describe('melCloudApp', () => {
       mockFacadeManagerGetById.mockReturnValue(mockFacade)
       await app.onInit()
 
-      const groupState = await app.getClassicAtaState({
-        zoneId: '1',
-        zoneType: 'devices',
-      })
+      const groupState = await app.getTargetAtaState('devices_1')
 
       expect(groupState).toBe(mockGroupState)
       expect(mockFacadeManagerGetById).toHaveBeenCalledWith('devices', 1)
@@ -1122,9 +1079,9 @@ describe('melCloudApp', () => {
       )
       await app.onInit()
 
-      await expect(
-        app.getClassicAtaState({ zoneId: '1', zoneType: 'devices' }),
-      ).rejects.toThrow('errors.deviceNotFound')
+      await expect(app.getTargetAtaState('devices_1')).rejects.toThrow(
+        'errors.deviceNotFound',
+      )
     })
   })
 
@@ -1695,9 +1652,9 @@ describe('melCloudApp', () => {
       })
       await app.onInit()
 
-      await expect(app.getHomeAtaState('device-1')).resolves.toStrictEqual(
-        groupState,
-      )
+      await expect(
+        app.getTargetAtaState('homeDevices_device-1'),
+      ).resolves.toStrictEqual(groupState)
     })
 
     it('should push the update delta through the group contract', async () => {
@@ -1707,9 +1664,9 @@ describe('melCloudApp', () => {
       setupHomeAtaFacade({ updateGroupState: mockUpdateGroupState })
       await app.onInit()
 
-      await app.updateHomeAtaState({
-        deviceId: 'device-1',
-        state: { Power: true, SetTemperature: 20 },
+      await app.updateTargetAtaState('homeDevices_device-1', {
+        Power: true,
+        SetTemperature: 20,
       })
 
       expect(mockUpdateGroupState).toHaveBeenCalledWith({
@@ -1718,23 +1675,10 @@ describe('melCloudApp', () => {
       })
     })
 
-    it('should swallow a no-changes rejection', async () => {
-      setupHomeAtaFacade({
-        updateGroupState: vi
-          .fn<(state: unknown) => Promise<unknown>>()
-          .mockRejectedValue(new NoChangesError('device-1')),
-      })
-      await app.onInit()
-
-      await expect(
-        app.updateHomeAtaState({
-          deviceId: 'device-1',
-          state: { Power: true },
-        }),
-      ).resolves.toBeUndefined()
-    })
-
-    it('should propagate other update failures', async () => {
+    // No-change tolerance is the library's own (every `updateGroupState`
+    // resolves an already-matching delta as success), so the app-side
+    // contract is plain propagation of whatever the facade rejects.
+    it('should propagate update failures', async () => {
       setupHomeAtaFacade({
         updateGroupState: vi
           .fn<(state: unknown) => Promise<unknown>>()
@@ -1743,10 +1687,7 @@ describe('melCloudApp', () => {
       await app.onInit()
 
       await expect(
-        app.updateHomeAtaState({
-          deviceId: 'device-1',
-          state: { Power: true },
-        }),
+        app.updateTargetAtaState('homeDevices_device-1', { Power: true }),
       ).rejects.toThrow('BFF failure')
     })
   })
@@ -1765,7 +1706,7 @@ describe('melCloudApp', () => {
       await app.onInit()
 
       await expect(
-        app.getHomeBuildingAtaState('building-1'),
+        app.getTargetAtaState('homeBuildings_building-1'),
       ).resolves.toStrictEqual(groupState)
       expect(mockHomeFacadeManagerGetBuilding).toHaveBeenCalledWith(
         'building-1',
@@ -1781,28 +1722,26 @@ describe('melCloudApp', () => {
       )
       await app.onInit()
 
-      await app.updateHomeBuildingAtaState({
-        buildingId: 'building-1',
-        state: groupState,
-      })
+      await app.updateTargetAtaState('homeBuildings_building-1', groupState)
 
       expect(mockUpdateGroupState).toHaveBeenCalledWith(groupState)
     })
 
     it('should list the member modes in the classic vocabulary', async () => {
-      const member = { id: 'device-1', isAta: (): boolean => true }
+      const getMemberOperationModes = vi
+        .fn<() => Classic.OperationMode[]>()
+        .mockReturnValue([Classic.OperationMode.heat])
       mockHomeFacadeManagerGetBuilding.mockReturnValue(
-        mock<Home.BuildingFacade>({ devices: [member] }),
-      )
-      mockHomeFacadeManagerGet.mockReturnValue(
-        mock<Home.DeviceAtaFacade>({ operationMode: 'Heat' }),
+        mock<Home.BuildingFacade>({ getMemberOperationModes }),
       )
       await app.onInit()
 
-      expect(app.getHomeBuildingAtaModes('building-1')).toStrictEqual([
+      expect(app.getTargetAtaModes('homeBuildings_building-1')).toStrictEqual([
         Classic.OperationMode.heat,
       ])
-      expect(mockHomeFacadeManagerGet).toHaveBeenCalledWith(member)
+      expect(getMemberOperationModes).toHaveBeenCalledWith({
+        poweredOnly: true,
+      })
     })
 
     it('should throw not-found for an unknown building', async () => {
@@ -1811,9 +1750,9 @@ describe('melCloudApp', () => {
 
       // A Home building is a zone in the picker vocabulary, so a missing
       // one answers the same error class as its Classic counterpart.
-      await expect(app.getHomeBuildingAtaState('missing')).rejects.toThrow(
-        'errors.zoneNotFound',
-      )
+      await expect(
+        app.getTargetAtaState('homeBuildings_missing'),
+      ).rejects.toThrow('errors.zoneNotFound')
     })
   })
 
@@ -1850,13 +1789,13 @@ describe('melCloudApp', () => {
   })
 
   describe('hourly temperature retrieval', () => {
-    it('should delegate to device facade', async () => {
+    it('should delegate to the classic device facade', async () => {
       const mockData = mock<ReportChartLineOptions>()
       await initWithDeviceFacade(app, 'getHourlyTemperatures', mockData)
 
-      const temperatures = await app.getClassicHourlyTemperatures({
-        deviceId: '1',
+      const temperatures = await app.getTargetHourlyTemperatures({
         hour: 10,
+        targetId: 'devices_1',
       })
 
       expect(temperatures).toBe(mockData)
@@ -1864,13 +1803,13 @@ describe('melCloudApp', () => {
   })
 
   describe('operation mode retrieval', () => {
-    it('should delegate to device facade with date range', async () => {
+    it('should delegate to the classic device facade with date range', async () => {
       const mockData = mock<ReportChartPieOptions>()
       await initWithDeviceFacade(app, 'getOperationModes', mockData)
 
-      const operationModes = await app.getClassicOperationModes({
+      const operationModes = await app.getTargetOperationModes({
         days: 7,
-        deviceId: '1',
+        targetId: 'devices_1',
       })
 
       expect(operationModes).toBe(mockData)
@@ -1878,24 +1817,35 @@ describe('melCloudApp', () => {
   })
 
   describe('signal retrieval', () => {
-    it('should delegate to device facade', async () => {
+    it('should delegate to the classic device facade', async () => {
       const mockData = mock<ReportChartLineOptions>()
       await initWithDeviceFacade(app, 'getSignalStrength', mockData)
 
-      const signal = await app.getClassicSignal({ deviceId: '1', hour: 5 })
+      const signal = await app.getTargetSignal({
+        hour: 5,
+        targetId: 'devices_1',
+      })
 
       expect(signal).toBe(mockData)
+    })
+
+    it('should reject a classic zone target above the device leaves', async () => {
+      await app.onInit()
+
+      await expect(
+        app.getTargetSignal({ targetId: 'buildings_1' }),
+      ).rejects.toThrow('errors.deviceNotFound')
     })
   })
 
   describe('temperature retrieval', () => {
-    it('should delegate to device facade with date range', async () => {
+    it('should delegate to the classic device facade with date range', async () => {
       const mockData = mock<ReportChartLineOptions>()
       await initWithDeviceFacade(app, 'getTemperatures', mockData)
 
-      const temperatures = await app.getClassicTemperatures({
+      const temperatures = await app.getTargetTemperatures({
         days: 30,
-        deviceId: '1',
+        targetId: 'devices_1',
       })
 
       expect(temperatures).toBe(mockData)
@@ -1907,9 +1857,9 @@ describe('melCloudApp', () => {
       const mockData = mock<ReportChartLineOptions>()
       await initWithDeviceFacade(app, 'getEnergyReport', mockData)
 
-      const report = await app.getClassicEnergyReport({
+      const report = await app.getTargetEnergyReport({
         days: 7,
-        deviceId: '1',
+        targetId: 'devices_1',
       })
 
       expect(report).toBe(mockData)
@@ -1923,9 +1873,9 @@ describe('melCloudApp', () => {
         mockData,
       })
 
-      const report = await app.getHomeEnergyReport({
+      const report = await app.getTargetEnergyReport({
         days: 7,
-        deviceId: 'guid-1',
+        targetId: 'homeDevices_guid-1',
       })
 
       expect(report).toBe(mockData)
@@ -1942,7 +1892,7 @@ describe('melCloudApp', () => {
         mockFacadeManagerGetById.mockReturnValue(mock({ getEnergyReport }))
         await app.onInit()
 
-        await app.getClassicEnergyReport({ days: 2, deviceId: '1' })
+        await app.getTargetEnergyReport({ days: 2, targetId: 'devices_1' })
 
         // Two days: yesterday and today, from yesterday's local midnight.
         expect(getEnergyReport).toHaveBeenCalledWith({
@@ -1970,7 +1920,10 @@ describe('melCloudApp', () => {
         mockHomeFacadeManagerGetById.mockReturnValue(mock({ getEnergyReport }))
         await app.onInit()
 
-        await app.getHomeEnergyReport({ days: 0, deviceId: 'guid-1' })
+        await app.getTargetEnergyReport({
+          days: 0,
+          targetId: 'homeDevices_guid-1',
+        })
 
         expect(getEnergyReport).toHaveBeenCalledWith({
           from: '2026-07-18T08:30:00',
@@ -1990,9 +1943,9 @@ describe('melCloudApp', () => {
         mockData,
       })
 
-      const temperatures = await app.getHomeTemperatures({
+      const temperatures = await app.getTargetTemperatures({
         days: 1,
-        deviceId: 'guid-1',
+        targetId: 'homeDevices_guid-1',
       })
 
       expect(temperatures).toBe(mockData)
@@ -2006,7 +1959,10 @@ describe('melCloudApp', () => {
         mockData,
       })
 
-      const signal = await app.getHomeSignal({ deviceId: 'guid-1', hour: 5 })
+      const signal = await app.getTargetSignal({
+        hour: 5,
+        targetId: 'homeDevices_guid-1',
+      })
 
       expect(signal).toBe(mockData)
     })
@@ -2020,9 +1976,9 @@ describe('melCloudApp', () => {
         type: Home.DeviceType.Atw,
       })
 
-      const temperatures = await app.getHomeTemperatures({
+      const temperatures = await app.getTargetTemperatures({
         days: 1,
-        deviceId: 'guid-1',
+        targetId: 'homeDevices_guid-1',
       })
 
       expect(temperatures).toBe(mockData)
@@ -2032,9 +1988,9 @@ describe('melCloudApp', () => {
       mockHomeFacadeManagerGetById.mockReturnValue(null)
       await app.onInit()
 
-      await expect(app.getHomeSignal({ deviceId: 'missing' })).rejects.toThrow(
-        'errors.deviceNotFound',
-      )
+      await expect(
+        app.getTargetSignal({ targetId: 'homeDevices_missing' }),
+      ).rejects.toThrow('errors.deviceNotFound')
     })
 
     it('should delegate hourly temperatures to the ATW facade', async () => {
@@ -2046,9 +2002,9 @@ describe('melCloudApp', () => {
         type: Home.DeviceType.Atw,
       })
 
-      const temperatures = await app.getHomeHourlyTemperatures({
-        deviceId: 'guid-1',
+      const temperatures = await app.getTargetHourlyTemperatures({
         hour: 10,
+        targetId: 'homeDevices_guid-1',
       })
 
       expect(temperatures).toBe(mockData)
@@ -2063,14 +2019,16 @@ describe('melCloudApp', () => {
         type: Home.DeviceType.Atw,
       })
 
-      const operationModes = await app.getHomeOperationModes({
+      const operationModes = await app.getTargetOperationModes({
         days: 7,
-        deviceId: 'guid-1',
+        targetId: 'homeDevices_guid-1',
       })
 
       expect(operationModes).toBe(mockData)
     })
 
+    // The ATW-only charts pin the Home leg: absence stays absent, so a
+    // Home ATA target answers not-found instead of an emulated chart.
     it('should reject an ATW-only chart for an ATA device', async () => {
       const mockData = mock<ReportChartPieOptions>()
       await initWithHomeDeviceFacade({
@@ -2080,72 +2038,21 @@ describe('melCloudApp', () => {
       })
 
       await expect(
-        app.getHomeOperationModes({ days: 7, deviceId: 'guid-1' }),
+        app.getTargetOperationModes({
+          days: 7,
+          targetId: 'homeDevices_guid-1',
+        }),
       ).rejects.toThrow('errors.deviceNotFound')
     })
   })
 
-  describe('home device zones', () => {
-    it('should suffix the building and sort for the flat pickers', async () => {
-      stubHomeZones([
-        { buildingName: 'Vinkenstraat 22', id: 'b', name: 'Garage' },
-        { buildingName: 'Verkstan', id: 'a', name: 'Garage ' },
-      ])
-      await app.onInit()
-
-      // Same-named devices on different buildings stay tellable apart;
-      // wire names are trimmed before suffixing.
-      expect(app.getHomeDeviceZones()).toStrictEqual([
-        {
-          buildingName: 'Verkstan',
-          deviceType: 'ata',
-          id: 'a',
-          level: 1,
-          model: 'homeDevices',
-          name: 'Garage (Verkstan)',
-        },
-        {
-          buildingName: 'Vinkenstraat 22',
-          deviceType: 'ata',
-          id: 'b',
-          level: 1,
-          model: 'homeDevices',
-          name: 'Garage (Vinkenstraat 22)',
-        },
-      ])
-    })
-
-    it('should filter by device type when one is given', async () => {
-      stubHomeZones([
-        {
-          buildingName: 'Huis',
-          deviceType: 'atw',
-          id: 'atw-1',
-          name: 'Warmtepomp',
-        },
-      ])
-      await app.onInit()
-
-      expect(app.getHomeDeviceZones(Home.DeviceType.Atw)).toStrictEqual([
-        {
-          buildingName: 'Huis',
-          deviceType: 'atw',
-          id: 'atw-1',
-          level: 1,
-          model: 'homeDevices',
-          name: 'Warmtepomp (Huis)',
-        },
-      ])
-      expect(mockHomeFacadeManagerGetZones).toHaveBeenCalledWith({
-        type: Home.DeviceType.Atw,
-      })
-    })
-  })
-
-  describe('classic device zones', () => {
-    it('should keep only the device leaves, suffixed and sorted', async () => {
-      // The shared source flattens the whole tree, each zone stamped with its
-      // building; the chart pickers keep just the devices.
+  describe('device zones', () => {
+    it('should merge both dialects into one suffixed, sorted device list', async () => {
+      // The Classic source flattens the whole tree, each zone stamped
+      // with its building; only the device leaves survive. Same-named
+      // devices on different buildings stay tellable apart, wire names
+      // are trimmed before suffixing, and the two dialects sort as one
+      // alphabetical list.
       mockFacadeManagerGetZones.mockReturnValue([
         {
           buildingName: 'Casa',
@@ -2171,15 +2078,35 @@ describe('melCloudApp', () => {
           name: 'Hydrobox',
         },
       ])
+      stubHomeZones([
+        { buildingName: 'Vinkenstraat 22', id: 'b', name: 'Garage' },
+        { buildingName: 'Verkstan', id: 'a', name: 'Garage ' },
+      ])
       await app.onInit()
 
-      expect(app.getClassicDeviceZones()).toStrictEqual([
+      expect(app.getDeviceZones()).toStrictEqual([
         {
           deviceType: 'ata',
           id: 20,
           level: 1,
           model: 'devices',
           name: 'Garage (Verkstan)',
+        },
+        {
+          buildingName: 'Verkstan',
+          deviceType: 'ata',
+          id: 'a',
+          level: 1,
+          model: 'homeDevices',
+          name: 'Garage (Verkstan)',
+        },
+        {
+          buildingName: 'Vinkenstraat 22',
+          deviceType: 'ata',
+          id: 'b',
+          level: 1,
+          model: 'homeDevices',
+          name: 'Garage (Vinkenstraat 22)',
         },
         {
           deviceType: 'atw',
@@ -2189,33 +2116,6 @@ describe('melCloudApp', () => {
           name: 'Hydrobox (Casa)',
         },
       ])
-    })
-
-    it('should narrow the source to a device type when one is given', async () => {
-      mockFacadeManagerGetZones.mockReturnValue([
-        {
-          buildingName: 'Huis',
-          deviceType: 'ata',
-          id: 30,
-          level: 1,
-          model: 'devices',
-          name: 'AC',
-        },
-      ])
-      await app.onInit()
-
-      expect(app.getClassicDeviceZones(Classic.DeviceType.Ata)).toStrictEqual([
-        {
-          deviceType: 'ata',
-          id: 30,
-          level: 1,
-          model: 'devices',
-          name: 'AC (Huis)',
-        },
-      ])
-      expect(mockFacadeManagerGetZones).toHaveBeenCalledWith({
-        type: Classic.DeviceType.Ata,
-      })
     })
   })
 
@@ -2257,7 +2157,7 @@ describe('melCloudApp', () => {
       expect(app.homeApi).toBe(mockHomeApiInstance)
     })
 
-    it('should delegate homeAuthenticate to homeApi authenticate', async () => {
+    it('should delegate the home login to homeApi authenticate', async () => {
       mockHomeApiInstance.authenticate.mockResolvedValue()
       await app.onInit()
       const credentials = mock<LoginCredentials>()
@@ -2368,11 +2268,7 @@ describe('melCloudApp', () => {
       )
 
       await expect(
-        app.updateClassicAtaState({
-          state: mock<Classic.GroupState>(),
-          zoneId: '1',
-          zoneType: 'buildings',
-        }),
+        app.updateTargetAtaState('buildings_1', mock<Classic.GroupState>()),
       ).resolves.toBeUndefined()
     })
 
@@ -2385,11 +2281,7 @@ describe('melCloudApp', () => {
       )
 
       await expect(
-        app.updateClassicAtaState({
-          state: mock<Classic.GroupState>(),
-          zoneId: '1',
-          zoneType: 'buildings',
-        }),
+        app.updateTargetAtaState('buildings_1', mock<Classic.GroupState>()),
       ).rejects.toThrow('temp: Invalid value')
     })
   })

--- a/tests/unit/ata-group-setting-api.test.ts
+++ b/tests/unit/ata-group-setting-api.test.ts
@@ -4,9 +4,7 @@ import type { Homey } from 'homey/lib/Homey'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import * as Home from '@olivierzal/melcloud-api/home'
 
-import type { GroupAtaStates } from '../../types/classic-ata.mts'
 import type { DriverCapabilitiesOptions } from '../../types/driver-settings.mts'
-import type { DeviceOrZoneData, ZoneData } from '../../types/zone.mts'
 import { mock } from '../helpers.ts'
 
 const mockGetBuildings = vi.fn<() => Classic.BuildingZone[]>()
@@ -25,15 +23,10 @@ const mockApp = {
   error: vi.fn<(...args: readonly unknown[]) => void>(),
   getClassicAtaCapabilities:
     vi.fn<() => [keyof Classic.GroupState, DriverCapabilitiesOptions][]>(),
-  getClassicAtaDetailedStates: vi.fn<() => GroupAtaStates>(),
-  getClassicAtaState: vi.fn<() => Promise<Classic.GroupState>>(),
-  getHomeAtaState: vi.fn<() => Promise<Classic.GroupState>>(),
-  getHomeBuildingAtaModes: vi.fn<() => number[]>(),
-  getHomeBuildingAtaState: vi.fn<() => Promise<Classic.GroupState>>(),
   getHomeTargets: vi.fn<() => (HomeBuildingZone | HomeDeviceZone)[]>(),
-  updateClassicAtaState: vi.fn<() => Promise<void>>(),
-  updateHomeAtaState: vi.fn<() => Promise<void>>(),
-  updateHomeBuildingAtaState: vi.fn<() => Promise<void>>(),
+  getTargetAtaModes: vi.fn<() => Classic.OperationMode[]>(),
+  getTargetAtaState: vi.fn<() => Promise<Classic.GroupState>>(),
+  updateTargetAtaState: vi.fn<() => Promise<void>>(),
 }
 
 const mockI18n = { getLanguage: vi.fn<() => string>() }
@@ -67,79 +60,39 @@ describe('ata-group-setting api', () => {
   })
 
   describe('ata value retrieval', () => {
-    const params = mock<ZoneData>({ zoneId: '1', zoneType: 'buildings' })
+    it.each([
+      'buildings_1',
+      'devices_42',
+      'homeBuildings_b_1',
+      'homeDevices_guid-1',
+    ])(
+      'should delegate the %s state with the raw targetId',
+      async (targetId) => {
+        const values = mock<Classic.GroupState>()
+        mockApp.getTargetAtaState.mockResolvedValue(values)
 
-    it('should delegate detailed states to their dedicated endpoint', () => {
-      const detailedValues = mock<GroupAtaStates>()
-      mockApp.getClassicAtaDetailedStates.mockReturnValue(detailedValues)
+        const result = await api.getTargetAtaState({
+          homey,
+          params: { targetId },
+        })
 
-      const result = api.getClassicAtaDetailedStates({
+        expect(result).toBe(values)
+        expect(mockApp.getTargetAtaState).toHaveBeenCalledWith(targetId)
+      },
+    )
+
+    it('should delegate member modes with the raw targetId', () => {
+      mockApp.getTargetAtaModes.mockReturnValue([1, 3])
+
+      const result = api.getTargetAtaModes({
         homey,
-        params,
-        query: { status: 'on' },
+        params: { targetId: 'homeBuildings_b_1' },
       })
 
-      expect(result).toBe(detailedValues)
-      expect(mockApp.getClassicAtaDetailedStates).toHaveBeenCalledWith({
-        ...params,
-        status: 'on',
-      })
-    })
-
-    it('should delegate group state to app.getClassicAtaState', async () => {
-      const values = mock<Classic.GroupState>()
-      mockApp.getClassicAtaState.mockResolvedValue(values)
-
-      const result = await api.getClassicAtaState({ homey, params })
-
-      expect(result).toBe(values)
-      expect(mockApp.getClassicAtaState).toHaveBeenCalledWith(params)
-    })
-
-    it('should accept a single device as group state target', async () => {
-      const deviceParams = mock<DeviceOrZoneData>({
-        zoneId: '42',
-        zoneType: 'devices',
-      })
-      const values = mock<Classic.GroupState>()
-      mockApp.getClassicAtaState.mockResolvedValue(values)
-
-      const result = await api.getClassicAtaState({
-        homey,
-        params: deviceParams,
-      })
-
-      expect(result).toBe(values)
-      expect(mockApp.getClassicAtaState).toHaveBeenCalledWith(deviceParams)
-    })
-
-    it('should reject an invalid zone type on the group state path', async () => {
-      await expect(
-        api.getClassicAtaState({
-          homey,
-          params: { zoneId: '1', zoneType: 'constructor' as 'buildings' },
-        }),
-      ).rejects.toThrow(RangeError)
-    })
-
-    it('should reject an invalid zone type from the URL', () => {
-      expect(() =>
-        api.getClassicAtaDetailedStates({
-          homey,
-          params: { zoneId: '1', zoneType: 'constructor' as 'buildings' },
-          query: {},
-        }),
-      ).toThrow(RangeError)
-    })
-
-    it('should keep detailed states zone-only', () => {
-      expect(() =>
-        api.getClassicAtaDetailedStates({
-          homey,
-          params: { zoneId: '42', zoneType: 'devices' as 'buildings' },
-          query: {},
-        }),
-      ).toThrow(RangeError)
+      expect(result).toStrictEqual([1, 3])
+      expect(mockApp.getTargetAtaModes).toHaveBeenCalledWith(
+        'homeBuildings_b_1',
+      )
     })
   })
 
@@ -163,6 +116,13 @@ describe('ata-group-setting api', () => {
       expect(result).toBe(buildings)
       expect(mockGetBuildings).toHaveBeenCalledWith({ type: 0 })
     })
+
+    it('should throw on invalid device type', () => {
+      expect(() =>
+        api.getClassicBuildings({ query: { type: '99' as '0' } }),
+      ).toThrow(RangeError)
+      expect(mockGetBuildings).not.toHaveBeenCalled()
+    })
   })
 
   describe('home target retrieval', () => {
@@ -174,44 +134,6 @@ describe('ata-group-setting api', () => {
 
       expect(result).toBe(targets)
       expect(mockApp.getHomeTargets).toHaveBeenCalledWith(Home.DeviceType.Ata)
-    })
-
-    it('should delegate home state to app.getHomeAtaState', async () => {
-      const values = mock<Classic.GroupState>()
-      mockApp.getHomeAtaState.mockResolvedValue(values)
-
-      const result = await api.getHomeAtaState({
-        homey,
-        params: { deviceId: 'home_1' },
-      })
-
-      expect(result).toBe(values)
-      expect(mockApp.getHomeAtaState).toHaveBeenCalledWith('home_1')
-    })
-
-    it('should delegate building state to app.getHomeBuildingAtaState', async () => {
-      const values = mock<Classic.GroupState>()
-      mockApp.getHomeBuildingAtaState.mockResolvedValue(values)
-
-      const result = await api.getHomeBuildingAtaState({
-        homey,
-        params: { buildingId: 'building_1' },
-      })
-
-      expect(result).toBe(values)
-      expect(mockApp.getHomeBuildingAtaState).toHaveBeenCalledWith('building_1')
-    })
-
-    it('should delegate building modes to app.getHomeBuildingAtaModes', () => {
-      mockApp.getHomeBuildingAtaModes.mockReturnValue([1, 3])
-
-      const result = api.getHomeBuildingAtaModes({
-        homey,
-        params: { buildingId: 'building_1' },
-      })
-
-      expect(result).toStrictEqual([1, 3])
-      expect(mockApp.getHomeBuildingAtaModes).toHaveBeenCalledWith('building_1')
     })
   })
 
@@ -227,66 +149,25 @@ describe('ata-group-setting api', () => {
   })
 
   describe('ata value update', () => {
-    it('should delegate to app.updateClassicAtaState', async () => {
-      const body = mock<Classic.GroupState>()
-      const params = mock<ZoneData>({ zoneId: '1', zoneType: 'buildings' })
-      mockApp.updateClassicAtaState.mockResolvedValue()
+    it.each([
+      'buildings_1',
+      'devices_42',
+      'homeBuildings_b_1',
+      'homeDevices_guid-1',
+    ])(
+      'should delegate the %s update with targetId and body',
+      async (targetId) => {
+        const body = mock<Classic.GroupState>()
+        mockApp.updateTargetAtaState.mockResolvedValue()
 
-      await api.updateClassicAtaState({ body, homey, params })
+        await api.updateTargetAtaState({ body, homey, params: { targetId } })
 
-      expect(mockApp.updateClassicAtaState).toHaveBeenCalledWith({
-        state: body,
-        ...params,
-      })
-    })
-
-    it('should accept a single device as update target', async () => {
-      const body = mock<Classic.GroupState>()
-      const params = mock<DeviceOrZoneData>({
-        zoneId: '42',
-        zoneType: 'devices',
-      })
-      mockApp.updateClassicAtaState.mockResolvedValue()
-
-      await api.updateClassicAtaState({ body, homey, params })
-
-      expect(mockApp.updateClassicAtaState).toHaveBeenCalledWith({
-        state: body,
-        ...params,
-      })
-    })
-
-    it('should delegate home updates to app.updateHomeAtaState', async () => {
-      const body = mock<Classic.GroupState>()
-      mockApp.updateHomeAtaState.mockResolvedValue()
-
-      await api.updateHomeAtaState({
-        body,
-        homey,
-        params: { deviceId: 'home_1' },
-      })
-
-      expect(mockApp.updateHomeAtaState).toHaveBeenCalledWith({
-        deviceId: 'home_1',
-        state: body,
-      })
-    })
-
-    it('should delegate building updates to app.updateHomeBuildingAtaState', async () => {
-      const body = mock<Classic.GroupState>()
-      mockApp.updateHomeBuildingAtaState.mockResolvedValue()
-
-      await api.updateHomeBuildingAtaState({
-        body,
-        homey,
-        params: { buildingId: 'building_1' },
-      })
-
-      expect(mockApp.updateHomeBuildingAtaState).toHaveBeenCalledWith({
-        buildingId: 'building_1',
-        state: body,
-      })
-    })
+        expect(mockApp.updateTargetAtaState).toHaveBeenCalledWith(
+          targetId,
+          body,
+        )
+      },
+    )
   })
 
   describe('webview hashes', () => {

--- a/tests/unit/ata-group-setting.test.ts
+++ b/tests/unit/ata-group-setting.test.ts
@@ -94,7 +94,7 @@ describe('ata group setting widget', () => {
       failures: { 'GET /classic/buildings?type=0': new Error('classic down') },
       routes: {
         ...widgetRoutes(),
-        'GET /home/buildings/b_1/ata': groupStateFixture(),
+        'GET /targets/homeBuildings_b_1/ata': groupStateFixture(),
       },
     })
 
@@ -114,9 +114,7 @@ describe('ata group setting widget', () => {
     })
 
     expect(document.querySelector('#values_melcloud select')).toBeNull()
-    expect(calledPaths(harness)).not.toContain(
-      'GET /classic/zones/buildings/1/ata',
-    )
+    expect(calledPaths(harness)).not.toContain('GET /targets/buildings_1/ata')
     expect(harness.ready).toHaveBeenCalledTimes(1)
   })
 
@@ -134,7 +132,7 @@ describe('ata group setting widget', () => {
     const harness = await bootWidget({
       routes: {
         ...widgetRoutes(),
-        'GET /classic/zones/devices/11/ata': {
+        'GET /targets/devices_11/ata': {
           ...groupStateFixture(),
           SetTemperature: 19,
         },
@@ -182,7 +180,7 @@ describe('ata group setting widget', () => {
     const harness = await bootWidget()
     const stateFetches = (): number =>
       calledPaths(harness).filter(
-        (key) => key === 'GET /classic/zones/buildings/1/ata',
+        (key) => key === 'GET /targets/buildings_1/ata',
       ).length
     const before = stateFetches()
     harness.emit('deviceupdate')
@@ -198,7 +196,7 @@ describe('ata group setting widget', () => {
     const routes = widgetRoutes()
     const harness = await bootWidget({ routes })
     commit(getSelect('SetTemperature'), '25')
-    routes['GET /classic/zones/buildings/1/ata'] = {
+    routes['GET /targets/buildings_1/ata'] = {
       ...groupStateFixture(),
       Power: false,
     }

--- a/tests/unit/ata-values.test.ts
+++ b/tests/unit/ata-values.test.ts
@@ -85,8 +85,8 @@ describe('ata value manager', () => {
     const { api, manager } = await createManager({
       routes: {
         ...widgetRoutes(),
-        'GET /home/buildings/b_1/ata': {},
-        'GET /home/devices/ata_1/ata': {},
+        'GET /targets/homeBuildings_b_1/ata': {},
+        'GET /targets/homeDevices_ata_1/ata': {},
       },
     })
     const zone = getSelect('zones')
@@ -102,8 +102,8 @@ describe('ata value manager', () => {
     }
     const paths = harnessPaths(api)
 
-    expect(paths).toContain('GET /home/buildings/b_1/ata')
-    expect(paths).toContain('GET /home/devices/ata_1/ata')
+    expect(paths).toContain('GET /targets/homeBuildings_b_1/ata')
+    expect(paths).toContain('GET /targets/homeDevices_ata_1/ata')
   })
 
   it('should apply a matching default zone and skip the rest', async () => {
@@ -319,7 +319,7 @@ describe('ata value manager', () => {
     const { manager } = await createManager({
       routes: {
         ...widgetRoutes(),
-        'GET /classic/zones/buildings/1/ata': {
+        'GET /targets/buildings_1/ata': {
           ...groupStateFixture(),
           SetTemperature: 22.3,
         },
@@ -362,7 +362,7 @@ describe('ata value manager', () => {
     const { manager } = await createManager({ routes })
     // The zone starts without a fan-speed reading: the control opens
     // blank, and blank-vs-absent must read as pristine, not as an edit.
-    routes['GET /classic/zones/buildings/1/ata'] = {
+    routes['GET /targets/buildings_1/ata'] = {
       OperationMode: 1,
       Power: true,
       SetTemperature: 22,
@@ -372,7 +372,7 @@ describe('ata value manager', () => {
     const fanSpeed = getInput('FanSpeed')
     fanSpeed.value = '5'
     fanSpeed.dispatchEvent(new Event('change', { bubbles: true }))
-    routes['GET /classic/zones/buildings/1/ata'] = {
+    routes['GET /targets/buildings_1/ata'] = {
       ...groupStateFixture(),
       Power: false,
     }
@@ -392,7 +392,7 @@ describe('ata value manager', () => {
     const { manager } = await createManager({ routes })
     await manager.fetchValues()
     commit(getSelect('SetTemperature'), '25')
-    routes['GET /classic/zones/buildings/1/ata'] = {
+    routes['GET /targets/buildings_1/ata'] = {
       ...groupStateFixture(),
       SetTemperature: 25,
     }
@@ -403,7 +403,7 @@ describe('ata value manager', () => {
     expect(getButtonDisabled('apply_values_melcloud')).toBe(true)
 
     // Caught up means released: the control follows the stream again.
-    routes['GET /classic/zones/buildings/1/ata'] = {
+    routes['GET /targets/buildings_1/ata'] = {
       ...groupStateFixture(),
       SetTemperature: 23,
     }
@@ -417,7 +417,7 @@ describe('ata value manager', () => {
     const { manager } = await createManager({ routes })
     await manager.fetchValues()
     commit(getSelect('SetTemperature'), '12')
-    routes['GET /classic/zones/buildings/1/ata'] = {
+    routes['GET /targets/buildings_1/ata'] = {
       ...groupStateFixture(),
       OperationMode: 3,
     }

--- a/tests/unit/charts-api.test.ts
+++ b/tests/unit/charts-api.test.ts
@@ -11,18 +11,12 @@ const { default: api } = await import('../../widgets/charts/api.mts')
 
 const mockApp = {
   error: vi.fn<(...args: readonly unknown[]) => void>(),
-  getClassicDeviceZones: vi.fn<() => unknown[]>(),
-  getClassicEnergyReport: vi.fn<() => Promise<ReportChartLineOptions>>(),
-  getClassicHourlyTemperatures: vi.fn<() => Promise<ReportChartLineOptions>>(),
-  getClassicOperationModes: vi.fn<() => Promise<ReportChartPieOptions>>(),
-  getClassicSignal: vi.fn<() => Promise<ReportChartLineOptions>>(),
-  getClassicTemperatures: vi.fn<() => Promise<ReportChartLineOptions>>(),
-  getHomeDeviceZones: vi.fn<() => unknown[]>(),
-  getHomeEnergyReport: vi.fn<() => Promise<ReportChartLineOptions>>(),
-  getHomeHourlyTemperatures: vi.fn<() => Promise<ReportChartLineOptions>>(),
-  getHomeOperationModes: vi.fn<() => Promise<ReportChartPieOptions>>(),
-  getHomeSignal: vi.fn<() => Promise<ReportChartLineOptions>>(),
-  getHomeTemperatures: vi.fn<() => Promise<ReportChartLineOptions>>(),
+  getDeviceZones: vi.fn<() => unknown[]>(),
+  getTargetEnergyReport: vi.fn<() => Promise<ReportChartLineOptions>>(),
+  getTargetHourlyTemperatures: vi.fn<() => Promise<ReportChartLineOptions>>(),
+  getTargetOperationModes: vi.fn<() => Promise<ReportChartPieOptions>>(),
+  getTargetSignal: vi.fn<() => Promise<ReportChartLineOptions>>(),
+  getTargetTemperatures: vi.fn<() => Promise<ReportChartLineOptions>>(),
 }
 
 const mockI18n = { getLanguage: vi.fn<() => string>() }
@@ -43,235 +37,99 @@ describe('charts api', () => {
   })
 
   describe('device retrieval', () => {
-    it('should list the Classic device zones without a type filter', () => {
+    it('should serve the one merged device-zone list', () => {
       const zones = [
-        { id: 2, level: 1, model: 'devices', name: 'Device 1 (Casa)' },
+        {
+          deviceType: 'ata',
+          id: 2,
+          level: 1,
+          model: 'devices',
+          name: 'Device 1 (Casa)',
+        },
+        {
+          buildingName: 'Huis',
+          deviceType: 'atw',
+          id: 'guid-1',
+          level: 1,
+          model: 'homeDevices',
+          name: 'Warmtepomp (Huis)',
+        },
       ]
-      mockApp.getClassicDeviceZones.mockReturnValue(zones)
+      mockApp.getDeviceZones.mockReturnValue(zones)
 
-      const result = api.getClassicDevices({ homey, query: {} })
+      const result = api.getDevices({ homey })
 
       expect(result).toBe(zones)
-      expect(mockApp.getClassicDeviceZones).toHaveBeenCalledWith(undefined)
-    })
-
-    it('should pass the numeric type filter through', () => {
-      mockApp.getClassicDeviceZones.mockReturnValue([])
-
-      api.getClassicDevices({ homey, query: { type: '0' } })
-
-      expect(mockApp.getClassicDeviceZones).toHaveBeenCalledWith(0)
-    })
-
-    it('should throw on invalid device type', () => {
-      expect(() =>
-        api.getClassicDevices({ homey, query: { type: '99' as '0' } }),
-      ).toThrow(RangeError)
+      expect(mockApp.getDeviceZones).toHaveBeenCalledTimes(1)
     })
   })
 
   describe('hourly temperature retrieval', () => {
-    it('should call app.getClassicHourlyTemperatures with hour number', async () => {
+    it('should call app.getTargetHourlyTemperatures with hour number', async () => {
       const lineOptions = mock<ReportChartLineOptions>()
-      mockApp.getClassicHourlyTemperatures.mockResolvedValue(lineOptions)
+      mockApp.getTargetHourlyTemperatures.mockResolvedValue(lineOptions)
 
-      const result = await api.getClassicHourlyTemperatures({
+      const result = await api.getTargetHourlyTemperatures({
         homey,
-        params: { deviceId: 'dev1' },
+        params: { targetId: 'devices_1' },
         query: { hour: '10' },
       })
 
       expect(result).toBe(lineOptions)
-      expect(mockApp.getClassicHourlyTemperatures).toHaveBeenCalledWith({
-        deviceId: 'dev1',
+      expect(mockApp.getTargetHourlyTemperatures).toHaveBeenCalledWith({
         hour: 10,
+        targetId: 'devices_1',
       })
     })
 
     it('should pass undefined when hour is undefined', async () => {
       const lineOptions = mock<ReportChartLineOptions>()
-      mockApp.getClassicHourlyTemperatures.mockResolvedValue(lineOptions)
+      mockApp.getTargetHourlyTemperatures.mockResolvedValue(lineOptions)
 
-      const result = await api.getClassicHourlyTemperatures({
+      const result = await api.getTargetHourlyTemperatures({
         homey,
-        params: { deviceId: 'dev1' },
+        params: { targetId: 'homeDevices_guid-1' },
         query: {},
       })
 
       expect(result).toBe(lineOptions)
-      expect(mockApp.getClassicHourlyTemperatures).toHaveBeenCalledWith({
-        deviceId: 'dev1',
+      expect(mockApp.getTargetHourlyTemperatures).toHaveBeenCalledWith({
         hour: undefined,
+        targetId: 'homeDevices_guid-1',
       })
     })
   })
 
   describe('energy report retrieval', () => {
-    it('should call app.getClassicEnergyReport with numeric days', async () => {
-      const lineOptions = mock<ReportChartLineOptions>()
-      mockApp.getClassicEnergyReport.mockResolvedValue(lineOptions)
+    it.each(['devices_1', 'homeDevices_guid-1'])(
+      'should call app.getTargetEnergyReport for %s with numeric days',
+      async (targetId) => {
+        const lineOptions = mock<ReportChartLineOptions>()
+        mockApp.getTargetEnergyReport.mockResolvedValue(lineOptions)
 
-      const result = await api.getClassicEnergyReport({
-        homey,
-        params: { deviceId: 'dev1' },
-        query: { days: '7' },
-      })
-
-      expect(result).toBe(lineOptions)
-      expect(mockApp.getClassicEnergyReport).toHaveBeenCalledWith({
-        days: 7,
-        deviceId: 'dev1',
-      })
-    })
-
-    it('should call app.getHomeEnergyReport with numeric days', async () => {
-      const lineOptions = mock<ReportChartLineOptions>()
-      mockApp.getHomeEnergyReport.mockResolvedValue(lineOptions)
-
-      const result = await api.getHomeEnergyReport({
-        homey,
-        params: { deviceId: 'guid-1' },
-        query: { days: '30' },
-      })
-
-      expect(result).toBe(lineOptions)
-      expect(mockApp.getHomeEnergyReport).toHaveBeenCalledWith({
-        days: 30,
-        deviceId: 'guid-1',
-      })
-    })
-  })
-
-  describe('home device retrieval', () => {
-    it('should list the Home device zones without a type filter', () => {
-      const zones = [
-        { id: 'guid-1', level: 1, model: 'homeDevices', name: 'Garage' },
-      ]
-      mockApp.getHomeDeviceZones.mockReturnValue(zones)
-
-      const result = api.getHomeDevices({ homey, query: {} })
-
-      expect(result).toBe(zones)
-      expect(mockApp.getHomeDeviceZones).toHaveBeenCalledWith(undefined)
-    })
-
-    it('should pass the Home device type filter through', () => {
-      mockApp.getHomeDeviceZones.mockReturnValue([])
-
-      api.getHomeDevices({ homey, query: { type: 'airToWater' } })
-
-      expect(mockApp.getHomeDeviceZones).toHaveBeenCalledWith('airToWater')
-    })
-
-    it('should throw on an invalid Home device type', () => {
-      expect(() =>
-        api.getHomeDevices({
+        const result = await api.getTargetEnergyReport({
           homey,
-          query: { type: 'submarine' as 'airToAir' },
+          params: { targetId },
+          query: { days: '7' },
+        })
+
+        expect(result).toBe(lineOptions)
+        expect(mockApp.getTargetEnergyReport).toHaveBeenCalledWith({
+          days: 7,
+          targetId,
+        })
+      },
+    )
+
+    it('should reject an out-of-range day count', async () => {
+      await expect(
+        api.getTargetEnergyReport({
+          homey,
+          params: { targetId: 'devices_1' },
+          query: { days: '9999' },
         }),
-      ).toThrow(RangeError)
-    })
-  })
-
-  describe('home chart retrieval', () => {
-    it('should call app.getHomeTemperatures with numeric days', async () => {
-      const lineOptions = mock<ReportChartLineOptions>()
-      mockApp.getHomeTemperatures.mockResolvedValue(lineOptions)
-
-      const result = await api.getHomeTemperatures({
-        homey,
-        params: { deviceId: 'guid-1' },
-        query: { days: '1' },
-      })
-
-      expect(result).toBe(lineOptions)
-      expect(mockApp.getHomeTemperatures).toHaveBeenCalledWith({
-        days: 1,
-        deviceId: 'guid-1',
-      })
-    })
-
-    it('should call app.getHomeOperationModes with numeric days', async () => {
-      const pieOptions = mock<ReportChartPieOptions>()
-      mockApp.getHomeOperationModes.mockResolvedValue(pieOptions)
-
-      const result = await api.getHomeOperationModes({
-        homey,
-        params: { deviceId: 'guid-1' },
-        query: { days: '7' },
-      })
-
-      expect(result).toBe(pieOptions)
-      expect(mockApp.getHomeOperationModes).toHaveBeenCalledWith({
-        days: 7,
-        deviceId: 'guid-1',
-      })
-    })
-
-    it('should call app.getHomeHourlyTemperatures with hour number', async () => {
-      const lineOptions = mock<ReportChartLineOptions>()
-      mockApp.getHomeHourlyTemperatures.mockResolvedValue(lineOptions)
-
-      const result = await api.getHomeHourlyTemperatures({
-        homey,
-        params: { deviceId: 'guid-1' },
-        query: { hour: '10' },
-      })
-
-      expect(result).toBe(lineOptions)
-      expect(mockApp.getHomeHourlyTemperatures).toHaveBeenCalledWith({
-        deviceId: 'guid-1',
-        hour: 10,
-      })
-    })
-
-    it('should default the hourly-temperatures hour when absent', async () => {
-      const lineOptions = mock<ReportChartLineOptions>()
-      mockApp.getHomeHourlyTemperatures.mockResolvedValue(lineOptions)
-
-      await api.getHomeHourlyTemperatures({
-        homey,
-        params: { deviceId: 'guid-1' },
-        query: {},
-      })
-
-      expect(mockApp.getHomeHourlyTemperatures).toHaveBeenCalledWith({
-        deviceId: 'guid-1',
-        hour: undefined,
-      })
-    })
-
-    it('should call app.getHomeSignal with hour number', async () => {
-      const lineOptions = mock<ReportChartLineOptions>()
-      mockApp.getHomeSignal.mockResolvedValue(lineOptions)
-
-      await api.getHomeSignal({
-        homey,
-        params: { deviceId: 'guid-1' },
-        query: { hour: '5' },
-      })
-
-      expect(mockApp.getHomeSignal).toHaveBeenCalledWith({
-        deviceId: 'guid-1',
-        hour: 5,
-      })
-    })
-
-    it('should call app.getHomeSignal, defaulting the hour', async () => {
-      const lineOptions = mock<ReportChartLineOptions>()
-      mockApp.getHomeSignal.mockResolvedValue(lineOptions)
-
-      const result = await api.getHomeSignal({
-        homey,
-        params: { deviceId: 'guid-1' },
-        query: {},
-      })
-
-      expect(result).toBe(lineOptions)
-      expect(mockApp.getHomeSignal).toHaveBeenCalledWith({
-        deviceId: 'guid-1',
-        hour: undefined,
-      })
+      ).rejects.toThrow(RangeError)
+      expect(mockApp.getTargetEnergyReport).not.toHaveBeenCalled()
     })
   })
 
@@ -287,75 +145,75 @@ describe('charts api', () => {
   })
 
   describe('operation mode retrieval', () => {
-    it('should call app.getClassicOperationModes with numeric days', async () => {
+    it('should call app.getTargetOperationModes with numeric days', async () => {
       const pieOptions = mock<ReportChartPieOptions>()
-      mockApp.getClassicOperationModes.mockResolvedValue(pieOptions)
+      mockApp.getTargetOperationModes.mockResolvedValue(pieOptions)
 
-      const result = await api.getClassicOperationModes({
+      const result = await api.getTargetOperationModes({
         homey,
-        params: { deviceId: 'dev1' },
+        params: { targetId: 'devices_1' },
         query: { days: '7' },
       })
 
       expect(result).toBe(pieOptions)
-      expect(mockApp.getClassicOperationModes).toHaveBeenCalledWith({
+      expect(mockApp.getTargetOperationModes).toHaveBeenCalledWith({
         days: 7,
-        deviceId: 'dev1',
+        targetId: 'devices_1',
       })
     })
   })
 
   describe('signal retrieval', () => {
-    it('should call app.getClassicSignal with hour number', async () => {
+    it('should call app.getTargetSignal with hour number', async () => {
       const lineOptions = mock<ReportChartLineOptions>()
-      mockApp.getClassicSignal.mockResolvedValue(lineOptions)
+      mockApp.getTargetSignal.mockResolvedValue(lineOptions)
 
-      const result = await api.getClassicSignal({
+      const result = await api.getTargetSignal({
         homey,
-        params: { deviceId: 'dev1' },
+        params: { targetId: 'devices_1' },
         query: { hour: '5' },
       })
 
       expect(result).toBe(lineOptions)
-      expect(mockApp.getClassicSignal).toHaveBeenCalledWith({
-        deviceId: 'dev1',
+      expect(mockApp.getTargetSignal).toHaveBeenCalledWith({
         hour: 5,
+        targetId: 'devices_1',
       })
     })
 
     it('should pass undefined when hour is undefined', async () => {
       const lineOptions = mock<ReportChartLineOptions>()
-      mockApp.getClassicSignal.mockResolvedValue(lineOptions)
+      mockApp.getTargetSignal.mockResolvedValue(lineOptions)
 
-      const result = await api.getClassicSignal({
+      const result = await api.getTargetSignal({
         homey,
-        params: { deviceId: 'dev1' },
+        params: { targetId: 'homeDevices_guid-1' },
         query: {},
       })
 
       expect(result).toBe(lineOptions)
-      expect(mockApp.getClassicSignal).toHaveBeenCalledWith({
-        deviceId: 'dev1',
+      expect(mockApp.getTargetSignal).toHaveBeenCalledWith({
         hour: undefined,
+        targetId: 'homeDevices_guid-1',
       })
     })
   })
 
   describe('temperature retrieval', () => {
-    it('should call app.getClassicTemperatures with numeric days', async () => {
+    it('should call app.getTargetTemperatures with numeric days', async () => {
       const lineOptions = mock<ReportChartLineOptions>()
-      mockApp.getClassicTemperatures.mockResolvedValue(lineOptions)
+      mockApp.getTargetTemperatures.mockResolvedValue(lineOptions)
 
-      const result = await api.getClassicTemperatures({
+      const result = await api.getTargetTemperatures({
         homey,
-        params: { deviceId: 'dev1' },
+        params: { targetId: 'devices_1' },
         query: { days: '30' },
       })
 
       expect(result).toBe(lineOptions)
-      expect(mockApp.getClassicTemperatures).toHaveBeenCalledWith({
+      expect(mockApp.getTargetTemperatures).toHaveBeenCalledWith({
         days: 30,
-        deviceId: 'dev1',
+        targetId: 'devices_1',
       })
     })
   })

--- a/tests/unit/charts.test.ts
+++ b/tests/unit/charts.test.ts
@@ -142,8 +142,11 @@ const loadChartsPage = (): void => {
 const device = (
   id: number | string,
   name: string,
-  model = 'devices',
-): unknown => ({ id, level: 1, model, name })
+  {
+    deviceType = 'ata',
+    model = 'devices',
+  }: { deviceType?: string; model?: string } = {},
+): unknown => ({ deviceType, id, level: 1, model, name })
 
 const lineOptions = (
   overrides: Record<string, unknown> = {},
@@ -166,12 +169,14 @@ const pieOptions = (
   ...overrides,
 })
 
+// The one merged listing arrives app-sorted; the widget derives every
+// per-chart line-up from the `deviceType`/`model` tags.
 const defaultRoutes = (): Record<string, unknown> => ({
-  'GET /classic/devices': [device(11, 'Bedroom'), device(12, 'Kitchen')],
-  'GET /classic/devices?type=0': [device(11, 'Bedroom')],
-  'GET /classic/devices?type=1': [device(12, 'Kitchen')],
-  'GET /home/devices': [device('h1', 'Attic', 'homeDevices')],
-  'GET /home/devices?type=airToWater': [device('h1', 'Attic', 'homeDevices')],
+  'GET /devices': [
+    device('h1', 'Attic', { deviceType: 'atw', model: 'homeDevices' }),
+    device(11, 'Bedroom'),
+    device(12, 'Kitchen', { deviceType: 'atw' }),
+  ],
   'GET /language': 'fr',
 })
 
@@ -353,14 +358,7 @@ describe('charts widget', () => {
 
   it('should build nothing without a single device', async () => {
     const harness = await boot({
-      routes: withLogs({
-        'GET /classic/devices': [],
-        'GET /classic/devices?type=0': [],
-        'GET /classic/devices?type=1': [],
-        'GET /home/devices': [],
-        'GET /home/devices?type=airToWater': [],
-        'GET /language': 'fr',
-      }),
+      routes: withLogs({ 'GET /devices': [], 'GET /language': 'fr' }),
     })
 
     expect(FakeChart.instances).toHaveLength(0)
@@ -461,7 +459,7 @@ describe('charts widget', () => {
       called.includes('/logs/'),
     )?.[1]
 
-    expect(path).toBe('/classic/devices/11/logs/report?days=30')
+    expect(path).toBe('/targets/devices_11/logs/report?days=30')
   })
 
   it('should route a home device to its own endpoint', async () => {
@@ -472,7 +470,7 @@ describe('charts widget', () => {
       called.includes('/logs/'),
     )?.[1]
 
-    expect(path).toBe('/home/devices/h1/logs/temperatures?days=7')
+    expect(path).toBe('/targets/homeDevices_h1/logs/temperatures?days=7')
   })
 
   it('should update the live chart in place on a refresh', async () => {
@@ -512,7 +510,9 @@ describe('charts widget', () => {
     vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
     const harness = await boot({
       failures: {
-        'GET /home/devices/h1/logs/temperatures?days=7': new Error('logs down'),
+        'GET /targets/homeDevices_h1/logs/temperatures?days=7': new Error(
+          'logs down',
+        ),
       },
     })
 
@@ -804,8 +804,7 @@ describe('charts widget', () => {
     await boot({
       routes: withLogs({
         ...defaultRoutes(),
-        'GET /classic/devices?type=1': [],
-        'GET /home/devices?type=airToWater': [],
+        'GET /devices': [device(11, 'Bedroom')],
       }),
     })
 

--- a/tests/unit/settings.test.ts
+++ b/tests/unit/settings.test.ts
@@ -235,20 +235,20 @@ const errorLogFixture = (
 })
 
 const defaultRoutes = (): Record<string, unknown> => ({
-  'DELETE /classic/sessions': undefined,
-  'DELETE /home/sessions': undefined,
+  'DELETE /sessions/classic': undefined,
+  'DELETE /sessions/home': undefined,
   'GET /classic/buildings': classicBuildingsFixture(),
-  'GET /classic/sessions': true,
-  'GET /home/sessions': false,
   'GET /language': 'fr',
+  'GET /sessions/classic': true,
+  'GET /sessions/home': false,
   'GET /settings/devices': deviceSettingsFixture(),
   'GET /settings/drivers': driverSettingsFixture(),
   'GET /targets/buildings_1/settings/frost-protection': protectionFixture(),
   'GET /targets/buildings_1/settings/holiday-mode': holidayFixture(),
   'GET /webview-hashes': {},
   'POST /boot-error': undefined,
-  'POST /classic/sessions': undefined,
-  'POST /home/sessions': undefined,
+  'POST /sessions/classic': undefined,
+  'POST /sessions/home': undefined,
   'PUT /settings/devices': undefined,
 })
 
@@ -363,9 +363,9 @@ const bootHome = async (options: HarnessOptions = {}): Promise<Harness> =>
     ...options,
     routes: {
       ...defaultRoutes(),
-      'GET /classic/sessions': false,
-      'GET /home/sessions': true,
       'GET /home/targets': homeTargetsFixture(),
+      'GET /sessions/classic': false,
+      'GET /sessions/home': true,
       'GET /settings/devices': { 'home-melcloud': { always_on: true } },
       'GET /settings/drivers': {
         login: loginSettings(),
@@ -509,7 +509,7 @@ describe('settings page', () => {
 
     it('should hide the content when no account is signed in', async () => {
       const harness = await bootPage({
-        routes: { ...defaultRoutes(), 'GET /classic/sessions': false },
+        routes: { ...defaultRoutes(), 'GET /sessions/classic': false },
       })
 
       expect(getDiv('content').hidden).toBe(true)
@@ -538,9 +538,9 @@ describe('settings page', () => {
       await bootPage({
         routes: {
           ...defaultRoutes(),
-          'GET /classic/sessions': false,
-          'GET /home/sessions': true,
           'GET /home/targets': homeTargetsFixture(),
+          'GET /sessions/classic': false,
+          'GET /sessions/home': true,
           'GET /settings/devices': { 'home-melcloud': { always_on: true } },
         },
       })
@@ -562,8 +562,8 @@ describe('settings page', () => {
       const harness = await bootPage({
         routes: {
           ...defaultRoutes(),
-          'GET /classic/sessions': false,
-          'GET /home/sessions': true,
+          'GET /sessions/classic': false,
+          'GET /sessions/home': true,
           'GET /settings/devices': {},
         },
       })
@@ -589,7 +589,7 @@ describe('settings page', () => {
 
     it('should alert after ready when the boot load fails', async () => {
       const harness = await bootPage({
-        failures: { 'GET /classic/sessions': new Error('boot down') },
+        failures: { 'GET /sessions/classic': new Error('boot down') },
       })
 
       expect(harness.ready).toHaveBeenCalledTimes(1)
@@ -857,7 +857,7 @@ describe('settings page', () => {
   describe('credentials', () => {
     it('should sign in and reveal the account content', async () => {
       const harness = await bootPage({
-        routes: { ...defaultRoutes(), 'GET /classic/sessions': false },
+        routes: { ...defaultRoutes(), 'GET /sessions/classic': false },
       })
 
       expect(getDiv('content').hidden).toBe(true)
@@ -874,7 +874,7 @@ describe('settings page', () => {
       await settleDetached()
       await settleDetached()
 
-      expect(lastCallBody(harness, 'POST /classic/sessions')).toStrictEqual({
+      expect(lastCallBody(harness, 'POST /sessions/classic')).toStrictEqual({
         password: 'secret',
         username: 'user@example.com',
       })
@@ -889,7 +889,7 @@ describe('settings page', () => {
       getButton('authenticate').click()
       await settleDetached()
 
-      expect(lastCallBody(harness, 'POST /classic/sessions')).toStrictEqual({
+      expect(lastCallBody(harness, 'POST /sessions/classic')).toStrictEqual({
         password: 'secret',
         username: 'user@example.com',
       })
@@ -904,7 +904,7 @@ describe('settings page', () => {
       getButton('authenticate').dispatchEvent(new Event('click'))
       await settleDetached()
 
-      expect(calledPaths(harness)).not.toContain('POST /classic/sessions')
+      expect(calledPaths(harness)).not.toContain('POST /sessions/classic')
       expect(harness.alert).toHaveBeenCalledWith(
         'settings.authenticate.failure',
       )
@@ -912,7 +912,7 @@ describe('settings page', () => {
 
     it('should alert the classified reason when the login fails', async () => {
       const harness = await bootPage({
-        failures: { 'POST /classic/sessions': new Error('Wrong credentials') },
+        failures: { 'POST /sessions/classic': new Error('Wrong credentials') },
       })
       commit(getSelect('api'), 'classic')
       commit(getInput('username'), 'user@example.com')
@@ -926,7 +926,7 @@ describe('settings page', () => {
     it('should alert unverified when the session probe denies', async () => {
       const routes: Record<string, unknown> = {
         ...defaultRoutes(),
-        'GET /classic/sessions': false,
+        'GET /sessions/classic': false,
       }
       const harness = await bootPage({ routes })
       commit(getInput('username'), 'user@example.com')
@@ -943,7 +943,7 @@ describe('settings page', () => {
       const harness = await bootPage()
       // The probe only fails after boot: the login path reads it fresh.
       swapRoutes(harness, defaultRoutes(), {
-        'GET /home/sessions': new Error('probe down'),
+        'GET /sessions/home': new Error('probe down'),
       })
       commit(getSelect('api'), 'home')
       commit(getInput('username'), 'user@example.com')
@@ -971,8 +971,8 @@ describe('settings page', () => {
       commit(getInput('password'), 'secret')
       swapRoutes(harness, {
         ...defaultRoutes(),
-        'GET /home/sessions': true,
         'GET /home/targets': homeTargetsFixture(),
+        'GET /sessions/home': true,
       })
       getButton('authenticate').click()
       await settleDetached()
@@ -987,7 +987,7 @@ describe('settings page', () => {
       commit(getSelect('api'), 'home')
       commit(getInput('username'), 'home@example.com')
       commit(getInput('password'), 'secret')
-      swapRoutes(harness, { ...defaultRoutes(), 'GET /home/sessions': true })
+      swapRoutes(harness, { ...defaultRoutes(), 'GET /sessions/home': true })
       getButton('authenticate').click()
       await settleDetached()
 
@@ -1005,7 +1005,7 @@ describe('settings page', () => {
       commit(getInput('password'), 'secret')
       swapRoutes(
         harness,
-        { ...defaultRoutes(), 'GET /home/sessions': true },
+        { ...defaultRoutes(), 'GET /sessions/home': true },
         { 'GET /home/targets': new Error('targets down') },
       )
       getButton('authenticate').click()
@@ -1038,7 +1038,7 @@ describe('settings page', () => {
 
     it('should collapse the auth panel when both accounts settle', async () => {
       await bootPage({
-        routes: { ...defaultRoutes(), 'GET /home/sessions': true },
+        routes: { ...defaultRoutes(), 'GET /sessions/home': true },
         storedSettings: {
           homePassword: 'home-secret',
           homeUsername: 'home@example.com',
@@ -1054,8 +1054,8 @@ describe('settings page', () => {
       await bootPage({
         routes: {
           ...defaultRoutes(),
-          'GET /home/sessions': true,
           'GET /home/targets': homeTargetsFixture(),
+          'GET /sessions/home': true,
           'GET /settings/devices': {
             ...deviceSettingsFixture(),
             'home-melcloud': { always_on: true },
@@ -1079,7 +1079,7 @@ describe('settings page', () => {
       // paired to it: the panel has no chore to show, and the form must
       // not open on an account the user never adopted.
       await bootPage({
-        routes: { ...defaultRoutes(), 'GET /home/sessions': false },
+        routes: { ...defaultRoutes(), 'GET /sessions/home': false },
         storedSettings: {
           password: 'classic-secret',
           username: 'classic@example.com',
@@ -1094,7 +1094,7 @@ describe('settings page', () => {
       await bootPage({
         routes: {
           ...defaultRoutes(),
-          'GET /home/sessions': false,
+          'GET /sessions/home': false,
           'GET /settings/devices': {
             ...deviceSettingsFixture(),
             'home-melcloud': { always_on: true },
@@ -1123,7 +1123,7 @@ describe('settings page', () => {
       getButton('reset_credentials').click()
       await settleDetached()
 
-      expect(calledPaths(harness)).toContain('DELETE /classic/sessions')
+      expect(calledPaths(harness)).toContain('DELETE /sessions/classic')
       expect(getInput('username').value).toBe('')
       expect(getInput('password').value).toBe('')
       // Logged out: the content follows the remaining account (none).
@@ -1140,13 +1140,13 @@ describe('settings page', () => {
       getButton('reset_credentials').click()
       await settleDetached()
 
-      expect(calledPaths(harness)).not.toContain('DELETE /classic/sessions')
+      expect(calledPaths(harness)).not.toContain('DELETE /sessions/classic')
       expect(getInput('username').value).toBe('user@example.com')
     })
 
     it('should alert when the reset fails', async () => {
       const harness = await bootPage({
-        failures: { 'DELETE /classic/sessions': new Error('reset down') },
+        failures: { 'DELETE /sessions/classic': new Error('reset down') },
         storedSettings: { password: 'secret', username: 'user@example.com' },
       })
       commit(getSelect('api'), 'classic')

--- a/tests/unit/widget.test.ts
+++ b/tests/unit/widget.test.ts
@@ -39,9 +39,9 @@ describe('widget transport', () => {
 
   it('should put a body', async () => {
     const { api, homey } = createWidgetHomey()
-    await homeyApiPut(homey, '/classic/zones/devices/1/ata', { Power: true })
+    await homeyApiPut(homey, '/targets/devices_1/ata', { Power: true })
 
-    expect(api).toHaveBeenCalledWith('PUT', '/classic/zones/devices/1/ata', {
+    expect(api).toHaveBeenCalledWith('PUT', '/targets/devices_1/ata', {
       Power: true,
     })
   })

--- a/tests/unit/zones.test.ts
+++ b/tests/unit/zones.test.ts
@@ -8,7 +8,6 @@ import {
   getSubzones,
   getZoneId,
   getZoneName,
-  getZonePath,
   isHomeBuildingValue,
   isHomeDeviceValue,
 } from '../../public/zones.mts'
@@ -34,11 +33,6 @@ describe('zones', () => {
     expect(getZoneId('building_1', 'homeBuildings')).toBe(
       'homeBuildings_building_1',
     )
-  })
-
-  it('should replace only the first underscore in a zone path', () => {
-    expect(getZonePath('devices_11')).toBe('devices/11')
-    expect(getZonePath('floors_2_1')).toBe('floors/2_1')
   })
 
   it('should indent a zone name by its level', () => {

--- a/types/api.mts
+++ b/types/api.mts
@@ -1,8 +1,8 @@
 import type {
   AggregatedHolidayModeState,
   AggregatedProtectionState,
+  BaseAPIAdapter,
   HolidayModeState,
-  LoginCredentials,
   ProtectionState,
 } from '@olivierzal/melcloud-api'
 
@@ -12,12 +12,14 @@ import type {
 export type Api = 'classic' | 'home'
 
 /**
- * Minimal API-client surface used by drivers during pairing/repair.
+ * Minimal API-client surface used by drivers during pairing/repair —
+ * the library's published adapter contract, narrowed to what pairing
+ * touches.
  */
-export interface AuthenticationAPI {
-  readonly authenticate: (credentials: LoginCredentials) => Promise<void>
-  readonly isAuthenticated: () => boolean
-}
+export type AuthenticationAPI = Pick<
+  BaseAPIAdapter,
+  'authenticate' | 'isAuthenticated'
+>
 
 /**
  * Holiday-mode window as the settings webview submits it: an absent

--- a/types/classic-ata.mts
+++ b/types/classic-ata.mts
@@ -42,17 +42,6 @@ export interface GetCapabilities extends BaseGetCapabilities {
   readonly 'alarm_generic.silent': boolean
 }
 
-export interface GroupAtaStates {
-  readonly FanSpeed: Exclude<Classic.FanSpeed, typeof Classic.FanSpeed.silent>[]
-  readonly OperationMode: Classic.OperationMode[]
-  readonly Power: boolean[]
-  readonly SetTemperature: number[]
-  readonly VaneHorizontalDirection: Classic.Horizontal[]
-  readonly VaneHorizontalSwing: boolean[]
-  readonly VaneVerticalDirection: Classic.Vertical[]
-  readonly VaneVerticalSwing: boolean[]
-}
-
 export interface ListCapabilities extends BaseListCapabilities {
   readonly 'alarm_generic.silent': boolean
   readonly 'fan_speed.state': number

--- a/types/widgets.mts
+++ b/types/widgets.mts
@@ -37,10 +37,6 @@ export interface DaysQuery {
   readonly days?: string
 }
 
-export interface GetAtaOptions {
-  readonly status?: 'on' | undefined
-}
-
 export interface HourQuery {
   readonly hour?: `${Hour}`
 }

--- a/types/zone.mts
+++ b/types/zone.mts
@@ -1,3 +1,6 @@
+import type { HomeDeviceZone } from '@olivierzal/melcloud-api'
+import type * as Classic from '@olivierzal/melcloud-api/classic'
+
 // One entry per MELCloud building (either dialect), for the extension
 // app's per-building settings grouping.
 export interface DeviceGroup {
@@ -8,13 +11,16 @@ export interface DeviceGroup {
 // Endpoints that can target a single device as well as a zone collection:
 // frost protection, holiday mode (the settings page lists devices in its
 // zone selector) and the ATA group state (the widget treats a device as a
-// group of one). The detailed ATA states endpoint stays zone-only — a
-// single device never reports a mixed operation mode, so the widget never
-// queries details for device targets.
+// group of one).
 export interface DeviceOrZoneData {
   readonly zoneId: string
   readonly zoneType: 'areas' | 'buildings' | 'devices' | 'floors'
 }
+
+// A chart-picker device leaf of either dialect: the `deviceType` tag
+// and the `model` discriminant together let one flat list serve every
+// per-chart line-up.
+export type FlatDeviceZone = Classic.DeviceZone | HomeDeviceZone
 
 export interface ZoneData {
   readonly zoneId: string

--- a/widgets/ata-group-setting/api.mts
+++ b/widgets/ata-group-setting/api.mts
@@ -3,13 +3,9 @@ import type * as Classic from '@olivierzal/melcloud-api/classic'
 import type { Homey } from 'homey/lib/Homey'
 import * as Home from '@olivierzal/melcloud-api/home'
 
-import type { GroupAtaStates } from '../../types/classic-ata.mts'
 import type { DriverCapabilitiesOptions } from '../../types/driver-settings.mts'
-import type { GetAtaOptions } from '../../types/widgets.mts'
-import type { DeviceOrZoneData, ZoneData } from '../../types/zone.mts'
 import { getClassicBuildings } from '../../lib/classic-facade-manager.mts'
 import { toDeviceType } from '../../lib/to-device-type.mts'
-import { toDeviceOrZoneData, toZoneData } from '../../lib/validation.mts'
 import { getWebviewHashes } from '../../lib/webview-hashes.mts'
 
 const api = {
@@ -19,24 +15,6 @@ const api = {
     homey: Homey
   }): [keyof Classic.GroupState, DriverCapabilitiesOptions][] =>
     app.getClassicAtaCapabilities(),
-  getClassicAtaDetailedStates: ({
-    homey: { app },
-    params,
-    query: { status },
-  }: {
-    homey: Homey
-    params: ZoneData
-    query: GetAtaOptions
-  }): GroupAtaStates =>
-    app.getClassicAtaDetailedStates({ ...toZoneData(params), status }),
-  getClassicAtaState: async ({
-    homey: { app },
-    params,
-  }: {
-    homey: Homey
-    params: DeviceOrZoneData
-  }): Promise<Classic.GroupState> =>
-    app.getClassicAtaState(toDeviceOrZoneData(params)),
   getClassicBuildings: ({
     query: { type },
   }: {
@@ -45,35 +23,28 @@ const api = {
     getClassicBuildings({
       type: type === undefined ? undefined : toDeviceType(type),
     }),
-  getHomeAtaState: async ({
-    homey: { app },
-    params: { deviceId },
-  }: {
-    homey: Homey
-    params: { deviceId: string }
-  }): Promise<Classic.GroupState> => app.getHomeAtaState(deviceId),
   getHomeAtaTargets: ({
     homey: { app },
   }: {
     homey: Homey
   }): (HomeBuildingZone | HomeDeviceZone)[] =>
     app.getHomeTargets(Home.DeviceType.Ata),
-  getHomeBuildingAtaModes: ({
-    homey: { app },
-    params: { buildingId },
-  }: {
-    homey: Homey
-    params: { buildingId: string }
-  }): number[] => app.getHomeBuildingAtaModes(buildingId),
-  getHomeBuildingAtaState: async ({
-    homey: { app },
-    params: { buildingId },
-  }: {
-    homey: Homey
-    params: { buildingId: string }
-  }): Promise<Classic.GroupState> => app.getHomeBuildingAtaState(buildingId),
   getLanguage: ({ homey: { i18n } }: { homey: Homey }): string =>
     i18n.getLanguage(),
+  getTargetAtaModes: ({
+    homey: { app },
+    params: { targetId },
+  }: {
+    homey: Homey
+    params: { targetId: string }
+  }): Classic.OperationMode[] => app.getTargetAtaModes(targetId),
+  getTargetAtaState: async ({
+    homey: { app },
+    params: { targetId },
+  }: {
+    homey: Homey
+    params: { targetId: string }
+  }): Promise<Classic.GroupState> => app.getTargetAtaState(targetId),
   getWebviewHashes: async (): Promise<Partial<Record<string, string>>> =>
     getWebviewHashes(),
   logWebviewBoot: ({
@@ -85,35 +56,15 @@ const api = {
   }): void => {
     app.error('Widget boot failed:', JSON.stringify(body))
   },
-  updateClassicAtaState: async ({
+  updateTargetAtaState: async ({
     body,
     homey: { app },
-    params,
+    params: { targetId },
   }: {
     body: Classic.GroupState
     homey: Homey
-    params: DeviceOrZoneData
-  }): Promise<void> =>
-    app.updateClassicAtaState({ state: body, ...toDeviceOrZoneData(params) }),
-  updateHomeAtaState: async ({
-    body,
-    homey: { app },
-    params: { deviceId },
-  }: {
-    body: Classic.GroupState
-    homey: Homey
-    params: { deviceId: string }
-  }): Promise<void> => app.updateHomeAtaState({ deviceId, state: body }),
-  updateHomeBuildingAtaState: async ({
-    body,
-    homey: { app },
-    params: { buildingId },
-  }: {
-    body: Classic.GroupState
-    homey: Homey
-    params: { buildingId: string }
-  }): Promise<void> =>
-    app.updateHomeBuildingAtaState({ buildingId, state: body }),
+    params: { targetId: string }
+  }): Promise<void> => app.updateTargetAtaState(targetId, body),
 }
 
 export default api

--- a/widgets/ata-group-setting/public/animation.mts
+++ b/widgets/ata-group-setting/public/animation.mts
@@ -7,17 +7,8 @@ import {
   ClassicOperationMode,
 } from '@olivierzal/melcloud-api/constants'
 
-import type { GroupAtaStates } from '../../../types/classic-ata.mts'
-import type {
-  GetAtaOptions,
-  AtaGroupSettingWidgetSettings as HomeySettings,
-} from '../../../types/widgets.mts'
+import type { AtaGroupSettingWidgetSettings as HomeySettings } from '../../../types/widgets.mts'
 import { type Homey, homeyApiGet } from '../../../public/widget.mts'
-import {
-  getHomeBuildingId,
-  getZonePath,
-  isHomeBuildingValue,
-} from '../../../public/zones.mts'
 import {
   generateStyleNumber,
   generateStyleString,
@@ -126,8 +117,6 @@ const generateDelay = (delay: number, speed: number): number => {
   // by one instead of freezing the cadence at Infinity.
   return (randomFraction() * delay) / (speedFactor === 0 ? 1 : speedFactor)
 }
-
-const getZoneValue = (): string => getZonePath(getSelect('zones').value)
 
 const parseStateParams = (
   state: Classic.GroupState,
@@ -628,24 +617,15 @@ export class AnimationController {
     return motion
   }
 
-  // A mixed Home building fetches its members' modes from the dedicated
-  // endpoint; Classic zones keep the detailed-states one. Home devices
-  // never reach here (a group of one cannot be mixed).
+  // A mixed group resolves its members' modes through the one neutral
+  // modes route — powered members only, whatever family serves the
+  // target. Single devices never reach here (a group of one cannot be
+  // mixed).
   async #getModes(): Promise<number[]> {
-    const { value } = getSelect('zones')
-    if (isHomeBuildingValue(value)) {
-      return homeyApiGet<number[]>(
-        this.#homey,
-        `/home/buildings/${encodeURIComponent(getHomeBuildingId(value))}/ata/modes`,
-      )
-    }
-    const detailedAtaStates = await homeyApiGet<GroupAtaStates>(
+    return homeyApiGet<number[]>(
       this.#homey,
-      `/classic/zones/${getZoneValue()}/ata/details?${new URLSearchParams({
-        status: 'on',
-      } satisfies Required<GetAtaOptions>)}`,
+      `/targets/${getSelect('zones').value}/ata/modes`,
     )
-    return detailedAtaStates.OperationMode
   }
 
   #getSunElement(): HTMLDivElement {

--- a/widgets/ata-group-setting/public/ata-values.mts
+++ b/widgets/ata-group-setting/public/ata-values.mts
@@ -5,8 +5,8 @@
 // — `OperationMode` included, always Classic-numbered — carries one
 // spelling whatever API backs the target, and the constants below apply
 // to both (`ClassicTemperature` is documented universal across ATA
-// models). The only place the family is visible at all is the state
-// path; see `getAtaStatePath`.
+// models). Even the address is family-neutral: the option value IS the
+// `/targets/:targetId/ata` targetId, resolved app-side.
 import type * as Classic from '@olivierzal/melcloud-api/classic'
 import {
   type HTMLValueElement,
@@ -31,15 +31,7 @@ import {
   homeyApiGet,
   homeyApiPut,
 } from '../../../public/widget.mts'
-import {
-  type PickerZone,
-  getHomeBuildingId,
-  getHomeDeviceId,
-  getZoneId,
-  getZonePath,
-  isHomeBuildingValue,
-  isHomeDeviceValue,
-} from '../../../public/zones.mts'
+import { type PickerZone, getZoneId } from '../../../public/zones.mts'
 
 // The generated controls are styled by element selectors in
 // `styles/layout.css` (Homey design tokens) — no utility classes needed,
@@ -123,19 +115,10 @@ const temperatureOptions = (
     }))
 }
 
-// Routes a `${model}_${id}` option value to its state endpoint — the one
-// place the API family surfaces, and it is ADDRESSING, not semantics: the
-// two families name their targets differently (a Home building or device
-// id versus a Classic zone type + id), so they are reachable only through
-// distinct routes. Everything downstream of the fetch is single-vocabulary.
-const getAtaStatePath = (value: string): string => {
-  if (isHomeBuildingValue(value)) {
-    return `/home/buildings/${encodeURIComponent(getHomeBuildingId(value))}/ata`
-  }
-  return isHomeDeviceValue(value)
-    ? `/home/devices/${encodeURIComponent(getHomeDeviceId(value))}/ata`
-    : `/classic/zones/${getZonePath(value)}/ata`
-}
+// The one state route for every target: the `${model}_${id}` option
+// value is the targetId verbatim (the settings routes' addressing), so
+// no family branch remains in the path.
+const getAtaStatePath = (value: string): string => `/targets/${value}/ata`
 
 // ── AtaValueManager class ──
 

--- a/widgets/ata-group-setting/widget.compose.json
+++ b/widgets/ata-group-setting/widget.compose.json
@@ -4,42 +4,19 @@
       "method": "GET",
       "path": "/classic/capabilities/ata"
     },
-    "getClassicAtaDetailedStates": {
-      "method": "GET",
-      "path": "/classic/zones/:zoneType/:zoneId/ata/details"
-    },
-    "getClassicAtaState": {
-      "method": "GET",
-      "path": "/classic/zones/:zoneType/:zoneId/ata"
-    },
     "getClassicBuildings": { "method": "GET", "path": "/classic/buildings" },
-    "getHomeAtaState": {
-      "method": "GET",
-      "path": "/home/devices/:deviceId/ata"
-    },
     "getHomeAtaTargets": { "method": "GET", "path": "/home/targets/ata" },
-    "getHomeBuildingAtaModes": {
-      "method": "GET",
-      "path": "/home/buildings/:buildingId/ata/modes"
-    },
-    "getHomeBuildingAtaState": {
-      "method": "GET",
-      "path": "/home/buildings/:buildingId/ata"
-    },
     "getLanguage": { "method": "GET", "path": "/language" },
+    "getTargetAtaModes": {
+      "method": "GET",
+      "path": "/targets/:targetId/ata/modes"
+    },
+    "getTargetAtaState": { "method": "GET", "path": "/targets/:targetId/ata" },
     "getWebviewHashes": { "method": "GET", "path": "/webview-hashes" },
     "logWebviewBoot": { "method": "POST", "path": "/boot-error" },
-    "updateClassicAtaState": {
+    "updateTargetAtaState": {
       "method": "PUT",
-      "path": "/classic/zones/:zoneType/:zoneId/ata"
-    },
-    "updateHomeAtaState": {
-      "method": "PUT",
-      "path": "/home/devices/:deviceId/ata"
-    },
-    "updateHomeBuildingAtaState": {
-      "method": "PUT",
-      "path": "/home/buildings/:buildingId/ata"
+      "path": "/targets/:targetId/ata"
     }
   },
   "name": {

--- a/widgets/charts/api.mts
+++ b/widgets/charts/api.mts
@@ -1,13 +1,10 @@
 import type {
-  HomeDeviceZone,
   ReportChartLineOptions,
   ReportChartPieOptions,
 } from '@olivierzal/melcloud-api'
-import type * as Classic from '@olivierzal/melcloud-api/classic'
-import type * as Home from '@olivierzal/melcloud-api/home'
 import type { Homey } from 'homey/lib/Homey'
 
-import { toDeviceType, toHomeDeviceType } from '../../lib/to-device-type.mts'
+import type { FlatDeviceZone } from '../../types/zone.mts'
 import { toHour, toNonNegativeInt } from '../../lib/validation.mts'
 import { getWebviewHashes } from '../../lib/webview-hashes.mts'
 import {
@@ -17,158 +14,75 @@ import {
 } from '../../types/widgets.mts'
 
 const api = {
-  getClassicDevices: ({
-    homey: { app },
-    query: { type },
-  }: {
-    homey: Homey
-    query: { type?: `${Classic.DeviceType}` }
-  }): Classic.Zone[] =>
-    app.getClassicDeviceZones(
-      type === undefined ? undefined : toDeviceType(type),
-    ),
-  getClassicEnergyReport: async ({
-    homey: { app },
-    params: { deviceId },
-    query: { days },
-  }: {
-    homey: Homey
-    params: { deviceId: string }
-    query: DaysQuery
-  }): Promise<ReportChartLineOptions> =>
-    app.getClassicEnergyReport({
-      days: toNonNegativeInt(days, { field: 'days', max: DAYS_MAX }),
-      deviceId,
-    }),
-  getClassicHourlyTemperatures: async ({
-    homey: { app },
-    params: { deviceId },
-    query: { hour },
-  }: {
-    homey: Homey
-    params: { deviceId: string }
-    query: HourQuery
-  }): Promise<ReportChartLineOptions> =>
-    app.getClassicHourlyTemperatures({
-      deviceId,
-      hour: hour === undefined ? undefined : toHour(hour, 'hour'),
-    }),
-  getClassicOperationModes: async ({
-    homey: { app },
-    params: { deviceId },
-    query: { days },
-  }: {
-    homey: Homey
-    params: { deviceId: string }
-    query: DaysQuery
-  }): Promise<ReportChartPieOptions> =>
-    app.getClassicOperationModes({
-      days: toNonNegativeInt(days, { field: 'days', max: DAYS_MAX }),
-      deviceId,
-    }),
-  getClassicSignal: async ({
-    homey: { app },
-    params: { deviceId },
-    query: { hour },
-  }: {
-    homey: Homey
-    params: { deviceId: string }
-    query: HourQuery
-  }): Promise<ReportChartLineOptions> =>
-    app.getClassicSignal({
-      deviceId,
-      hour: hour === undefined ? undefined : toHour(hour, 'hour'),
-    }),
-  getClassicTemperatures: async ({
-    homey: { app },
-    params: { deviceId },
-    query: { days },
-  }: {
-    homey: Homey
-    params: { deviceId: string }
-    query: DaysQuery
-  }): Promise<ReportChartLineOptions> =>
-    app.getClassicTemperatures({
-      days: toNonNegativeInt(days, { field: 'days', max: DAYS_MAX }),
-      deviceId,
-    }),
-  getHomeDevices: ({
-    homey: { app },
-    query: { type },
-  }: {
-    homey: Homey
-    query: { type?: Home.DeviceType }
-  }): HomeDeviceZone[] =>
-    app.getHomeDeviceZones(
-      type === undefined ? undefined : toHomeDeviceType(type),
-    ),
-  getHomeEnergyReport: async ({
-    homey: { app },
-    params: { deviceId },
-    query: { days },
-  }: {
-    homey: Homey
-    params: { deviceId: string }
-    query: DaysQuery
-  }): Promise<ReportChartLineOptions> =>
-    app.getHomeEnergyReport({
-      days: toNonNegativeInt(days, { field: 'days', max: DAYS_MAX }),
-      deviceId,
-    }),
-  getHomeHourlyTemperatures: async ({
-    homey: { app },
-    params: { deviceId },
-    query: { hour },
-  }: {
-    homey: Homey
-    params: { deviceId: string }
-    query: HourQuery
-  }): Promise<ReportChartLineOptions> =>
-    app.getHomeHourlyTemperatures({
-      deviceId,
-      hour: hour === undefined ? undefined : toHour(hour, 'hour'),
-    }),
-  getHomeOperationModes: async ({
-    homey: { app },
-    params: { deviceId },
-    query: { days },
-  }: {
-    homey: Homey
-    params: { deviceId: string }
-    query: DaysQuery
-  }): Promise<ReportChartPieOptions> =>
-    app.getHomeOperationModes({
-      days: toNonNegativeInt(days, { field: 'days', max: DAYS_MAX }),
-      deviceId,
-    }),
-  getHomeSignal: async ({
-    homey: { app },
-    params: { deviceId },
-    query: { hour },
-  }: {
-    homey: Homey
-    params: { deviceId: string }
-    query: HourQuery
-  }): Promise<ReportChartLineOptions> =>
-    app.getHomeSignal({
-      deviceId,
-      hour: hour === undefined ? undefined : toHour(hour, 'hour'),
-    }),
-  getHomeTemperatures: async ({
-    homey: { app },
-    params: { deviceId },
-    query: { days },
-  }: {
-    homey: Homey
-    params: { deviceId: string }
-    query: DaysQuery
-  }): Promise<ReportChartLineOptions> =>
-    app.getHomeTemperatures({
-      days: toNonNegativeInt(days, { field: 'days', max: DAYS_MAX }),
-      deviceId,
-    }),
+  getDevices: ({ homey: { app } }: { homey: Homey }): FlatDeviceZone[] =>
+    app.getDeviceZones(),
   getLanguage: ({ homey: { i18n } }: { homey: Homey }): string =>
     i18n.getLanguage(),
+  getTargetEnergyReport: async ({
+    homey: { app },
+    params: { targetId },
+    query: { days },
+  }: {
+    homey: Homey
+    params: { targetId: string }
+    query: DaysQuery
+  }): Promise<ReportChartLineOptions> =>
+    app.getTargetEnergyReport({
+      days: toNonNegativeInt(days, { field: 'days', max: DAYS_MAX }),
+      targetId,
+    }),
+  getTargetHourlyTemperatures: async ({
+    homey: { app },
+    params: { targetId },
+    query: { hour },
+  }: {
+    homey: Homey
+    params: { targetId: string }
+    query: HourQuery
+  }): Promise<ReportChartLineOptions> =>
+    app.getTargetHourlyTemperatures({
+      hour: hour === undefined ? undefined : toHour(hour, 'hour'),
+      targetId,
+    }),
+  getTargetOperationModes: async ({
+    homey: { app },
+    params: { targetId },
+    query: { days },
+  }: {
+    homey: Homey
+    params: { targetId: string }
+    query: DaysQuery
+  }): Promise<ReportChartPieOptions> =>
+    app.getTargetOperationModes({
+      days: toNonNegativeInt(days, { field: 'days', max: DAYS_MAX }),
+      targetId,
+    }),
+  getTargetSignal: async ({
+    homey: { app },
+    params: { targetId },
+    query: { hour },
+  }: {
+    homey: Homey
+    params: { targetId: string }
+    query: HourQuery
+  }): Promise<ReportChartLineOptions> =>
+    app.getTargetSignal({
+      hour: hour === undefined ? undefined : toHour(hour, 'hour'),
+      targetId,
+    }),
+  getTargetTemperatures: async ({
+    homey: { app },
+    params: { targetId },
+    query: { days },
+  }: {
+    homey: Homey
+    params: { targetId: string }
+    query: DaysQuery
+  }): Promise<ReportChartLineOptions> =>
+    app.getTargetTemperatures({
+      days: toNonNegativeInt(days, { field: 'days', max: DAYS_MAX }),
+      targetId,
+    }),
   getWebviewHashes: async (): Promise<Partial<Record<string, string>>> =>
     getWebviewHashes(),
   logWebviewBoot: ({

--- a/widgets/charts/public/index.mts
+++ b/widgets/charts/public/index.mts
@@ -1,11 +1,8 @@
 import type {
-  HomeDeviceZone,
   ReportChartBand,
   ReportChartLineOptions,
   ReportChartPieOptions,
 } from '@olivierzal/melcloud-api'
-import type * as Classic from '@olivierzal/melcloud-api/classic'
-import type * as Home from '@olivierzal/melcloud-api/home'
 import { createOption, getDiv, getSelect } from '@olivierzal/homey-kit/dom'
 import {
   fireAndForget,
@@ -13,10 +10,6 @@ import {
   surfaceError,
   trySetDocumentLanguage,
 } from '@olivierzal/homey-kit/webview'
-import {
-  ClassicDeviceType,
-  HomeDeviceType,
-} from '@olivierzal/melcloud-api/constants'
 import {
   type ChartConfiguration,
   type ChartData,
@@ -40,6 +33,7 @@ import {
 } from 'chart.js'
 import { Temporal } from 'temporal-polyfill'
 
+import type { FlatDeviceZone } from '../../../types/zone.mts'
 import {
   hideInitError,
   showInitError,
@@ -47,7 +41,7 @@ import {
 } from '../../../public/dom.mts'
 import { watchWidgetFreshness } from '../../../public/webview-freshness-boot.mts'
 import { type Homey, homeyApiGet } from '../../../public/widget.mts'
-import { getZoneId, getZonePath } from '../../../public/zones.mts'
+import { getZoneId } from '../../../public/zones.mts'
 import {
   type DaysQuery,
   type ChartsWidgetSettings as HomeySettings,
@@ -70,8 +64,6 @@ const PERCENT_FACTOR = 100
 // Slices narrower than this angle get no percentage label.
 const PIE_LABEL_MIN_ANGLE_DEGREES = 10
 const PIE_LABEL_RADIUS_RATIO = 0.8
-
-type ChartDeviceZone = Classic.DeviceZone | HomeDeviceZone
 
 interface ChartSelection {
   readonly chart: HomeySettings['chart']
@@ -300,11 +292,6 @@ const getDayValues = (defaultDays: number): number[] =>
       (days) => Number.isSafeInteger(days) && days > 0 && days <= DAYS_MAX,
     )
     .toSorted((first, second) => first - second)
-
-// The per-vendor device lists arrive sorted, their concatenation is
-// not: re-sort so Classic and Home read as one alphabetical list.
-const byDeviceName = (zone: ChartDeviceZone, other: ChartDeviceZone): number =>
-  zone.name.localeCompare(other.name)
 
 // The rolling last-24-hours picker entry, localized like the day
 // counts (no locale files needed).
@@ -773,8 +760,6 @@ const getChartConfig = (
 
 // ── Chart data fetching ──
 
-const HOME_DEVICES_PATH_PREFIX = 'homeDevices/'
-
 const fetchChartData = async (
   homey: Homey,
   { chart, days, zoneValue }: ChartSelection,
@@ -782,13 +767,9 @@ const fetchChartData = async (
   const daysQuery = chartsWithDays.has(chart)
     ? `?${new URLSearchParams({ days: String(days) } satisfies DaysQuery)}`
     : ''
-  const isHome = zoneValue.startsWith(HOME_DEVICES_PATH_PREFIX)
-  const path = isHome
-    ? `home/devices/${zoneValue.slice(HOME_DEVICES_PATH_PREFIX.length)}`
-    : `classic/${zoneValue}`
   return homeyApiGet<ReportChartLineOptions | ReportChartPieOptions>(
     homey,
-    `/${path}/logs/${chart.replaceAll('_', '-')}${daysQuery}`,
+    `/targets/${zoneValue}/logs/${chart.replaceAll('_', '-')}${daysQuery}`,
   )
 }
 
@@ -920,7 +901,7 @@ class ChartWidget {
     devicesForChart,
   }: {
     canUseLast24Hours: () => boolean
-    devicesForChart: () => readonly ChartDeviceZone[]
+    devicesForChart: () => readonly FlatDeviceZone[]
   }): void {
     this.#chartSelect.addEventListener('change', () => {
       this.#repopulateZoneOptions(devicesForChart())
@@ -948,7 +929,7 @@ class ChartWidget {
   // midnight-anchored windows start near-empty each morning. The one
   // exception is the Classic ATW report, whose wire never buckets
   // energy under a day.
-  #buildLast24HoursGate(classicAtw: readonly ChartDeviceZone[]): () => boolean {
+  #buildLast24HoursGate(classicAtw: readonly FlatDeviceZone[]): () => boolean {
     const dailyOnlyZones = new Set(
       classicAtw.map(({ id, model }) => getZoneId(id, model)),
     )
@@ -1031,19 +1012,6 @@ class ChartWidget {
     }
   }
 
-  // One fetcher for both vendors: `String(type)` is an identity on the
-  // Home string enum and stringifies the Classic numeric one.
-  async #fetchDeviceZones<T extends ChartDeviceZone>(
-    vendor: 'classic' | 'home',
-    type?: Classic.DeviceType | Home.DeviceType,
-  ): Promise<T[]> {
-    const typeQuery =
-      type === undefined
-        ? ''
-        : `?${new URLSearchParams({ type: String(type) })}`
-    return homeyApiGet<T[]>(this.#homey, `/${vendor}/devices${typeQuery}`)
-  }
-
   // Resolves to null when a picker change landed while the fetch was in
   // flight: the response is stale, and the change listener's own draw
   // renders the new selection.
@@ -1065,40 +1033,37 @@ class ChartWidget {
   }
 
   async #initControls(): Promise<void> {
-    const [classicAll, classicAta, classicAtw, homeAll, homeAtw] =
-      await Promise.all([
-        this.#fetchDeviceZones<Classic.DeviceZone>('classic'),
-        this.#fetchDeviceZones<Classic.DeviceZone>(
-          'classic',
-          ClassicDeviceType.Ata,
-        ),
-        this.#fetchDeviceZones<Classic.DeviceZone>(
-          'classic',
-          ClassicDeviceType.Atw,
-        ),
-        this.#fetchDeviceZones<HomeDeviceZone>('home'),
-        this.#fetchDeviceZones<HomeDeviceZone>('home', HomeDeviceType.Atw),
-      ])
+    // ONE fetch: the app serves both dialects' device leaves as a single
+    // alphabetical list, each tagged with its `deviceType` and `model`,
+    // so every line-up below is a filter that preserves the order.
+    const devices = await homeyApiGet<FlatDeviceZone[]>(this.#homey, '/devices')
     // Per-chart device line-up: temperature and signal history exist for
     // every device; the hourly temperatures and the operation modes are
     // ATW-only on the Home side (comfort-graph) and, for the hourly one,
     // on the Classic side too; the energy report skips Classic ERV
-    // (no energy data). Classic and Home merge into one alphabetical
-    // list.
+    // (no energy data).
     const devicesByChart: Record<
       HomeySettings['chart'],
-      readonly ChartDeviceZone[]
+      readonly FlatDeviceZone[]
     > = {
-      hourly_temperatures: [...classicAtw, ...homeAtw].toSorted(byDeviceName),
-      operation_modes: [...classicAll, ...homeAtw].toSorted(byDeviceName),
-      report: [...classicAta, ...classicAtw, ...homeAll].toSorted(byDeviceName),
-      signal: [...classicAll, ...homeAll].toSorted(byDeviceName),
-      temperatures: [...classicAll, ...homeAll].toSorted(byDeviceName),
+      hourly_temperatures: devices.filter((zone) => zone.deviceType === 'atw'),
+      operation_modes: devices.filter(
+        (zone) => zone.model === 'devices' || zone.deviceType === 'atw',
+      ),
+      report: devices.filter(
+        (zone) => !(zone.model === 'devices' && zone.deviceType === 'erv'),
+      ),
+      signal: devices,
+      temperatures: devices,
     }
     if (Object.values(devicesByChart).some((list) => list.length > 0)) {
-      const canUseLast24Hours = this.#buildLast24HoursGate(classicAtw)
+      const canUseLast24Hours = this.#buildLast24HoursGate(
+        devices.filter(
+          (zone) => zone.model === 'devices' && zone.deviceType === 'atw',
+        ),
+      )
       this.#populateChartOptions(devicesByChart)
-      const devicesForChart = (): readonly ChartDeviceZone[] =>
+      const devicesForChart = (): readonly FlatDeviceZone[] =>
         devicesByChart[this.#getChart()]
       this.#repopulateZoneOptions(devicesForChart())
       this.#populateDayOptions(canUseLast24Hours())
@@ -1112,7 +1077,7 @@ class ChartWidget {
   // Home-only ATA account); the picker then falls back to its first option
   // if the configured default was omitted.
   #populateChartOptions(
-    devicesByChart: Record<HomeySettings['chart'], readonly ChartDeviceZone[]>,
+    devicesByChart: Record<HomeySettings['chart'], readonly FlatDeviceZone[]>,
   ): void {
     for (const chart of CHARTS) {
       if (devicesByChart[chart].length > 0) {
@@ -1155,7 +1120,7 @@ class ChartWidget {
     return {
       chart: this.#getChart(),
       days: Number(this.#daySelect.value),
-      zoneValue: getZonePath(this.#zoneSelect.value),
+      zoneValue: this.#zoneSelect.value,
     }
   }
 
@@ -1197,7 +1162,7 @@ class ChartWidget {
   // temperatures), so the options are rebuilt on every chart change: the
   // previous selection wins, then the configured default, then the first
   // option as the final fallback.
-  #repopulateZoneOptions(devices: readonly ChartDeviceZone[]): void {
+  #repopulateZoneOptions(devices: readonly FlatDeviceZone[]): void {
     const previous = this.#zoneSelect.value
     this.#zoneSelect.replaceChildren()
     for (const { id, model, name } of devices) {

--- a/widgets/charts/widget.compose.json
+++ b/widgets/charts/widget.compose.json
@@ -1,48 +1,27 @@
 {
   "api": {
-    "getClassicDevices": { "method": "GET", "path": "/classic/devices" },
-    "getClassicEnergyReport": {
-      "method": "GET",
-      "path": "/classic/devices/:deviceId/logs/report"
-    },
-    "getClassicHourlyTemperatures": {
-      "method": "GET",
-      "path": "/classic/devices/:deviceId/logs/hourly-temperatures"
-    },
-    "getClassicOperationModes": {
-      "method": "GET",
-      "path": "/classic/devices/:deviceId/logs/operation-modes"
-    },
-    "getClassicSignal": {
-      "method": "GET",
-      "path": "/classic/devices/:deviceId/logs/signal"
-    },
-    "getClassicTemperatures": {
-      "method": "GET",
-      "path": "/classic/devices/:deviceId/logs/temperatures"
-    },
-    "getHomeDevices": { "method": "GET", "path": "/home/devices" },
-    "getHomeEnergyReport": {
-      "method": "GET",
-      "path": "/home/devices/:deviceId/logs/report"
-    },
-    "getHomeHourlyTemperatures": {
-      "method": "GET",
-      "path": "/home/devices/:deviceId/logs/hourly-temperatures"
-    },
-    "getHomeOperationModes": {
-      "method": "GET",
-      "path": "/home/devices/:deviceId/logs/operation-modes"
-    },
-    "getHomeSignal": {
-      "method": "GET",
-      "path": "/home/devices/:deviceId/logs/signal"
-    },
-    "getHomeTemperatures": {
-      "method": "GET",
-      "path": "/home/devices/:deviceId/logs/temperatures"
-    },
+    "getDevices": { "method": "GET", "path": "/devices" },
     "getLanguage": { "method": "GET", "path": "/language" },
+    "getTargetEnergyReport": {
+      "method": "GET",
+      "path": "/targets/:targetId/logs/report"
+    },
+    "getTargetHourlyTemperatures": {
+      "method": "GET",
+      "path": "/targets/:targetId/logs/hourly-temperatures"
+    },
+    "getTargetOperationModes": {
+      "method": "GET",
+      "path": "/targets/:targetId/logs/operation-modes"
+    },
+    "getTargetSignal": {
+      "method": "GET",
+      "path": "/targets/:targetId/logs/signal"
+    },
+    "getTargetTemperatures": {
+      "method": "GET",
+      "path": "/targets/:targetId/logs/temperatures"
+    },
     "getWebviewHashes": { "method": "GET", "path": "/webview-hashes" },
     "logWebviewBoot": { "method": "POST", "path": "/boot-error" }
   },


### PR DESCRIPTION
Three route unifications under the recorded no-alias policy (path renames break stale cached webviews; the freshness handshake bounds the blast radius; no legacy aliases by decision).

## A — one session resource

`GET/POST/DELETE /sessions/:api` replaces the six per-family session routes. One handler trio (`isAuthenticated` / `authenticate` / `logOut`) resolves the client over a map on the existing `Api` union; the DELETE (logout) carried over the same way. `types/api.mts`'s local `AuthenticationAPI` re-declaration retires in favor of `Pick<BaseAPIAdapter, 'authenticate' | 'isAuthenticated'>` — the library's published adapter contract. The settings page's session paths lose their dialect fork (`/${api}/sessions` → `/sessions/${api}`).

## B — ATA group onto /targets

`GET/PUT /targets/:targetId/ata` + `GET /targets/:targetId/ata/modes` replace the eight per-family group routes; `targetId` is the picker value verbatim — the same `${model}_${id}` addressing as `/targets/settings`, resolved by `#getAtaGroupTarget` (mirror of `#getSettingsTarget`). The library's `getMemberOperationModes({ poweredOnly: true })` replaces BOTH `getClassicAtaDetailedStates` (verified: its only consumer was the widget's mixed-mode scene resolver, reading `OperationMode` with `status: 'on'` — powered-only exactly) and `getHomeBuildingAtaModes` (whose power-blindness was the inconsistency: the neutral call makes the Home leg match the Classic one). `/classic/…/ata/details` and the `GroupAtaStates` / `GetAtaOptions` types die.

**NoChangesError verdict:** no app-side no-change handling, on any leg. The old handlers disagreed (the Home device leg swallowed, its twins propagated) — but at melcloud-api 53.0.0 no-op tolerance lives in the library itself: every `updateGroupState` leg resolves an already-matching delta as the success it is (Classic ATA device and Home device via `tolerateNoChanges`, the Home building per member, the native Classic zone wire having no such concept), pinned by the library's own ata-group contract kernel. Nothing can propagate, so a catch app-side would re-derive a library invariant; and the widget's arming gate blocks empty bodies but NOT bodies the device caught up with meanwhile (its zone mapping lags the debounced stream), so those PUTs remain possible — and are correctly answered as success. Recorded as a comment on `updateTargetAtaState`.

**Picker grammar:** already ONE grammar — both widgets' select values were `${model}_${id}` all along; the slash forms lived only in path-building helpers (`getZonePath`, `getAtaStatePath`'s fork, the charts `homeDevices/` prefix), which die with the routes. No convergence needed; the value rides verbatim.

## C — charts onto /targets

`GET /targets/:targetId/logs/{report,hourly-temperatures,operation-modes,signal,temperatures}` replace the ten per-family chart routes. The five app method twins merge into five target-neutral methods over the melcloud-api 53.0.0 `/report` interfaces: `#getReportTarget` (ReportSurface) for report/signal/temperatures, `#getFullReportTarget` (FullReportSurface) for the ATW-only pair — the Home leg pins `Home.DeviceType.Atw`, so a Home ATA target gets NotFoundError, nothing emulated.

**Listings decision: merged.** ONE `GET /devices` route replaces `/classic/devices` + `/home/devices` (and their `?type=` variants — five fetches at boot). The widget picker code genuinely benefits: `ClassicDeviceZone.deviceType` (53.0.0) plus `model` let every per-chart line-up, the last-24h gate included, derive from a single app-sorted list by client-side filters that preserve order — the five parallel fetches, the per-vendor type queries and the widget-side re-sorts all disappear (`getDeviceZones()` app-side also now feeds the widget-settings autocomplete). Keeping two listings would have preserved wire-side filtering nobody needed.

Both test kernels (`api-contract`, `api-route-guards`) hold every moved route on all three surfaces; the widget `public/` sources stay within the es2023 floor (no new APIs). CLAUDE.md's surface-conventions section records the new tables and the verdict.

Gates: format 0, lint 0, typecheck 0, test 0 (923), test:coverage 0 (100 % × 4), build 0, homey:validate 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKsbttD4wLTrZnZDwKK1Fn
