### PR TITLE
build: adopt @olivierzal/melcloud-api 54.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "GPL-3.0-only",
       "dependencies": {
         "@olivierzal/homey-kit": "5.0.0",
-        "@olivierzal/melcloud-api": "53.1.1",
+        "@olivierzal/melcloud-api": "54.0.0",
         "source-map-support": "^0.5.21",
         "temporal-polyfill": "^1.0.4"
       },
@@ -1129,9 +1129,9 @@
       }
     },
     "node_modules/@olivierzal/melcloud-api": {
-      "version": "53.1.1",
-      "resolved": "https://npm.pkg.github.com/download/@olivierzal/melcloud-api/53.1.1/a7ac107cb1503e52f60a30925f20315ff8f40341",
-      "integrity": "sha512-goemBoHh/sOShNPJebz2lrYta4y+ZA0z3xln2AVDksL3X97Mz5VJrxBEHEXOKVcN9ExD7SJTPs8b0t0OPh/eWw==",
+      "version": "54.0.0",
+      "resolved": "https://npm.pkg.github.com/download/@olivierzal/melcloud-api/54.0.0/dc360af9e5b0ef08f561d556f6985ed3e5b90df8",
+      "integrity": "sha512-Xv2weql7ix6aIti+vRE/W6tmZctkrrL7/E8TZGApwXRO72hp4ANEqZJPyawGQ/W6m6x9spjINGEKSfUvT4vaEQ==",
       "license": "MIT",
       "dependencies": {
         "@olivierzal/api-core": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "prettier": "@olivierzal/configs/prettier",
   "dependencies": {
     "@olivierzal/homey-kit": "5.0.0",
-    "@olivierzal/melcloud-api": "53.1.1",
+    "@olivierzal/melcloud-api": "54.0.0",
     "source-map-support": "^0.5.21",
     "temporal-polyfill": "^1.0.4"
   },


### PR DESCRIPTION
Exact pin `53.1.1` → `54.0.0`, no code change — and the reason no code change is needed is the interesting part of this adoption.

54.0.0 makes `authenticate()` **reject** when its enforced post-auth registry sync fails, where it used to resolve over an empty registry. Both of this app's call sites already handle that correctly, and one of them gets strictly better behavior:

- `drivers/base-driver.mts` — the pairing `login` handler catches only `AuthenticationError` and rethrows everything else. Before, a failed registry sync resolved, so pairing returned `true` and the user landed on an empty device list; now the failure surfaces in the pairing session.
- `api.mts` — `toLoginFailure` already classifies: a non-`AuthenticationError` becomes `new Error(getErrorMessage(error))`, so a sync failure keeps its own message instead of being labelled "credentials rejected".

The release also fixes a latent defect that shows up here: a Classic device of a type the SDK does not model used to invalidate the whole `/User/ListDevices` payload, so such an account saw ZERO devices. Unmodelled entries are now dropped at the listing boundary and every other device of the account lists normally.

Gates: format 0, lint 0, typecheck 0, test:coverage 0 (923), build 0, homey:validate 0 (publish level).

No store release in this PR; the next one carries the pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKsbttD4wLTrZnZDwKK1Fn