### PR TITLE
test: pin the labels the app borrows from node-homey-lib

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,7 +114,25 @@ caught real failures that the others miss:
   vendored node-homey-lib capability JSONs under `vendor/capabilities/`
   (homey-lib is a devDependency and must not ship to the device); the
   drift test in `tests/unit/capability-definitions.test.ts` fails when
-  the copies fall behind.
+  the copies fall behind. A homey-lib bump re-checks a SECOND thing the
+  same way: beyond the definitions, the app copies homey-lib's canonical
+  WORDING into labels of its own capabilities and flow cards, and
+  `tests/unit/borrowed-labels.test.ts` pins those copies — an explicit
+  table, one row per app site (file + JSON path) against the homey-lib
+  label it borrows, compared per locale. Membership states an INTENT,
+  never a measured string collision: a label enters the table only where
+  it deliberately speaks homey-lib's wording — today the `horizontal` /
+  `vertical` `auto` position with its flow-card copies (homey-lib
+  declares no vane capability, so `auto` is the one value that can
+  borrow) and the ATA drivers' `thermostat_mode` `cool` value. A
+  coincidence stays OUT: `operational_state` names a state
+  ("Heating"/"Cooling") where `thermostat_mode` names a command
+  ("Heat"/"Cool") and they meet in ar/it/ko/pl/ru only, while the app's
+  own `hot_water_mode` and `thermostat_mode` values keep their own
+  Russian ("Авто") — pinning either would force an edit upstream never
+  asked for. When a row breaks, the APP copy follows: adopt the new
+  wording there and revisit that label's other locales, never edit
+  `vendor/capabilities/` to make it pass.
 - `npm run homey:start` — `homey app run --remote` for on-device testing.
   The `homey:*` wrappers are plain CLI calls: the CLI's own
   `npm run build` (post-copy) emits everything the package needs into

--- a/tests/unit/borrowed-labels.test.ts
+++ b/tests/unit/borrowed-labels.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from 'vitest'
+import libThermostatMode from 'homey-lib/assets/capability/capabilities/thermostat_mode.json' with { type: 'json' }
+
+import horizontalCapability from '../../.homeycompose/capabilities/horizontal.json' with { type: 'json' }
+import verticalCapability from '../../.homeycompose/capabilities/vertical.json' with { type: 'json' }
+import horizontalAction from '../../.homeycompose/flow/actions/horizontal_action.json' with { type: 'json' }
+import verticalAction from '../../.homeycompose/flow/actions/vertical_action.json' with { type: 'json' }
+import horizontalCondition from '../../.homeycompose/flow/conditions/horizontal_condition.json' with { type: 'json' }
+import verticalCondition from '../../.homeycompose/flow/conditions/vertical_condition.json' with { type: 'json' }
+import horizontalChanged from '../../.homeycompose/flow/triggers/horizontal_changed.json' with { type: 'json' }
+import verticalChanged from '../../.homeycompose/flow/triggers/vertical_changed.json' with { type: 'json' }
+import homeAtaCompose from '../../drivers/home-melcloud/driver.compose.json' with { type: 'json' }
+import classicAtaCompose from '../../drivers/melcloud/driver.compose.json' with { type: 'json' }
+
+// The companion of tests/unit/capability-definitions.test.ts: that one
+// pins the vendored DEFINITIONS against node-homey-lib, this one pins
+// the LABELS the app copies out of them. Nothing derives those copies at
+// build time, so a homey-lib re-wording would leave the app spelling a
+// value one way where Homey spells it another — on the same device page,
+// since the ATA drivers ship `thermostat_mode` next to their own vane
+// pickers.
+//
+// Membership states an INTENT, not a measurement: a row exists because
+// the app site deliberately speaks homey-lib's wording. A label that
+// merely collides in a few locales stays out, because pinning it would
+// force an edit upstream never asked for. Kept out on that ground:
+// `operational_state` (a state noun — "Heating"/"Cooling") against
+// `thermostat_mode` (a mode verb — "Heat"/"Cool"), which meet only in
+// ar/it/ko/pl/ru; the ATA driver settings' per-mode meter labels, whose
+// siblings already decline homey-lib's wording; and the app's own
+// `hot_water_mode` and `thermostat_mode` values, which keep their own
+// Russian ("Авто") and are therefore the app's wording, not Homey's.
+interface LabelSite {
+  readonly json: unknown
+  readonly path: string
+  readonly source: string
+}
+
+const THERMOSTAT_AUTO: LabelSite = {
+  json: libThermostatMode,
+  path: 'values[0].title',
+  source: 'thermostat_mode',
+}
+
+const THERMOSTAT_COOL: LabelSite = {
+  json: libThermostatMode,
+  path: 'values[2].title',
+  source: 'thermostat_mode',
+}
+
+const borrowedFrom = (
+  lib: LabelSite,
+  apps: LabelSite[],
+): { app: LabelSite; lib: LabelSite }[] => apps.map((app) => ({ app, lib }))
+
+// `horizontal` and `vertical` are the app's own capabilities: homey-lib
+// declares no vane capability, so their `auto` position is the one value
+// that can borrow, and it borrows the whole localized map — in the
+// capability, in each flow card repeating the dropdown, and in the
+// trigger token's example. The two ATA drivers re-declare Homey's
+// `thermostat_mode` to add the MELCloud-only modes and keep Homey's
+// wording for `cool`; `driver-compose.test.ts` keeps those two blocks
+// byte-identical to each other, this pins what they both say.
+const BORROWED_LABELS = [
+  ...borrowedFrom(THERMOSTAT_AUTO, [
+    {
+      json: horizontalCapability,
+      path: 'values[0].title',
+      source: '.homeycompose/capabilities/horizontal.json',
+    },
+    {
+      json: verticalCapability,
+      path: 'values[0].title',
+      source: '.homeycompose/capabilities/vertical.json',
+    },
+    {
+      json: horizontalAction,
+      path: 'args[1].values[0].title',
+      source: '.homeycompose/flow/actions/horizontal_action.json',
+    },
+    {
+      json: verticalAction,
+      path: 'args[1].values[0].title',
+      source: '.homeycompose/flow/actions/vertical_action.json',
+    },
+    {
+      json: horizontalCondition,
+      path: 'args[1].values[0].title',
+      source: '.homeycompose/flow/conditions/horizontal_condition.json',
+    },
+    {
+      json: verticalCondition,
+      path: 'args[1].values[0].title',
+      source: '.homeycompose/flow/conditions/vertical_condition.json',
+    },
+    {
+      json: horizontalChanged,
+      path: 'tokens[0].example',
+      source: '.homeycompose/flow/triggers/horizontal_changed.json',
+    },
+    {
+      json: verticalChanged,
+      path: 'tokens[0].example',
+      source: '.homeycompose/flow/triggers/vertical_changed.json',
+    },
+  ]),
+  ...borrowedFrom(THERMOSTAT_COOL, [
+    {
+      json: classicAtaCompose,
+      path: 'capabilitiesOptions.thermostat_mode.values[1].title',
+      source: 'drivers/melcloud/driver.compose.json',
+    },
+    {
+      json: homeAtaCompose,
+      path: 'capabilitiesOptions.thermostat_mode.values[1].title',
+      source: 'drivers/home-melcloud/driver.compose.json',
+    },
+  ]),
+]
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null
+
+const resolve = ({ json, path }: LabelSite): unknown => {
+  const keys = path.replaceAll('[', '.').replaceAll(']', '').split('.')
+  let node: unknown = json
+  for (const key of keys) {
+    node = isRecord(node) ? node[key] : undefined
+  }
+  return node
+}
+
+const readLabels = (site: LabelSite): Record<string, string> => {
+  const node = resolve(site)
+  const entries = Object.entries(isRecord(node) ? node : {})
+  const labels: Record<string, string> = {}
+  for (const [locale, wording] of entries) {
+    if (typeof wording === 'string') {
+      labels[locale] = wording
+    }
+  }
+  return labels
+}
+
+// One entry per diverging locale, each carrying the remedy: the app
+// label follows homey-lib, so the app file is what moves.
+const findWordingBreaches = ({
+  app,
+  lib,
+}: {
+  app: LabelSite
+  lib: LabelSite
+}): string[] => {
+  const appLabels = readLabels(app)
+  const libLabels = Object.entries(readLabels(lib))
+  const breaches: string[] = []
+  for (const [locale, wording] of libLabels) {
+    if (appLabels[locale] !== wording) {
+      breaches.push(
+        `${app.source} ${app.path} [${locale}] says ${JSON.stringify(appLabels[locale])} where node-homey-lib ${lib.source} ${lib.path} says ${JSON.stringify(wording)}: adopt the upstream wording in the app file and revisit this label's other locales — never edit vendor/capabilities to make this pass.`,
+      )
+    }
+  }
+  return breaches
+}
+
+describe('borrowed capability labels', () => {
+  it.each(BORROWED_LABELS)(
+    'should spell $app.source $app.path as homey-lib $lib.source $lib.path',
+    (row) => {
+      expect.assertions(2)
+
+      // A mistyped homey-lib path would otherwise compare nothing.
+      expect(Object.keys(readLabels(row.lib))).not.toStrictEqual([])
+
+      expect(findWordingBreaches(row)).toStrictEqual([])
+    },
+  )
+})


### PR DESCRIPTION
## The gap

`tests/unit/capability-definitions.test.ts` pins the vendored capability
DEFINITIONS (`vendor/capabilities/*.json`) against the installed
node-homey-lib — it caught the 2.52.1 bump. But the app also copies
homey-lib's canonical **wording** into labels of its own capabilities and
flow cards, and nothing checked those. CLAUDE.md stated the rule
("`melcloud_atw`'s labels are the reference (node-homey-lib wording)")
with no guard behind it: a homey-lib re-wording would leave the app
spelling a value one way where Homey spells it another, on the same
device page.

This PR adds the guard. **Nothing was stale** — the 2.52.1 bump moved
none of the borrowed strings, so this is purely the pin.

## What was derived

Every `title` / `label` / `example` localized map the app declares was
intersected, per locale, with every `title` the vendored capabilities
declare — over **all** git-tracked compose JSON, not just
`.homeycompose/**`. 140 (app site × homey-lib label) pairs share at least
one locale. Ranked by how much of the 13-locale map they share:

| shared locales | app site | homey-lib label | verdict |
| --- | --- | --- | --- |
| 13/13 | `horizontal` / `vertical` `auto` (capability, flow action, flow condition, trigger token example) — 8 sites | `thermostat_mode` `values[0].title` | **borrowed** |
| 13/13 | ATA drivers' `thermostat_mode` `cool` override — 2 sites | `thermostat_mode` `values[2].title` | **borrowed** |
| 13/13 | `drivers/melcloud/driver.settings.compose.json` `[2..4].children[1].label` ("Automatic") — 3 sites | `thermostat_mode` `values[0].title` | coincidence |
| 12/13 | `hot_water_mode` `auto` (defaults template) | `thermostat_mode` `values[0].title` | coincidence |
| 12/13 | ATA/ERV `thermostat_mode` `auto` override — 3 sites | `thermostat_mode` `values[0].title` | coincidence |
| 10/13 | ATA `thermostat_mode` `heat` override | `thermostat_mode` `values[1].title` | coincidence |
| 8/13 | ATA/ERV `thermostat_mode` `off` override | `thermostat_mode` `values[3].title` | coincidence |
| 5/13 | `operational_state` `cooling` (template, zone1, zone2, flow conditions) | `thermostat_mode` `values[2].title` | coincidence |
| 2–3/13 | `operational_state` `heating` (same sites) | `thermostat_mode` `values[1].title` | coincidence |
| 1/13 | `thermostat_mode` `off` override (fr, ko) | `onoff` `$flow` titles | coincidence |
| ≤2/13 | `widgets.charts.series.*` in `.homeycompose/locales/*.json` | various | coincidence |

### How this differs from the measured list

The list I was handed (19 strings, four sites) was neither complete nor
accurate:

- **Missed entirely**: `.homeycompose/capabilities/vertical.json`, the
  four horizontal/vertical **flow cards** (2 actions, 2 conditions), the
  two trigger **token examples**, and — outside the `.homeycompose/**`
  sweep it prescribed — the ATA drivers' `thermostat_mode` `cool` value
  and the ATA driver-settings labels. The vane `auto` label is copied at
  **eight** sites, not one.
- **Wrong on `hot_water_mode`**: the copy matches in 12 locales
  (`ar da de en es fr it ko nl no pl sv`), not the 8 listed — `ru`
  diverges.
- **Wrong on `operational_state` `de`**: `defaults.json` says `Heizung`
  where homey-lib says `Heizen`; they do not share `de`. The template's
  `heating` shares only `ko`/`pl`, `cooling` only `ar it ko pl ru`. The
  `de` "Heizen" the list cited lives in the **flow condition**, whose
  `operational_state` values are independently translated and differ from
  the capabilitiesOptions wording in several locales.
- **`horizontal.values[0]` is a borrowing, not a coincidence** — the
  opposite of the guess in the brief. See below.

## Borrowed vs coincidence, and why

The discriminator is not "do these strings match" but "does this label
follow homey-lib's wording as a rule". Two independent translations of
the same idea agree in a few locales; a copy agrees in all thirteen,
inflections included.

**Borrowed — pinned (10 rows).**

- **Vane `auto`, 8 sites.** homey-lib declares no vane capability, so
  `auto` is the one value of `horizontal`/`vertical` that *can* borrow,
  and it borrows the whole map. The fingerprint is decisive: 13/13
  byte-exact across 13 languages, including Swedish `Automatiskt` — the
  neuter/adverbial form, which agrees with *läge* (mode, neuter) and is
  **wrong** for *riktning* (direction, common gender) — and Russian
  `Автоматически`, an adverb. A fresh translation of a vane position
  produces neither. homey-lib also offers a shorter rendering of the same
  concept in `fan_mode` (`Auto` / `Авто` / `Automatico`); these sites
  match the longer `thermostat_mode` forms in every locale, which is a
  choice, not an accident.
- **ATA drivers' `thermostat_mode` `cool`, 2 sites.** The canonical case:
  the app re-declares Homey's own capability to add the MELCloud-only
  modes, re-words `heat` / `off` / `auto` in its own voice, and keeps
  Homey's wording verbatim for `cool` — 13/13. `driver-compose.test.ts`
  already keeps the twins byte-identical to each other; this pins what
  they both say.

**Coincidence — deliberately NOT pinned.**

- **`operational_state` heating/cooling.** Different concept: the app
  names a *state* (`Heating`/`Cooling`, `Heizung`/`Kühlung`,
  `Chauffage`/`Refroidissement`), homey-lib names a *command*
  (`Heat`/`Cool`, `Heizen`/`Kühlen`, `Chauffer`/`Refroidir`). They differ
  in `en de fr da nl no sv es` and collide only where the language does
  not distinguish verb from noun (`ar it ko pl ru`). Pinning it would
  chain an unrelated app label to an unrelated upstream edit — exactly
  the trap.
- **`hot_water_mode` `auto`, and the ATA/ERV `thermostat_mode` `auto`
  overrides (12/13).** The single divergence is the tell: all four sites
  say `Авто` in Russian, homey-lib says `Автоматически`. That is the
  app's own wording for a mode picker, used consistently across every
  mode enum it authors. Twelve locales coincide because homey-lib's
  phrasing is the natural one there — but the thirteenth shows the app
  did not adopt the label, it wrote one. Pinning the twelve would assert
  an intent the thirteenth refutes, and would force the app to chase a
  re-wording it already declined once.
- **ATA driver-settings "Automatic" labels (13/13).** These label
  per-mode energy meters, and their siblings in the same checkbox family
  (`Cooling`, `Heating`) already decline homey-lib's wording (`Cool`,
  `Heat`). The family is app-authored; changing one member on upstream's
  say-so would break its internal consistency. Copied once ≠ tracking.
- **`thermostat_mode` `off` (fr/ko) against `onoff` flow titles, and the
  charts series names.** One or two locales — noise.

## What landed

`tests/unit/borrowed-labels.test.ts`, a sibling of the definitions drift
test (the `api-contract` / `api-route-guards` precedent: one concern, two
halves, one file each). The table is **explicit** — hand-written rows,
each naming the app site (file + JSON path) and the homey-lib source
(capability + path), compared per locale. An implicit "any shared string"
assertion was rejected on purpose: a coincidental match would enter
silently and then fail on an unrelated upstream edit.

| app site | JSON path | homey-lib source |
| --- | --- | --- |
| `.homeycompose/capabilities/horizontal.json` | `values[0].title` | `thermostat_mode` `values[0].title` |
| `.homeycompose/capabilities/vertical.json` | `values[0].title` | `thermostat_mode` `values[0].title` |
| `.homeycompose/flow/actions/horizontal_action.json` | `args[1].values[0].title` | `thermostat_mode` `values[0].title` |
| `.homeycompose/flow/actions/vertical_action.json` | `args[1].values[0].title` | `thermostat_mode` `values[0].title` |
| `.homeycompose/flow/conditions/horizontal_condition.json` | `args[1].values[0].title` | `thermostat_mode` `values[0].title` |
| `.homeycompose/flow/conditions/vertical_condition.json` | `args[1].values[0].title` | `thermostat_mode` `values[0].title` |
| `.homeycompose/flow/triggers/horizontal_changed.json` | `tokens[0].example` | `thermostat_mode` `values[0].title` |
| `.homeycompose/flow/triggers/vertical_changed.json` | `tokens[0].example` | `thermostat_mode` `values[0].title` |
| `drivers/melcloud/driver.compose.json` | `capabilitiesOptions.thermostat_mode.values[1].title` | `thermostat_mode` `values[2].title` |
| `drivers/home-melcloud/driver.compose.json` | `capabilitiesOptions.thermostat_mode.values[1].title` | `thermostat_mode` `values[2].title` |

The source side reads homey-lib directly, not the vendored copy, so an
upstream re-wording fails both tests with distinct instructions: the
definitions test says "run the sync script", this one says "move the app
label".

**Failure message** — one entry per diverging locale, so the "check the
other locales" advice comes with the list. Verified by mutating a label:

```
.homeycompose/capabilities/vertical.json values[0].title [sv] says "Automatisk"
where node-homey-lib thermostat_mode values[0].title says "Automatiskt":
adopt the upstream wording in the app file and revisit this label's other
locales — never edit vendor/capabilities to make this pass.
```

`CLAUDE.md` gains the rule beside the existing vendored-capabilities
paragraph: a homey-lib bump re-checks the borrowed labels the same way it
re-checks the definitions, membership is an intent rather than a measured
collision, and the app copy is what moves when a row breaks.

## Gates

`format` 0 · `lint` 0 (no disables added) · `typecheck` 0 ·
`test:coverage` 0 (933 tests, 53 files; statements/branches/functions/
lines all 100%) · `build` 0 · `homey:validate` 0 (publish level, no file
rewritten).

The table's shared homey-lib source is hoisted through one `borrowedFrom`
helper rather than repeated per row, so no duplicated block is
introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKsbttD4wLTrZnZDwKK1Fn
