### PR TITLE
test: deduplicate the suites Sonar flags

### DIFF
--- a/tests/flow-card-mocks.ts
+++ b/tests/flow-card-mocks.ts
@@ -1,0 +1,29 @@
+import { vi } from 'vitest'
+
+interface FlowCardsStub {
+  readonly getActionCard: ReturnType<typeof vi.fn>
+  readonly getConditionCard: ReturnType<typeof vi.fn>
+}
+
+interface RunListenerCard {
+  readonly registerRunListener: (
+    listener: (args: Record<string, unknown>) => unknown,
+  ) => void
+}
+
+const createCard = (): RunListenerCard => ({
+  registerRunListener:
+    vi.fn<(listener: (args: Record<string, unknown>) => unknown) => void>(),
+})
+
+// Every driver mock stubs the same two flow-card getters, each answering
+// one card whose only member is its run-listener registrar. The card is
+// created once per getter, so a suite can assert on the registration.
+export const createFlowCardsStub = (): FlowCardsStub => ({
+  getActionCard: vi
+    .fn<(id: string) => RunListenerCard>()
+    .mockReturnValue(createCard()),
+  getConditionCard: vi
+    .fn<(id: string) => RunListenerCard>()
+    .mockReturnValue(createCard()),
+})

--- a/tests/mock-driver-class.ts
+++ b/tests/mock-driver-class.ts
@@ -1,5 +1,7 @@
 import { vi } from 'vitest'
 
+import { createFlowCardsStub } from './flow-card-mocks.ts'
+
 const applyOverrides = (
   target: object,
   overrides?: Record<string, unknown>,
@@ -29,36 +31,7 @@ export const createMockDriverClass = (
           .fn<(type: number) => readonly unknown[]>()
           .mockReturnValue([]),
       },
-      flow: {
-        getActionCard: vi
-          .fn<
-            (id: string) => {
-              registerRunListener: (
-                listener: (args: Record<string, unknown>) => unknown,
-              ) => void
-            }
-          >()
-          .mockReturnValue({
-            registerRunListener:
-              vi.fn<
-                (listener: (args: Record<string, unknown>) => unknown) => void
-              >(),
-          }),
-        getConditionCard: vi
-          .fn<
-            (id: string) => {
-              registerRunListener: (
-                listener: (args: Record<string, unknown>) => unknown,
-              ) => void
-            }
-          >()
-          .mockReturnValue({
-            registerRunListener:
-              vi.fn<
-                (listener: (args: Record<string, unknown>) => unknown) => void
-              >(),
-          }),
-      },
+      flow: createFlowCardsStub(),
     }
 
     public log = vi.fn<(...args: readonly unknown[]) => void>()

--- a/tests/pair-session.ts
+++ b/tests/pair-session.ts
@@ -1,0 +1,34 @@
+import type PairSession from 'homey/lib/PairSession'
+import { vi } from 'vitest'
+
+import { mock } from './helpers.ts'
+
+interface ListDevicesSession {
+  readonly listHandler: ReturnType<
+    typeof vi.fn<(...args: unknown[]) => unknown>
+  >
+  readonly session: PairSession
+}
+
+// Pairing hands the driver a session it registers handlers on; a suite
+// drives the listing by capturing the `list_devices` one and calling it.
+// `showViewMock` stays the caller's, so each suite keeps asserting on its
+// own view navigation.
+export const createListDevicesSession = (
+  showViewMock: ReturnType<typeof vi.fn<(view: string) => Promise<void>>>,
+): ListDevicesSession => {
+  const listHandler = vi.fn<(...args: unknown[]) => unknown>()
+  const session = mock<PairSession>({
+    setHandler: vi
+      .fn<(event: string, handler: (...args: unknown[]) => unknown) => void>()
+      .mockImplementation(
+        (event: string, handler: (...args: unknown[]) => unknown) => {
+          if (event === 'list_devices') {
+            listHandler.mockImplementation(handler)
+          }
+        },
+      ),
+    showView: showViewMock,
+  })
+  return { listHandler, session }
+}

--- a/tests/report-mocks.ts
+++ b/tests/report-mocks.ts
@@ -1,0 +1,35 @@
+import { Temporal } from 'temporal-polyfill'
+import { vi } from 'vitest'
+
+// 12:00 CET in Paris = 11:00Z; the local day started at 2026-03-17T23:00Z.
+export const FAKE_NOW: number = Temporal.Instant.from(
+  '2026-03-18T12:00:00.000+01:00',
+).epochMilliseconds
+
+interface ReportDeviceMocks {
+  readonly cleanMappingMock: ReturnType<typeof vi.fn>
+  readonly clearTimeoutMock: ReturnType<typeof vi.fn>
+  readonly ensureDeviceMock: ReturnType<typeof vi.fn>
+  readonly setCapabilityValueMock: ReturnType<typeof vi.fn>
+  readonly setTimeoutMock: ReturnType<typeof vi.fn>
+}
+
+// The device seam an energy report drives is the same on both dialects:
+// it writes capabilities, resolves its device, cleans its tag mapping and
+// schedules its next run. Each suite seats its own fresh set.
+export const createReportDeviceMocks = (): ReportDeviceMocks => ({
+  cleanMappingMock: vi.fn<(mapping: unknown) => Record<string, unknown>>(),
+  clearTimeoutMock: vi.fn<(timeout: NodeJS.Timeout | null) => void>(),
+  ensureDeviceMock: vi.fn<() => Promise<unknown>>(),
+  setCapabilityValueMock:
+    vi.fn<(capability: string, value: unknown) => Promise<void>>(),
+  setTimeoutMock: vi
+    .fn<
+      (
+        callback: () => Promise<void>,
+        interval: unknown,
+        actionType: string,
+      ) => number
+    >()
+    .mockReturnValue(1),
+})

--- a/tests/unit/app.test.ts
+++ b/tests/unit/app.test.ts
@@ -12,7 +12,7 @@ import {
   UpdateRejectedError,
 } from '@olivierzal/melcloud-api'
 import { Temporal } from 'temporal-polyfill'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import * as Classic from '@olivierzal/melcloud-api/classic'
 import * as Home from '@olivierzal/melcloud-api/home'
 
@@ -447,6 +447,11 @@ const setupWidgetListeners = (): {
 
 // Mutations resolve void and throw UpdateRejectedError on a wire
 // rejection (melcloud-api 45.0.0): `null` models the accepted write.
+// The holiday windows the flow cards write are all stamped from one
+// instant, so the suites that assert on them freeze the clock rather
+// than each test wrapping its own spy in a try/finally.
+const FIXED_NOW = '2026-07-19T08:30:00'
+
 const mockUpdateResult = (
   attributeErrors: Record<string, string[]> | null,
 ): ReturnType<typeof vi.fn> =>
@@ -2454,6 +2459,16 @@ describe('melCloudApp', () => {
   describe('holiday mode flow cards', () => {
     const zoneArg = { id: 'buildings_1' } as const
 
+    beforeEach(() => {
+      vi.spyOn(Temporal.Now, 'plainDateTimeISO').mockReturnValue(
+        Temporal.PlainDateTime.from(FIXED_NOW),
+      )
+    })
+
+    afterEach(() => {
+      vi.mocked(Temporal.Now.plainDateTimeISO).mockRestore()
+    })
+
     describe('zone autocomplete', () => {
       it('should filter zones by query, suffixing leaves and carrying the value', async () => {
         mockFacadeManagerGetZones.mockReturnValue([
@@ -2559,132 +2574,95 @@ describe('melCloudApp', () => {
 
     describe('action run listener', () => {
       it('should end at midnight, N days out, starting now', async () => {
-        vi.spyOn(Temporal.Now, 'plainDateTimeISO').mockReturnValue(
-          Temporal.PlainDateTime.from('2026-07-19T08:30:00'),
-        )
-        try {
-          const mockUpdateHolidayMode = mockUpdateResult(null)
-          await initWithHolidayModeFacade(app, {
-            updateHolidayMode: mockUpdateHolidayMode,
-          })
+        const mockUpdateHolidayMode = mockUpdateResult(null)
+        await initWithHolidayModeFacade(app, {
+          updateHolidayMode: mockUpdateHolidayMode,
+        })
 
-          await getActionRunListener()({ duration: 3, zone: zoneArg })
+        await getActionRunListener()({ duration: 3, zone: zoneArg })
 
-          // Start = now; end = the start of the day 3 days out (00:00), not
-          // the trigger time.
-          expect(
-            getMockCallArg<HolidayModeUpdate>(mockUpdateHolidayMode, 0, 0),
-          ).toStrictEqual({
-            endDate: '2026-07-22T00:00:00',
-            isEnabled: true,
-            startDate: '2026-07-19T08:30:00',
-          })
-        } finally {
-          vi.mocked(Temporal.Now.plainDateTimeISO).mockRestore()
-        }
+        // Start = now; end = the start of the day 3 days out (00:00), not
+        // the trigger time.
+        expect(
+          getMockCallArg<HolidayModeUpdate>(mockUpdateHolidayMode, 0, 0),
+        ).toStrictEqual({
+          endDate: '2026-07-22T00:00:00',
+          isEnabled: true,
+          startDate: '2026-07-19T08:30:00',
+        })
       })
 
       it('should disable holiday mode for a zero duration', async () => {
-        vi.spyOn(Temporal.Now, 'plainDateTimeISO').mockReturnValue(
-          Temporal.PlainDateTime.from('2026-07-19T08:30:00'),
-        )
-        try {
-          const mockUpdateHolidayMode = mockUpdateResult(null)
-          await initWithHolidayModeFacade(app, {
-            updateHolidayMode: mockUpdateHolidayMode,
-          })
+        const mockUpdateHolidayMode = mockUpdateResult(null)
+        await initWithHolidayModeFacade(app, {
+          updateHolidayMode: mockUpdateHolidayMode,
+        })
 
-          await getActionRunListener()({ duration: 0, zone: zoneArg })
+        await getActionRunListener()({ duration: 0, zone: zoneArg })
 
-          // Disabled: the window bounds are stamped at now and ignored.
-          expect(
-            getMockCallArg<HolidayModeUpdate>(mockUpdateHolidayMode, 0, 0),
-          ).toStrictEqual({
-            endDate: '2026-07-19T08:30:00',
-            isEnabled: false,
-            startDate: '2026-07-19T08:30:00',
-          })
-        } finally {
-          vi.mocked(Temporal.Now.plainDateTimeISO).mockRestore()
-        }
+        // Disabled: the window bounds are stamped at now and ignored.
+        expect(
+          getMockCallArg<HolidayModeUpdate>(mockUpdateHolidayMode, 0, 0),
+        ).toStrictEqual({
+          endDate: '2026-07-19T08:30:00',
+          isEnabled: false,
+          startDate: '2026-07-19T08:30:00',
+        })
       })
 
       it('should batch a Home device window via the Home endpoint', async () => {
-        vi.spyOn(Temporal.Now, 'plainDateTimeISO').mockReturnValue(
-          Temporal.PlainDateTime.from('2026-07-19T08:30:00'),
-        )
-        try {
-          await app.onInit()
-          const updateHolidayMode = vi
-            .fn<() => Promise<void>>()
-            .mockResolvedValue()
-          stubHomeDevice({ updateHolidayMode })
+        await app.onInit()
+        const updateHolidayMode = vi
+          .fn<() => Promise<void>>()
+          .mockResolvedValue()
+        stubHomeDevice({ updateHolidayMode })
 
-          await getActionRunListener()({ duration: 3, zone: homeHolidayZone })
+        await getActionRunListener()({ duration: 3, zone: homeHolidayZone })
 
-          // Start = now (matching the Classic path's omitted `from`), end =
-          // midnight 3 days out; the device facade writes its own unit.
-          expect(updateHolidayMode).toHaveBeenCalledWith({
-            endDate: '2026-07-22T00:00:00',
-            isEnabled: true,
-            startDate: '2026-07-19T08:30:00',
-          })
-        } finally {
-          vi.mocked(Temporal.Now.plainDateTimeISO).mockRestore()
-        }
+        // Start = now (matching the Classic path's omitted `from`), end =
+        // midnight 3 days out; the device facade writes its own unit.
+        expect(updateHolidayMode).toHaveBeenCalledWith({
+          endDate: '2026-07-22T00:00:00',
+          isEnabled: true,
+          startDate: '2026-07-19T08:30:00',
+        })
       })
 
       it('should batch a Home building window across its devices', async () => {
-        vi.spyOn(Temporal.Now, 'plainDateTimeISO').mockReturnValue(
-          Temporal.PlainDateTime.from('2026-07-19T08:30:00'),
-        )
-        try {
-          await app.onInit()
-          const updateHolidayMode = vi
-            .fn<() => Promise<void>>()
-            .mockResolvedValue()
-          mockHomeFacadeManagerGetBuilding.mockReturnValue({
-            updateHolidayMode,
-          })
+        await app.onInit()
+        const updateHolidayMode = vi
+          .fn<() => Promise<void>>()
+          .mockResolvedValue()
+        mockHomeFacadeManagerGetBuilding.mockReturnValue({ updateHolidayMode })
 
-          await getActionRunListener()({
-            duration: 3,
-            zone: { id: 'homeBuildings_b1' },
-          })
+        await getActionRunListener()({
+          duration: 3,
+          zone: { id: 'homeBuildings_b1' },
+        })
 
-          // A whole Home building batches the one window over its members
-          // — the fan-out lives in the library's building facade.
-          expect(updateHolidayMode).toHaveBeenCalledWith({
-            endDate: '2026-07-22T00:00:00',
-            isEnabled: true,
-            startDate: '2026-07-19T08:30:00',
-          })
-        } finally {
-          vi.mocked(Temporal.Now.plainDateTimeISO).mockRestore()
-        }
+        // A whole Home building batches the one window over its members
+        // — the fan-out lives in the library's building facade.
+        expect(updateHolidayMode).toHaveBeenCalledWith({
+          endDate: '2026-07-22T00:00:00',
+          isEnabled: true,
+          startDate: '2026-07-19T08:30:00',
+        })
       })
 
       // Tokens dropped into the duration field arrive as numbers or
       // numeric strings and bypass the manifest min/max/step.
       it('should accept a numeric string duration from a token', async () => {
-        vi.spyOn(Temporal.Now, 'plainDateTimeISO').mockReturnValue(
-          Temporal.PlainDateTime.from('2026-07-19T08:30:00'),
-        )
-        try {
-          const mockUpdateHolidayMode = mockUpdateResult(null)
-          await initWithHolidayModeFacade(app, {
-            updateHolidayMode: mockUpdateHolidayMode,
-          })
+        const mockUpdateHolidayMode = mockUpdateResult(null)
+        await initWithHolidayModeFacade(app, {
+          updateHolidayMode: mockUpdateHolidayMode,
+        })
 
-          await getActionRunListener()({ duration: '3', zone: zoneArg })
+        await getActionRunListener()({ duration: '3', zone: zoneArg })
 
-          expect(
-            getMockCallArg<HolidayModeUpdate>(mockUpdateHolidayMode, 0, 0)
-              .endDate,
-          ).toBe('2026-07-22T00:00:00')
-        } finally {
-          vi.mocked(Temporal.Now.plainDateTimeISO).mockRestore()
-        }
+        expect(
+          getMockCallArg<HolidayModeUpdate>(mockUpdateHolidayMode, 0, 0)
+            .endDate,
+        ).toBe('2026-07-22T00:00:00')
       })
 
       it.each([1.5, -1, 366, 'holidays', '', false, true, null])(
@@ -2706,85 +2684,64 @@ describe('melCloudApp', () => {
 
     describe('with-time action run listener', () => {
       it('should end at the chosen time, N days out, starting now', async () => {
-        vi.spyOn(Temporal.Now, 'plainDateTimeISO').mockReturnValue(
-          Temporal.PlainDateTime.from('2026-07-19T08:30:00'),
-        )
-        try {
-          const mockUpdateHolidayMode = mockUpdateResult(null)
-          await initWithHolidayModeFacade(app, {
-            updateHolidayMode: mockUpdateHolidayMode,
-          })
+        const mockUpdateHolidayMode = mockUpdateResult(null)
+        await initWithHolidayModeFacade(app, {
+          updateHolidayMode: mockUpdateHolidayMode,
+        })
 
-          await getWithTimeRunListener()({
-            duration: 5,
-            time: '10:00',
-            zone: zoneArg,
-          })
+        await getWithTimeRunListener()({
+          duration: 5,
+          time: '10:00',
+          zone: zoneArg,
+        })
 
-          // Start = now; end is that time 5 days out.
-          expect(
-            getMockCallArg<HolidayModeUpdate>(mockUpdateHolidayMode, 0, 0),
-          ).toStrictEqual({
-            endDate: '2026-07-24T10:00:00',
-            isEnabled: true,
-            startDate: '2026-07-19T08:30:00',
-          })
-        } finally {
-          vi.mocked(Temporal.Now.plainDateTimeISO).mockRestore()
-        }
+        // Start = now; end is that time 5 days out.
+        expect(
+          getMockCallArg<HolidayModeUpdate>(mockUpdateHolidayMode, 0, 0),
+        ).toStrictEqual({
+          endDate: '2026-07-24T10:00:00',
+          isEnabled: true,
+          startDate: '2026-07-19T08:30:00',
+        })
       })
 
       // Zero days is not a disable here: it ends the same day at the time.
       it('should end today for a zero duration', async () => {
-        vi.spyOn(Temporal.Now, 'plainDateTimeISO').mockReturnValue(
-          Temporal.PlainDateTime.from('2026-07-19T08:30:00'),
-        )
-        try {
-          const mockUpdateHolidayMode = mockUpdateResult(null)
-          await initWithHolidayModeFacade(app, {
-            updateHolidayMode: mockUpdateHolidayMode,
-          })
+        const mockUpdateHolidayMode = mockUpdateResult(null)
+        await initWithHolidayModeFacade(app, {
+          updateHolidayMode: mockUpdateHolidayMode,
+        })
 
-          await getWithTimeRunListener()({
-            duration: 0,
-            time: '10:00',
-            zone: zoneArg,
-          })
+        await getWithTimeRunListener()({
+          duration: 0,
+          time: '10:00',
+          zone: zoneArg,
+        })
 
-          expect(
-            getMockCallArg<HolidayModeUpdate>(mockUpdateHolidayMode, 0, 0),
-          ).toStrictEqual({
-            endDate: '2026-07-19T10:00:00',
-            isEnabled: true,
-            startDate: '2026-07-19T08:30:00',
-          })
-        } finally {
-          vi.mocked(Temporal.Now.plainDateTimeISO).mockRestore()
-        }
+        expect(
+          getMockCallArg<HolidayModeUpdate>(mockUpdateHolidayMode, 0, 0),
+        ).toStrictEqual({
+          endDate: '2026-07-19T10:00:00',
+          isEnabled: true,
+          startDate: '2026-07-19T08:30:00',
+        })
       })
 
       it('should reject an end that is not after now', async () => {
-        vi.spyOn(Temporal.Now, 'plainDateTimeISO').mockReturnValue(
-          Temporal.PlainDateTime.from('2026-07-19T08:30:00'),
-        )
-        try {
-          const mockUpdateHolidayMode = mockUpdateResult(null)
-          await initWithHolidayModeFacade(app, {
-            updateHolidayMode: mockUpdateHolidayMode,
-          })
+        const mockUpdateHolidayMode = mockUpdateResult(null)
+        await initWithHolidayModeFacade(app, {
+          updateHolidayMode: mockUpdateHolidayMode,
+        })
 
-          await expect(
-            getWithTimeRunListener()({
-              duration: 0,
-              time: '06:00',
-              zone: zoneArg,
-            }),
-          ).rejects.toThrow('errors.invalidHolidayModeEnd')
+        await expect(
+          getWithTimeRunListener()({
+            duration: 0,
+            time: '06:00',
+            zone: zoneArg,
+          }),
+        ).rejects.toThrow('errors.invalidHolidayModeEnd')
 
-          expect(mockUpdateHolidayMode).not.toHaveBeenCalled()
-        } finally {
-          vi.mocked(Temporal.Now.plainDateTimeISO).mockRestore()
-        }
+        expect(mockUpdateHolidayMode).not.toHaveBeenCalled()
       })
 
       it.each([1.5, -1, 366, 'holidays', '', false, true, null])(
@@ -2826,50 +2783,36 @@ describe('melCloudApp', () => {
 
     describe('false action run listener', () => {
       it('should clear the holiday mode window', async () => {
-        vi.spyOn(Temporal.Now, 'plainDateTimeISO').mockReturnValue(
-          Temporal.PlainDateTime.from('2026-07-19T08:30:00'),
-        )
-        try {
-          const mockUpdateHolidayMode = mockUpdateResult(null)
-          await initWithHolidayModeFacade(app, {
-            updateHolidayMode: mockUpdateHolidayMode,
-          })
+        const mockUpdateHolidayMode = mockUpdateResult(null)
+        await initWithHolidayModeFacade(app, {
+          updateHolidayMode: mockUpdateHolidayMode,
+        })
 
-          await getFalseRunListener()({ zone: zoneArg })
+        await getFalseRunListener()({ zone: zoneArg })
 
-          expect(
-            getMockCallArg<HolidayModeUpdate>(mockUpdateHolidayMode, 0, 0),
-          ).toStrictEqual({
-            endDate: '2026-07-19T08:30:00',
-            isEnabled: false,
-            startDate: '2026-07-19T08:30:00',
-          })
-        } finally {
-          vi.mocked(Temporal.Now.plainDateTimeISO).mockRestore()
-        }
+        expect(
+          getMockCallArg<HolidayModeUpdate>(mockUpdateHolidayMode, 0, 0),
+        ).toStrictEqual({
+          endDate: '2026-07-19T08:30:00',
+          isEnabled: false,
+          startDate: '2026-07-19T08:30:00',
+        })
       })
 
       it('should disable holiday mode on a Home device', async () => {
-        vi.spyOn(Temporal.Now, 'plainDateTimeISO').mockReturnValue(
-          Temporal.PlainDateTime.from('2026-07-19T08:30:00'),
-        )
-        try {
-          await app.onInit()
-          const updateHolidayMode = vi
-            .fn<() => Promise<void>>()
-            .mockResolvedValue()
-          stubHomeDevice({ updateHolidayMode })
+        await app.onInit()
+        const updateHolidayMode = vi
+          .fn<() => Promise<void>>()
+          .mockResolvedValue()
+        stubHomeDevice({ updateHolidayMode })
 
-          await getFalseRunListener()({ zone: homeHolidayZone })
+        await getFalseRunListener()({ zone: homeHolidayZone })
 
-          expect(updateHolidayMode).toHaveBeenCalledWith({
-            endDate: '2026-07-19T08:30:00',
-            isEnabled: false,
-            startDate: '2026-07-19T08:30:00',
-          })
-        } finally {
-          vi.mocked(Temporal.Now.plainDateTimeISO).mockRestore()
-        }
+        expect(updateHolidayMode).toHaveBeenCalledWith({
+          endDate: '2026-07-19T08:30:00',
+          isEnabled: false,
+          startDate: '2026-07-19T08:30:00',
+        })
       })
     })
 

--- a/tests/unit/ata-group-setting-api.test.ts
+++ b/tests/unit/ata-group-setting-api.test.ts
@@ -1,11 +1,14 @@
 import type { HomeBuildingZone, HomeDeviceZone } from '@olivierzal/melcloud-api'
 import type * as Classic from '@olivierzal/melcloud-api/classic'
-import type { Homey } from 'homey/lib/Homey'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import * as Home from '@olivierzal/melcloud-api/home'
 
 import type { DriverCapabilitiesOptions } from '../../types/driver-settings.mts'
 import { mock } from '../helpers.ts'
+import {
+  createWidgetApiHarness,
+  describeWebviewBootLogging,
+} from '../widget-api.ts'
 
 const mockGetBuildings = vi.fn<() => Classic.BuildingZone[]>()
 
@@ -29,22 +32,16 @@ const mockApp = {
   updateTargetAtaState: vi.fn<() => Promise<void>>(),
 }
 
-const mockI18n = { getLanguage: vi.fn<() => string>() }
-
-const homey = mock<Homey>({ app: mockApp, i18n: mockI18n })
+const { homey, mockI18n } = createWidgetApiHarness(mockApp)
 
 describe('ata-group-setting api', () => {
   beforeEach(() => {
     vi.clearAllMocks()
   })
 
-  describe('webview boot logging', () => {
-    it('should log the boot failure body via app.error', () => {
-      api.logWebviewBoot({ body: { message: 'boom' }, homey })
-
-      expect(mockApp.error).toHaveBeenCalledTimes(1)
-    })
-  })
+  describeWebviewBootLogging(() => {
+    api.logWebviewBoot({ body: { message: 'boom' }, homey })
+  }, mockApp.error)
 
   describe('ata capability retrieval', () => {
     it('should delegate to app.getClassicAtaCapabilities', () => {

--- a/tests/unit/charts-api.test.ts
+++ b/tests/unit/charts-api.test.ts
@@ -2,10 +2,13 @@ import type {
   ReportChartLineOptions,
   ReportChartPieOptions,
 } from '@olivierzal/melcloud-api'
-import type { Homey } from 'homey/lib/Homey'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { mock } from '../helpers.ts'
+import {
+  createWidgetApiHarness,
+  describeWebviewBootLogging,
+} from '../widget-api.ts'
 
 const { default: api } = await import('../../widgets/charts/api.mts')
 
@@ -19,22 +22,16 @@ const mockApp = {
   getTargetTemperatures: vi.fn<() => Promise<ReportChartLineOptions>>(),
 }
 
-const mockI18n = { getLanguage: vi.fn<() => string>() }
-
-const homey = mock<Homey>({ app: mockApp, i18n: mockI18n })
+const { homey, mockI18n } = createWidgetApiHarness(mockApp)
 
 describe('charts api', () => {
   beforeEach(() => {
     vi.clearAllMocks()
   })
 
-  describe('webview boot logging', () => {
-    it('should log the boot failure body via app.error', () => {
-      api.logWebviewBoot({ body: { message: 'boom' }, homey })
-
-      expect(mockApp.error).toHaveBeenCalledTimes(1)
-    })
-  })
+  describeWebviewBootLogging(() => {
+    api.logWebviewBoot({ body: { message: 'boom' }, homey })
+  }, mockApp.error)
 
   describe('device retrieval', () => {
     it('should serve the one merged device-zone list', () => {

--- a/tests/unit/classic-driver.test.ts
+++ b/tests/unit/classic-driver.test.ts
@@ -2,7 +2,6 @@ import type * as Classic from '@olivierzal/melcloud-api/classic'
 import type HomeyModule from 'homey'
 import type FlowCardAction from 'homey/lib/FlowCardAction'
 import type FlowCardCondition from 'homey/lib/FlowCardCondition'
-import type PairSession from 'homey/lib/PairSession'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { EnergyCapabilityTagMapping } from '../../types/classic-capabilities.mts'
@@ -13,6 +12,7 @@ import {
   testRepairing,
 } from '../driver-descriptors.ts'
 import { type InteropModule, assertDefined, mock } from '../helpers.ts'
+import { createListDevicesSession } from '../pair-session.ts'
 import {
   type TestDriver,
   type TestDriverType,
@@ -85,26 +85,6 @@ vi.mock(import('homey'), async () => {
   })
 })
 
-const createListDevicesSession = (): {
-  listHandler: ReturnType<typeof vi.fn<(...args: unknown[]) => unknown>>
-  session: PairSession
-} => {
-  const listHandler = vi.fn<(...args: unknown[]) => unknown>()
-  const session = mock<PairSession>({
-    setHandler: vi
-      .fn<(event: string, handler: (...args: unknown[]) => unknown) => void>()
-      .mockImplementation(
-        (event: string, handler: (...args: unknown[]) => unknown) => {
-          if (event === 'list_devices') {
-            listHandler.mockImplementation(handler)
-          }
-        },
-      ),
-    showView: showViewMock,
-  })
-  return { listHandler, session }
-}
-
 describe(ClassicMELCloudDriver, () => {
   let driver: TestDriver
 
@@ -144,7 +124,7 @@ describe(ClassicMELCloudDriver, () => {
 
   describe('device discovery', () => {
     it('should discover devices on list_devices handler', async () => {
-      const { listHandler, session } = createListDevicesSession()
+      const { listHandler, session } = createListDevicesSession(showViewMock)
       stubDiscoverableDevice()
       await driver.onPair(session)
       const devices = await listHandler()
@@ -162,7 +142,7 @@ describe(ClassicMELCloudDriver, () => {
     // The opt-in rule at the pairing-details call site: the raw required
     // list carries measure_signal_strength, the listed device must not.
     it('should exclude the opt-in measure_signal_strength from pairing details', async () => {
-      const { listHandler, session } = createListDevicesSession()
+      const { listHandler, session } = createListDevicesSession(showViewMock)
       stubDiscoverableDevice()
       vi.spyOn(driver, 'getRequiredCapabilities').mockReturnValue([
         'onoff',

--- a/tests/unit/classic-report.test.ts
+++ b/tests/unit/classic-report.test.ts
@@ -18,27 +18,17 @@ import type { Homey } from '../../lib/homey.mts'
 import type { EnergyCapabilityTagMapping } from '../../types/classic-capabilities.mts'
 import { EnergyReport } from '../../drivers/classic-report.mts'
 import { getMockCallArg, mock } from '../helpers.ts'
+import { createReportDeviceMocks, FAKE_NOW } from '../report-mocks.ts'
 
 type TestDeviceType = typeof Classic.DeviceType.Ata
 
-const FAKE_NOW = Temporal.Instant.from(
-  '2026-03-18T12:00:00.000+01:00',
-).epochMilliseconds
-
-const setCapabilityValueMock =
-  vi.fn<(capability: string, value: unknown) => Promise<void>>()
-const ensureDeviceMock = vi.fn<() => Promise<unknown>>()
-const cleanMappingMock = vi.fn<(mapping: unknown) => Record<string, unknown>>()
-const clearTimeoutMock = vi.fn<(timeout: NodeJS.Timeout | null) => void>()
-const setTimeoutMock = vi
-  .fn<
-    (
-      callback: () => Promise<void>,
-      interval: unknown,
-      actionType: string,
-    ) => number
-  >()
-  .mockReturnValue(1)
+const {
+  cleanMappingMock,
+  clearTimeoutMock,
+  ensureDeviceMock,
+  setCapabilityValueMock,
+  setTimeoutMock,
+} = createReportDeviceMocks()
 const logMock = vi.fn<(...args: unknown[]) => void>()
 const errorMock = vi.fn<(...args: unknown[]) => void>()
 const setWarningMock = vi.fn<(warning: string | null) => Promise<void>>()

--- a/tests/unit/home-base-driver.test.ts
+++ b/tests/unit/home-base-driver.test.ts
@@ -1,5 +1,4 @@
 import type HomeyModule from 'homey'
-import type PairSession from 'homey/lib/PairSession'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import * as Home from '@olivierzal/melcloud-api/home'
 
@@ -10,6 +9,7 @@ import {
   testRepairing,
 } from '../driver-descriptors.ts'
 import { type InteropModule, mock } from '../helpers.ts'
+import { createListDevicesSession } from '../pair-session.ts'
 import HomeMELCloudDriverAta from '../../drivers/home-melcloud/driver.mts'
 import { createInstance } from './create-test-instance.ts'
 
@@ -33,6 +33,7 @@ const {
 
 vi.mock(import('homey'), async () => {
   const { mock: mockModule } = await import('../helpers.ts')
+  const { createFlowCardsStub } = await import('../flow-card-mocks.ts')
   class MockDriver {
     public homey = {
       app: {
@@ -43,36 +44,7 @@ vi.mock(import('homey'), async () => {
           isAuthenticated: isAuthenticatedMock,
         },
       },
-      flow: {
-        getActionCard: vi
-          .fn<
-            (id: string) => {
-              registerRunListener: (
-                listener: (args: Record<string, unknown>) => unknown,
-              ) => void
-            }
-          >()
-          .mockReturnValue({
-            registerRunListener:
-              vi.fn<
-                (listener: (args: Record<string, unknown>) => unknown) => void
-              >(),
-          }),
-        getConditionCard: vi
-          .fn<
-            (id: string) => {
-              registerRunListener: (
-                listener: (args: Record<string, unknown>) => unknown,
-              ) => void
-            }
-          >()
-          .mockReturnValue({
-            registerRunListener:
-              vi.fn<
-                (listener: (args: Record<string, unknown>) => unknown) => void
-              >(),
-          }),
-      },
+      flow: createFlowCardsStub(),
     }
 
     public log = vi.fn<(...args: readonly unknown[]) => void>()
@@ -137,21 +109,7 @@ describe(BaseMELCloudDriver, () => {
         capabilities: { hasAutomaticFanSpeed: true, numberOfFanSpeeds: 5 },
       })
 
-      const listHandler = vi.fn<(...args: unknown[]) => unknown>()
-      const session = mock<PairSession>({
-        setHandler: vi
-          .fn<
-            (event: string, handler: (...args: unknown[]) => unknown) => void
-          >()
-          .mockImplementation(
-            (event: string, handler: (...args: unknown[]) => unknown) => {
-              if (event === 'list_devices') {
-                listHandler.mockImplementation(handler)
-              }
-            },
-          ),
-        showView: showViewMock,
-      })
+      const { listHandler, session } = createListDevicesSession(showViewMock)
       await driver.onPair(session)
       const result = await listHandler()
 
@@ -191,21 +149,7 @@ describe(BaseMELCloudDriver, () => {
     it('should return empty array when getHomeDevicesByType returns empty', async () => {
       getHomeDevicesByTypeMock.mockReturnValue([])
 
-      const listHandler = vi.fn<(...args: unknown[]) => unknown>()
-      const session = mock<PairSession>({
-        setHandler: vi
-          .fn<
-            (event: string, handler: (...args: unknown[]) => unknown) => void
-          >()
-          .mockImplementation(
-            (event: string, handler: (...args: unknown[]) => unknown) => {
-              if (event === 'list_devices') {
-                listHandler.mockImplementation(handler)
-              }
-            },
-          ),
-        showView: showViewMock,
-      })
+      const { listHandler, session } = createListDevicesSession(showViewMock)
       await driver.onPair(session)
       const result = await listHandler()
 

--- a/tests/unit/home-melcloud-atw-driver.test.ts
+++ b/tests/unit/home-melcloud-atw-driver.test.ts
@@ -13,6 +13,7 @@ import {
   testTagMappings,
 } from '../driver-descriptors.ts'
 import { type InteropModule, mock } from '../helpers.ts'
+import { createListDevicesSession } from '../pair-session.ts'
 import HomeMELCloudDriverAtw from '../../drivers/home-melcloud_atw/driver.mts'
 import { createInstance } from './create-test-instance.ts'
 
@@ -78,19 +79,7 @@ const createProfile = ({
 const registerListHandler = async (driver: {
   onPair: (session: PairSession) => Promise<void>
 }): Promise<(...args: unknown[]) => unknown> => {
-  const listHandler = vi.fn<(...args: unknown[]) => unknown>()
-  const session = mock<PairSession>({
-    setHandler: vi
-      .fn<(event: string, handler: (...args: unknown[]) => unknown) => void>()
-      .mockImplementation(
-        (event: string, handler: (...args: unknown[]) => unknown) => {
-          if (event === 'list_devices') {
-            listHandler.mockImplementation(handler)
-          }
-        },
-      ),
-    showView: showViewMock,
-  })
+  const { listHandler, session } = createListDevicesSession(showViewMock)
   await driver.onPair(session)
   return listHandler
 }

--- a/tests/unit/home-report.test.ts
+++ b/tests/unit/home-report.test.ts
@@ -17,26 +17,15 @@ import type { HomeMELCloudDevice } from '../../drivers/home-device.mts'
 import { HomeEnergyReportAta } from '../../drivers/home-report-ata.mts'
 import { HomeEnergyReportAtw } from '../../drivers/home-report-atw.mts'
 import { getMockCallArg, mock } from '../helpers.ts'
+import { createReportDeviceMocks, FAKE_NOW } from '../report-mocks.ts'
 
-// 12:00 CET in Paris = 11:00Z; the local day started at 2026-03-17T23:00Z.
-const FAKE_NOW = Temporal.Instant.from(
-  '2026-03-18T12:00:00.000+01:00',
-).epochMilliseconds
-
-const setCapabilityValueMock =
-  vi.fn<(capability: string, value: unknown) => Promise<void>>()
-const ensureDeviceMock = vi.fn<() => Promise<unknown>>()
-const cleanMappingMock = vi.fn<(mapping: unknown) => Record<string, unknown>>()
-const clearTimeoutMock = vi.fn<(timeout: NodeJS.Timeout | null) => void>()
-const setTimeoutMock = vi
-  .fn<
-    (
-      callback: () => Promise<void>,
-      interval: unknown,
-      actionType: string,
-    ) => number
-  >()
-  .mockReturnValue(1)
+const {
+  cleanMappingMock,
+  clearTimeoutMock,
+  ensureDeviceMock,
+  setCapabilityValueMock,
+  setTimeoutMock,
+} = createReportDeviceMocks()
 const getStoreValueMock = vi.fn<(key: string) => unknown>()
 const setStoreValueMock =
   vi.fn<(key: string, value: unknown) => Promise<void>>()

--- a/tests/widget-api.ts
+++ b/tests/widget-api.ts
@@ -1,0 +1,32 @@
+import type { Homey } from 'homey/lib/Homey'
+import { describe, expect, it, vi } from 'vitest'
+
+import { mock } from './helpers.ts'
+
+interface WidgetApiHarness {
+  readonly homey: Homey
+  readonly mockI18n: { readonly getLanguage: ReturnType<typeof vi.fn> }
+}
+
+// Every widget api reaches its handlers through the same pair: the app
+// instance under test and Homey's i18n manager.
+export const createWidgetApiHarness = (mockApp: object): WidgetApiHarness => {
+  const mockI18n = { getLanguage: vi.fn<() => string>() }
+  return { homey: mock<Homey>({ app: mockApp, i18n: mockI18n }), mockI18n }
+}
+
+// The boot beacon is one contract across the widget surfaces: whatever
+// body the page posts reaches app.error. `logBoot` stays a thunk so each
+// suite keeps calling its OWN api with its own types.
+export const describeWebviewBootLogging = (
+  logBoot: () => void,
+  mockError: ReturnType<typeof vi.fn>,
+): void => {
+  describe('webview boot logging', () => {
+    it('should log the boot failure body via app.error', () => {
+      logBoot()
+
+      expect(mockError).toHaveBeenCalledTimes(1)
+    })
+  })
+}


### PR DESCRIPTION
SonarCloud's main-branch quality gate fails at 0.9 % duplication — our own 0 % ceiling — which is what turns the repo's CI badge red (the `ci / Test (Node 22.20)` leg carries the scanner). All 393 duplicated lines sat in tests; none in `src`. What each block became:

- **`app.test.ts` (117 lines)** — ten holiday-mode flow-card tests each wrapped their body in `vi.spyOn(Temporal.Now…)` / `try` / `finally mockRestore()`. The clock now freezes once, in a `beforeEach` on the enclosing `holiday mode flow cards` describe, so every test body is just its own arrangement and assertion. `FIXED_NOW` names the instant the assertions already spelled.
- **the two report suites (36 lines)** — `tests/report-mocks.ts` seats the five device mocks an energy report drives (capability write, device resolution, mapping clean, timer pair) plus the shared `FAKE_NOW`; each suite calls the factory once and keeps its own dialect-specific mocks.
- **the two widget-api suites (41 lines)** — `tests/widget-api.ts` holds the i18n+app harness and the boot-beacon kernel. `describeWebviewBootLogging` takes a thunk, so each suite still calls its OWN api with its own types.
- **the driver suites (~199 lines)** — `tests/flow-card-mocks.ts` replaces the flow-card getter stub duplicated between `home-base-driver.test.ts` and `mock-driver-class.ts`; `tests/pair-session.ts` hoists the `list_devices` session scaffold that `classic-driver.test.ts` had as a local helper and two Home suites repeated inline — it takes each suite's own `showViewMock`, so view-navigation assertions stay per-suite.

No `sonar.cpd` exclusion, no lint disable, no assertion touched.

Proof: 923 tests before and after, coverage thresholds held, all gates 0 (format, lint, typecheck, test:coverage, build). Mutation check on the hoisted clock — shifting the holiday window end by one day is killed by six of the unwrapped tests, and those same tests pass unmutated, which proves the frozen clock reaches them in both directions; src restored and re-greened after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKsbttD4wLTrZnZDwKK1Fn