### PR TITLE
build: adopt @olivierzal/melcloud-api 53.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "GPL-3.0-only",
       "dependencies": {
         "@olivierzal/homey-kit": "5.0.0",
-        "@olivierzal/melcloud-api": "53.1.0",
+        "@olivierzal/melcloud-api": "53.1.1",
         "source-map-support": "^0.5.21",
         "temporal-polyfill": "^1.0.4"
       },
@@ -1129,9 +1129,9 @@
       }
     },
     "node_modules/@olivierzal/melcloud-api": {
-      "version": "53.1.0",
-      "resolved": "https://npm.pkg.github.com/download/@olivierzal/melcloud-api/53.1.0/24a52060fc42807d72efa98bc539224494fdd37e",
-      "integrity": "sha512-jYNm8Rj/sL0VM1P77VEdrvEGrn5YkSI9CquSbwHXlvZKgHAK1u9Jq+k5CqKqqLWznQtM2Ulf5OXuCSmWb0EMog==",
+      "version": "53.1.1",
+      "resolved": "https://npm.pkg.github.com/download/@olivierzal/melcloud-api/53.1.1/a7ac107cb1503e52f60a30925f20315ff8f40341",
+      "integrity": "sha512-goemBoHh/sOShNPJebz2lrYta4y+ZA0z3xln2AVDksL3X97Mz5VJrxBEHEXOKVcN9ExD7SJTPs8b0t0OPh/eWw==",
       "license": "MIT",
       "dependencies": {
         "@olivierzal/api-core": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "prettier": "@olivierzal/configs/prettier",
   "dependencies": {
     "@olivierzal/homey-kit": "5.0.0",
-    "@olivierzal/melcloud-api": "53.1.0",
+    "@olivierzal/melcloud-api": "53.1.1",
     "source-map-support": "^0.5.21",
     "temporal-polyfill": "^1.0.4"
   },


### PR DESCRIPTION
Exact-pin bump 53.1.0 → 53.1.1 ([release](https://github.com/OlivierZal/melcloud-api/releases/tag/v53.1.1)): the protection/holiday level fallback is one-way again — a `false` flag reads the device level only, removing the speculative device→zone fallback that could mask a real failure with a wrong never-configured answer. Owner review catch on #1741; no app-side code change, no store urgency (the removed path never fired in production).

Verified: typecheck, lint, format, build, homey:validate, 923 tests — all exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKsbttD4wLTrZnZDwKK1Fn