### PR TITLE
test: deduplicate the driver suites' residual scaffolds

### DIFF
--- a/tests/home-driver-mocks.ts
+++ b/tests/home-driver-mocks.ts
@@ -1,0 +1,38 @@
+import type * as Home from '@olivierzal/melcloud-api/home'
+import { vi } from 'vitest'
+
+interface HomeDriverMocks {
+  readonly authenticateMock: ReturnType<
+    typeof vi.fn<(data: unknown) => Promise<boolean>>
+  >
+  readonly getHomeDevicesByTypeMock: ReturnType<
+    typeof vi.fn<(type: Home.DeviceType) => readonly unknown[]>
+  >
+  readonly getHomeFacadeMock: ReturnType<
+    typeof vi.fn<(id: string, type: Home.DeviceType) => unknown>
+  >
+  readonly isAuthenticatedMock: ReturnType<typeof vi.fn<() => boolean>>
+  readonly setHandlerMock: ReturnType<
+    typeof vi.fn<
+      (event: string, handler: (...args: unknown[]) => unknown) => void
+    >
+  >
+  readonly showViewMock: ReturnType<
+    typeof vi.fn<(view: string) => Promise<void>>
+  >
+}
+
+// The seam every Home driver suite mocks: the app's device registry and
+// facade lookup, the session's handler/view pair, and the two auth reads.
+// Reached through an async `vi.hoisted`, because the `homey` mock factory
+// runs before the importing suite's own body does.
+export const createHomeDriverMocks = (): HomeDriverMocks => ({
+  authenticateMock: vi.fn<(data: unknown) => Promise<boolean>>(),
+  getHomeDevicesByTypeMock:
+    vi.fn<(type: Home.DeviceType) => readonly unknown[]>(),
+  getHomeFacadeMock: vi.fn<(id: string, type: Home.DeviceType) => unknown>(),
+  isAuthenticatedMock: vi.fn<() => boolean>(),
+  setHandlerMock:
+    vi.fn<(event: string, handler: (...args: unknown[]) => unknown) => void>(),
+  showViewMock: vi.fn<(view: string) => Promise<void>>(),
+})

--- a/tests/unit/classic-driver.test.ts
+++ b/tests/unit/classic-driver.test.ts
@@ -231,23 +231,32 @@ describe(ClassicMELCloudDriver, () => {
     })
   })
 
+  // Every clause here drives a registered condition listener, so the
+  // suite captures them by standing in for the card registry.
+  const captureConditionListeners = async (): Promise<
+    Record<string, (args: Record<string, unknown>) => unknown>
+  > => {
+    const conditionListeners: Record<
+      string,
+      (args: Record<string, unknown>) => unknown
+    > = {}
+    vi.spyOn(driver.homey.flow, 'getConditionCard').mockImplementation(
+      (cardName: string) =>
+        mock<FlowCardCondition>({
+          registerRunListener: (
+            listener: (args: Record<string, unknown>) => unknown,
+          ): void => {
+            conditionListeners[cardName] = listener
+          },
+        }),
+    )
+    await driver.onInit()
+    return conditionListeners
+  }
+
   describe('condition run listener registration', () => {
     it('should return boolean capability value for boolean capabilities', async () => {
-      const conditionListeners: Record<
-        string,
-        (args: Record<string, unknown>) => unknown
-      > = {}
-      vi.spyOn(driver.homey.flow, 'getConditionCard').mockImplementation(
-        (cardName: string) =>
-          mock<FlowCardCondition>({
-            registerRunListener: (
-              listener: (args: Record<string, unknown>) => unknown,
-            ): void => {
-              conditionListeners[cardName] = listener
-            },
-          }),
-      )
-      await driver.onInit()
+      const conditionListeners = await captureConditionListeners()
 
       const { onoff_condition: onoffListener } = conditionListeners
       assertDefined(onoffListener)
@@ -264,21 +273,7 @@ describe(ClassicMELCloudDriver, () => {
     })
 
     it('should compare string/number capability values with arg', async () => {
-      const conditionListeners: Record<
-        string,
-        (args: Record<string, unknown>) => unknown
-      > = {}
-      vi.spyOn(driver.homey.flow, 'getConditionCard').mockImplementation(
-        (cardName: string) =>
-          mock<FlowCardCondition>({
-            registerRunListener: (
-              listener: (args: Record<string, unknown>) => unknown,
-            ): void => {
-              conditionListeners[cardName] = listener
-            },
-          }),
-      )
-      await driver.onInit()
+      const conditionListeners = await captureConditionListeners()
 
       const { thermostat_mode_condition: thermostatListener } =
         conditionListeners

--- a/tests/unit/home-base-driver.test.ts
+++ b/tests/unit/home-base-driver.test.ts
@@ -20,16 +20,10 @@ const {
   isAuthenticatedMock,
   setHandlerMock,
   showViewMock,
-} = vi.hoisted(() => ({
-  authenticateMock: vi.fn<(data: unknown) => Promise<boolean>>(),
-  getHomeDevicesByTypeMock:
-    vi.fn<(type: Home.DeviceType) => readonly unknown[]>(),
-  getHomeFacadeMock: vi.fn<(id: string, type: Home.DeviceType) => unknown>(),
-  isAuthenticatedMock: vi.fn<() => boolean>(),
-  setHandlerMock:
-    vi.fn<(event: string, handler: (...args: unknown[]) => unknown) => void>(),
-  showViewMock: vi.fn<(view: string) => Promise<void>>(),
-}))
+} = await vi.hoisted(async () => {
+  const { createHomeDriverMocks } = await import('../home-driver-mocks.ts')
+  return createHomeDriverMocks()
+})
 
 vi.mock(import('homey'), async () => {
   const { mock: mockModule } = await import('../helpers.ts')

--- a/tests/unit/home-melcloud-atw-driver.test.ts
+++ b/tests/unit/home-melcloud-atw-driver.test.ts
@@ -24,16 +24,10 @@ const {
   isAuthenticatedMock,
   setHandlerMock,
   showViewMock,
-} = vi.hoisted(() => ({
-  authenticateMock: vi.fn<(data: unknown) => Promise<boolean>>(),
-  getHomeDevicesByTypeMock:
-    vi.fn<(type: Home.DeviceType) => readonly unknown[]>(),
-  getHomeFacadeMock: vi.fn<(id: string, type: Home.DeviceType) => unknown>(),
-  isAuthenticatedMock: vi.fn<() => boolean>(),
-  setHandlerMock:
-    vi.fn<(event: string, handler: (...args: unknown[]) => unknown) => void>(),
-  showViewMock: vi.fn<(view: string) => Promise<void>>(),
-}))
+} = await vi.hoisted(async () => {
+  const { createHomeDriverMocks } = await import('../home-driver-mocks.ts')
+  return createHomeDriverMocks()
+})
 
 vi.mock(import('homey'), async () => {
   const { createMockDriverClass, mock: mockModule } =


### PR DESCRIPTION
Second pass. After #1623 the whole-project measure fell from 0.9 % to 0.2 % (393 → 70 duplicated lines) but not to zero: the PR-scope analysis only weighs the files a PR touches, so two blocks the branch never opened stayed standing. The main-branch measure is the referee, and it named them:

- **`home-base-driver.test.ts` ↔ `home-melcloud-atw-driver.test.ts` (19 lines each)** — both Home driver suites declared the same six `vi.hoisted` mocks. They now come from `tests/home-driver-mocks.ts` through an **async** `vi.hoisted`: the `homey` mock factory runs before the importing suite's body, so a plain static import would be a load-order gamble — `await vi.hoisted(async () => …)` makes the ordering explicit instead of relying on where the import sorter happens to place the module.
- **`classic-driver.test.ts` (32 lines)** — two condition-listener tests repeated the card-registry stand-in. It becomes `captureConditionListeners()`, defined in the describe where `driver` lives (`unicorn/consistent-function-scoping` is right: the inner describe was the wrong home for it).

Proof: 923 tests before and after, coverage thresholds held, gates all 0 (format, lint, typecheck, test:coverage, build). No exclusion, no disable, no assertion changed.

Lesson worth stating: a green PR-scope Sonar is not a whole-project verdict — for a duplication sweep, the main-branch measure after merge is the one that counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKsbttD4wLTrZnZDwKK1Fn