### PR TITLE
chore(release): 46.7.0

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -1903,5 +1903,20 @@
     "pl": "Ustawienia ochrony przed mrozem i trybu wakacyjnego działają teraz także w budynkach udostępnionych Tobie.",
     "ru": "Настройки защиты от замерзания и режима отпуска теперь работают и в зданиях, к которым вам предоставлен доступ.",
     "sv": "Frostskydds- och semesterlägesinställningar fungerar nu även i byggnader som delats med dig."
+  },
+  "46.7.0": {
+    "ar": "صيانة داخلية وإعادة هيكلة للشفرة البرمجية.",
+    "da": "Intern vedligeholdelse og omstrukturering af koden.",
+    "de": "Interne Wartung und Code-Umstrukturierung.",
+    "en": "Internal maintenance and code restructuring.",
+    "es": "Mantenimiento interno y reestructuración del código.",
+    "fr": "Maintenance interne et restructuration du code.",
+    "it": "Manutenzione interna e ristrutturazione del codice.",
+    "ko": "내부 유지 보수 및 코드 구조 개선.",
+    "nl": "Intern onderhoud en herstructurering van de code.",
+    "no": "Internt vedlikehold og omstrukturering av koden.",
+    "pl": "Wewnętrzna konserwacja i restrukturyzacja kodu.",
+    "ru": "Внутреннее обслуживание и реструктуризация кода.",
+    "sv": "Internt underhåll och omstrukturering av koden."
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -286,5 +286,5 @@
       "värmeåtervinning"
     ]
   },
-  "version": "46.6.3"
+  "version": "46.7.0"
 }

--- a/app.json
+++ b/app.json
@@ -287,7 +287,7 @@
       "värmeåtervinning"
     ]
   },
-  "version": "46.6.3",
+  "version": "46.7.0",
   "flow": {
     "triggers": [
       {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "com.melcloud",
-  "version": "46.6.3",
+  "version": "46.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "com.melcloud",
-      "version": "46.6.3",
+      "version": "46.7.0",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@olivierzal/homey-kit": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.melcloud",
-  "version": "46.6.3",
+  "version": "46.7.0",
   "description": "MELCloud for Homey",
   "homepage": "https://github.com/OlivierZal/com.melcloud/",
   "bugs": {


### PR DESCRIPTION
Store release 46.7.0: the melcloud-api 53.0.0 adoption (#1616) and the target-neutral session, group and chart routes (#1617). Nothing user-visible changed, so the changelog entry says maintenance plainly, in the file's thirteen locales.

- `.homeychangelog.json`: `46.7.0` entry (13 locales)
- `.homeycompose/app.json` + `package.json`/`package-lock.json`: 46.7.0
- `app.json`: regenerated by `homey:validate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKsbttD4wLTrZnZDwKK1Fn
