### PR TITLE
fix: follow node-homey-lib's re-worded thermostat vocabulary in the zone-2 flow cards

### DIFF
--- a/.homeycompose/flow/conditions/thermostat_mode.zone2_condition.json
+++ b/.homeycompose/flow/conditions/thermostat_mode.zone2_condition.json
@@ -126,10 +126,10 @@
     "fr": "Mode du thermostat !{{est|n'est pas}} dans la zone 2",
     "it": "La modalità termostato !{{è|non è}} nella zona 2",
     "ko": "구역 2의 온도조절기 모드가 !{{맞습니다|아닙니다}}",
-    "nl": "Thermostaatmodus !{{is|is niet}} in zone 2",
+    "nl": "Thermostaatstand !{{is|is niet}} in zone 2",
     "no": "Termostatmodus !{{er|er ikke}} i sone 2",
     "pl": "Tryb termostatu !{{jest|nie jest}} w strefie 2",
-    "ru": "Режим термостата !{{соответствует|не соответствует}} в зоне 2",
+    "ru": "Режим работы термостата !{{соответствует|не соответствует}} в зоне 2",
     "sv": "Termostatläge !{{är|är inte}} i zon 2"
   },
   "titleFormatted": {
@@ -141,10 +141,10 @@
     "fr": "Mode du thermostat !{{est|n'est pas}} [[thermostat_mode]] dans la zone 2",
     "it": "La modalità termostato !{{è|non è}} [[thermostat_mode]] nella zona 2",
     "ko": "구역 2의 온도조절기 모드가 [[thermostat_mode]] !{{입니다|이(가) 아닙니다}}",
-    "nl": "Thermostaatmodus !{{is|is niet}} [[thermostat_mode]] in zone 2",
+    "nl": "Thermostaatstand !{{is|is niet}} [[thermostat_mode]] in zone 2",
     "no": "Termostatmodus !{{er|er ikke}} [[thermostat_mode]] i sone 2",
     "pl": "Tryb termostatu !{{jest|nie jest}} [[thermostat_mode]] w strefie 2",
-    "ru": "Режим термостата !{{соответствует|не соответствует}} [[thermostat_mode]] в зоне 2",
+    "ru": "Режим работы термостата !{{соответствует|не соответствует}} [[thermostat_mode]] в зоне 2",
     "sv": "Termostatläge !{{är|är inte}} [[thermostat_mode]] i zon 2"
   }
 }

--- a/.homeycompose/flow/triggers/thermostat_mode.zone2_changed.json
+++ b/.homeycompose/flow/triggers/thermostat_mode.zone2_changed.json
@@ -15,10 +15,10 @@
     "fr": "Mode du thermostat dans la zone 2 a changé",
     "it": "La modalità termostato nella zona 2 è cambiata",
     "ko": "구역 2의 온도조절기 모드가 변경되었습니다",
-    "nl": "Thermostaatmodus in zone 2 is veranderd",
+    "nl": "Thermostaatstand in zone 2 is veranderd",
     "no": "Termostatmodus i sone 2 ble endret",
     "pl": "Tryb termostatu w strefie 2 uległ zmianie",
-    "ru": "Режим термостата в зоне 2 изменился",
+    "ru": "Режим работы термостата в зоне 2 изменился",
     "sv": "Termostatläge i zon 2 ändrades"
   },
   "tokens": [

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,24 +115,58 @@ caught real failures that the others miss:
   (homey-lib is a devDependency and must not ship to the device); the
   drift test in `tests/unit/capability-definitions.test.ts` fails when
   the copies fall behind. A homey-lib bump re-checks a SECOND thing the
-  same way: beyond the definitions, the app copies homey-lib's canonical
+  same way: beyond the definitions, the app takes homey-lib's canonical
   WORDING into labels of its own capabilities and flow cards, and
-  `tests/unit/borrowed-labels.test.ts` pins those copies — an explicit
-  table, one row per app site (file + JSON path) against the homey-lib
-  label it borrows, compared per locale. Membership states an INTENT,
-  never a measured string collision: a label enters the table only where
-  it deliberately speaks homey-lib's wording — today the `horizontal` /
+  `tests/unit/borrowed-labels.test.ts` pins it. The wording arrives in
+  TWO shapes and the file holds a table for each — check BOTH on a bump,
+  a re-wording usually moves only one.
+  A **copy** is byte-equal to its homey-lib label, so `BORROWED_LABELS`
+  compares whole strings, one row per app site (file + JSON path)
+  against the label it borrows, per locale — today the `horizontal` /
   `vertical` `auto` position with its flow-card copies (homey-lib
   declares no vane capability, so `auto` is the one value that can
-  borrow) and the ATA drivers' `thermostat_mode` `cool` value. A
-  coincidence stays OUT: `operational_state` names a state
+  borrow) and the ATA drivers' `thermostat_mode` `cool` value.
+  A **derivative** only embeds homey-lib's term inside a sentence of the
+  app's own ("… in zone 2", "- zone 2", its own `!{{…|…}}` inflection):
+  nothing is byte-equal, so an equality table cannot see it — that is
+  how homey-lib 2.52.1 re-worded the nl `thermostat_mode` cards to
+  "thermostaatstand" and the ru ones to "Режим работы термостата" while
+  the app's zone-2 cards kept the old nouns, two words for one concept
+  in one flow-card list (fixed 2026-08-30). `DERIVED_WORDINGS` pins the
+  TERM instead: a whole localized noun phrase, per row and per locale,
+  asserted to sit inside BOTH sides. Against homey-lib it is the
+  tripwire — an upstream re-wording stops the term being found there;
+  against the app it holds the adoption. A noun phrase cannot hold by
+  accident the way a bare `includes` of a common word would, which is
+  what keeps the table from crying wolf.
+  Which homey-lib label a derivative follows is a per-site judgement,
+  recorded in the row's `lib` column: a card TITLE follows the card of
+  the same kind (the app's condition card sits beside Homey's condition
+  card), while a trigger's TOKEN title follows the capability HEADER,
+  because a token is a tag name — Homey titles the zone-1 tag from the
+  header, and the app's other zone-2 tags ("Operational state - zone 2")
+  are built the same way. The two diverge: 2.52.1 re-worded the nl/ru
+  cards and left both capability titles alone, so the zone-2 token
+  rightly still says "Thermostaatmodus - zone 2". Per-locale
+  `libExceptions` cover a locale whose app string speaks a different
+  upstream label than its row's default — today Italian alone, whose
+  cards say "modalità termostato" (the header) where homey-lib's cards
+  say "modalità del termostato".
+  Membership states an INTENT in both tables, never a measured string
+  collision. A coincidence stays OUT: `operational_state` names a state
   ("Heating"/"Cooling") where `thermostat_mode` names a command
   ("Heat"/"Cool") and they meet in ar/it/ko/pl/ru only, while the app's
   own `hot_water_mode` and `thermostat_mode` values keep their own
   Russian ("Авто") — pinning either would force an edit upstream never
-  asked for. When a row breaks, the APP copy follows: adopt the new
-  wording there and revisit that label's other locales, never edit
-  `vendor/capabilities/` to make it pass.
+  asked for. So does a site that names the concept in the app's OWN
+  voice: the zone-2 ACTION card says "the mode in zone 2" in all 13
+  locales, embedding no homey-lib term, so it has none to follow and a
+  row for it would have to invent an upstream wording the app never
+  spoke. When a row breaks, the APP string follows: adopt the new
+  wording there — reasoning about the sentence, not substituting a
+  substring, where the locale's grammar demands it — revisit that
+  label's other locales, and never edit `vendor/capabilities/` to make
+  it pass.
 - `npm run homey:start` — `homey app run --remote` for on-device testing.
   The `homey:*` wrappers are plain CLI calls: the CLI's own
   `npm run build` (post-copy) emits everything the package needs into

--- a/app.json
+++ b/app.json
@@ -947,10 +947,10 @@
           "fr": "Mode du thermostat dans la zone 2 a changé",
           "it": "La modalità termostato nella zona 2 è cambiata",
           "ko": "구역 2의 온도조절기 모드가 변경되었습니다",
-          "nl": "Thermostaatmodus in zone 2 is veranderd",
+          "nl": "Thermostaatstand in zone 2 is veranderd",
           "no": "Termostatmodus i sone 2 ble endret",
           "pl": "Tryb termostatu w strefie 2 uległ zmianie",
-          "ru": "Режим термостата в зоне 2 изменился",
+          "ru": "Режим работы термостата в зоне 2 изменился",
           "sv": "Termostatläge i zon 2 ändrades"
         },
         "tokens": [
@@ -2006,10 +2006,10 @@
           "fr": "Mode du thermostat !{{est|n'est pas}} dans la zone 2",
           "it": "La modalità termostato !{{è|non è}} nella zona 2",
           "ko": "구역 2의 온도조절기 모드가 !{{맞습니다|아닙니다}}",
-          "nl": "Thermostaatmodus !{{is|is niet}} in zone 2",
+          "nl": "Thermostaatstand !{{is|is niet}} in zone 2",
           "no": "Termostatmodus !{{er|er ikke}} i sone 2",
           "pl": "Tryb termostatu !{{jest|nie jest}} w strefie 2",
-          "ru": "Режим термостата !{{соответствует|не соответствует}} в зоне 2",
+          "ru": "Режим работы термостата !{{соответствует|не соответствует}} в зоне 2",
           "sv": "Termostatläge !{{är|är inte}} i zon 2"
         },
         "titleFormatted": {
@@ -2021,10 +2021,10 @@
           "fr": "Mode du thermostat !{{est|n'est pas}} [[thermostat_mode]] dans la zone 2",
           "it": "La modalità termostato !{{è|non è}} [[thermostat_mode]] nella zona 2",
           "ko": "구역 2의 온도조절기 모드가 [[thermostat_mode]] !{{입니다|이(가) 아닙니다}}",
-          "nl": "Thermostaatmodus !{{is|is niet}} [[thermostat_mode]] in zone 2",
+          "nl": "Thermostaatstand !{{is|is niet}} [[thermostat_mode]] in zone 2",
           "no": "Termostatmodus !{{er|er ikke}} [[thermostat_mode]] i sone 2",
           "pl": "Tryb termostatu !{{jest|nie jest}} [[thermostat_mode]] w strefie 2",
-          "ru": "Режим термостата !{{соответствует|не соответствует}} [[thermostat_mode]] в зоне 2",
+          "ru": "Режим работы термостата !{{соответствует|не соответствует}} [[thermostat_mode]] в зоне 2",
           "sv": "Termostatläge !{{är|är inte}} [[thermostat_mode]] i zon 2"
         },
         "id": "thermostat_mode.zone2_condition"

--- a/tests/unit/borrowed-labels.test.ts
+++ b/tests/unit/borrowed-labels.test.ts
@@ -6,19 +6,29 @@ import verticalCapability from '../../.homeycompose/capabilities/vertical.json' 
 import horizontalAction from '../../.homeycompose/flow/actions/horizontal_action.json' with { type: 'json' }
 import verticalAction from '../../.homeycompose/flow/actions/vertical_action.json' with { type: 'json' }
 import horizontalCondition from '../../.homeycompose/flow/conditions/horizontal_condition.json' with { type: 'json' }
+import thermostatZone2Condition from '../../.homeycompose/flow/conditions/thermostat_mode.zone2_condition.json' with { type: 'json' }
 import verticalCondition from '../../.homeycompose/flow/conditions/vertical_condition.json' with { type: 'json' }
 import horizontalChanged from '../../.homeycompose/flow/triggers/horizontal_changed.json' with { type: 'json' }
+import thermostatZone2Changed from '../../.homeycompose/flow/triggers/thermostat_mode.zone2_changed.json' with { type: 'json' }
 import verticalChanged from '../../.homeycompose/flow/triggers/vertical_changed.json' with { type: 'json' }
 import homeAtaCompose from '../../drivers/home-melcloud/driver.compose.json' with { type: 'json' }
 import classicAtaCompose from '../../drivers/melcloud/driver.compose.json' with { type: 'json' }
 
 // The companion of tests/unit/capability-definitions.test.ts: that one
 // pins the vendored DEFINITIONS against node-homey-lib, this one pins
-// the LABELS the app copies out of them. Nothing derives those copies at
-// build time, so a homey-lib re-wording would leave the app spelling a
-// value one way where Homey spells it another — on the same device page,
-// since the ATA drivers ship `thermostat_mode` next to their own vane
-// pickers.
+// the LABELS the app takes from them. Nothing derives those at build
+// time, so a homey-lib re-wording would leave the app spelling a value
+// one way where Homey spells it another — on the same device page, since
+// the ATA drivers ship `thermostat_mode` next to their own vane pickers,
+// and in the same flow-card list, since the ATW drivers ship the app's
+// zone-2 cards next to Homey's own.
+//
+// The app leans on that wording in TWO shapes, one table each. A COPY is
+// byte-equal to its homey-lib label, so `BORROWED_LABELS` compares whole
+// strings. A DERIVATIVE only embeds homey-lib's term inside a sentence of
+// the app's own ("… in zone 2", "- zone 2", its own `!{{…|…}}`
+// inflection), so nothing is byte-equal and `DERIVED_WORDINGS` pins the
+// TERM instead — see its own note below.
 //
 // Membership states an INTENT, not a measurement: a row exists because
 // the app site deliberately speaks homey-lib's wording. A label that
@@ -118,6 +128,119 @@ const BORROWED_LABELS = [
   ]),
 ]
 
+const THERMOSTAT_CAPABILITY: LabelSite = {
+  json: libThermostatMode,
+  path: 'title',
+  source: 'thermostat_mode',
+}
+
+const THERMOSTAT_CONDITION: LabelSite = {
+  json: libThermostatMode,
+  path: '$flow.conditions[0].title',
+  source: 'thermostat_mode',
+}
+
+const THERMOSTAT_TRIGGER: LabelSite = {
+  json: libThermostatMode,
+  path: '$flow.triggers[0].title',
+  source: 'thermostat_mode',
+}
+
+// The noun as homey-lib's CARDS spell it. It is not always the noun the
+// capability header spells: 2.52.1 re-worded the nl cards to
+// "thermostaatstand" and the ru ones to "Режим работы термостата" while
+// leaving both capability titles alone.
+const CARD_TERMS = {
+  ar: 'وضع الثرموستات',
+  da: 'termostattilstand',
+  de: 'thermostat-modus',
+  en: 'thermostat mode',
+  es: 'modo del termostato',
+  fr: 'mode du thermostat',
+  it: 'modalità termostato',
+  ko: '온도조절기 모드',
+  nl: 'thermostaatstand',
+  no: 'termostatmodus',
+  pl: 'tryb termostatu',
+  ru: 'режим работы термостата',
+  sv: 'termostatläge',
+}
+
+// The noun as the capability HEADER spells it — what Homey shows on the
+// device page and on the tag its own capability trigger exposes.
+const CAPABILITY_TERMS = {
+  ...CARD_TERMS,
+  nl: 'thermostaatmodus',
+  ru: 'режим термостата',
+}
+
+// Italian is the one locale whose app cards speak the capability header
+// ("modalità termostato") where homey-lib's cards say "modalità del
+// termostato". Pinning it against the header keeps the row biting there
+// instead of dropping the locale, and states which upstream label an
+// Italian re-wording has to move for the app to follow.
+const CARD_EXCEPTIONS = { it: THERMOSTAT_CAPABILITY }
+
+// The ATW drivers ship `thermostat_mode.zone2` beside Homey's own
+// `thermostat_mode`, so the app's zone-2 cards stand next to Homey's in
+// one flow-card list and must name the concept with Homey's word. Which
+// homey-lib label each one follows is a per-site judgement, and it is
+// the `lib` column that records it: a card TITLE follows the card of the
+// same kind (Homey's condition card is what the app's condition card
+// sits beside), while the trigger's TOKEN title follows the capability
+// header, because a token is a tag name — Homey titles the zone-1 tag
+// from the header, and the app's other zone-2 tags ("Operational state -
+// zone 2", "Temperature - zone 2") are built the same way.
+//
+// Out by the same judgement: the zone-2 ACTION card, whose every locale
+// names "the mode in zone 2" rather than the thermostat mode. It embeds
+// no homey-lib term, so it has none to follow — a row for it would have
+// to invent an upstream wording the app never spoke.
+const DERIVED_WORDINGS = [
+  {
+    app: {
+      json: thermostatZone2Changed,
+      path: 'title',
+      source: '.homeycompose/flow/triggers/thermostat_mode.zone2_changed.json',
+    },
+    lib: THERMOSTAT_TRIGGER,
+    libExceptions: CARD_EXCEPTIONS,
+    terms: CARD_TERMS,
+  },
+  {
+    app: {
+      json: thermostatZone2Changed,
+      path: 'tokens[0].title',
+      source: '.homeycompose/flow/triggers/thermostat_mode.zone2_changed.json',
+    },
+    lib: THERMOSTAT_CAPABILITY,
+    libExceptions: {},
+    terms: CAPABILITY_TERMS,
+  },
+  {
+    app: {
+      json: thermostatZone2Condition,
+      path: 'title',
+      source:
+        '.homeycompose/flow/conditions/thermostat_mode.zone2_condition.json',
+    },
+    lib: THERMOSTAT_CONDITION,
+    libExceptions: CARD_EXCEPTIONS,
+    terms: CARD_TERMS,
+  },
+  {
+    app: {
+      json: thermostatZone2Condition,
+      path: 'titleFormatted',
+      source:
+        '.homeycompose/flow/conditions/thermostat_mode.zone2_condition.json',
+    },
+    lib: THERMOSTAT_CONDITION,
+    libExceptions: CARD_EXCEPTIONS,
+    terms: CARD_TERMS,
+  },
+]
+
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null
 
@@ -164,6 +287,61 @@ const findWordingBreaches = ({
   return breaches
 }
 
+const listLocales = (labels: Record<string, unknown>): string =>
+  Object.keys(labels)
+    .toSorted((one, other) => one.localeCompare(other))
+    .join(', ')
+
+const speaks = (wording: string | undefined, term: string): boolean =>
+  wording?.toLowerCase().includes(term.toLowerCase()) ?? false
+
+// A derivative cannot be compared whole, so the row's TERM carries the
+// comparison: it is pinned to sit inside BOTH sides. Against homey-lib it
+// is the tripwire — the day upstream re-words the noun, the term stops
+// being found there and the row fails with the new wording in hand.
+// Against the app it holds the adoption, so a later edit cannot quietly
+// walk the app's sentence away from Homey's word. A term is a whole
+// localized noun phrase, authored per locale as an intent: it cannot hold
+// by accident the way a bare `includes` of a common word would, and it
+// cannot keep matching a phrase upstream has rewritten.
+const findTermBreaches = ({
+  app,
+  lib,
+  libExceptions,
+  terms,
+}: {
+  app: LabelSite
+  lib: LabelSite
+  libExceptions: Record<string, LabelSite>
+  terms: Record<string, string>
+}): string[] => {
+  const appLabels = readLabels(app)
+  const breaches: string[] = []
+  const pinned = listLocales(terms)
+  const localized = listLocales(readLabels(lib))
+  if (pinned !== localized) {
+    breaches.push(
+      `${app.source} ${app.path} pins a term for [${pinned}] where node-homey-lib ${lib.source} ${lib.path} is localized into [${localized}]: translate the app string into the locales upstream gained, or drop the ones it lost, then re-pin the terms here.`,
+    )
+  }
+  for (const [locale, term] of Object.entries(terms)) {
+    const source = libExceptions[locale] ?? lib
+    const libWording = readLabels(source)[locale]
+    const appWording = appLabels[locale]
+    if (!speaks(libWording, term)) {
+      breaches.push(
+        `node-homey-lib ${source.source} ${source.path} [${locale}] says ${JSON.stringify(libWording)}, which no longer contains the term ${JSON.stringify(term)} that ${app.source} ${app.path} embeds: upstream re-worded it — carry the new noun into the app string, keeping the app's own additions around it, then re-pin the term here.`,
+      )
+    }
+    if (!speaks(appWording, term)) {
+      breaches.push(
+        `${app.source} ${app.path} [${locale}] says ${JSON.stringify(appWording)}, which does not contain node-homey-lib's term ${JSON.stringify(term)} from ${source.source} ${source.path}: speak the upstream noun and keep the app's own additions around it — never edit vendor/capabilities to make this pass.`,
+      )
+    }
+  }
+  return breaches
+}
+
 describe('borrowed capability labels', () => {
   it.each(BORROWED_LABELS)(
     'should spell $app.source $app.path as homey-lib $lib.source $lib.path',
@@ -174,6 +352,20 @@ describe('borrowed capability labels', () => {
       expect(Object.keys(readLabels(row.lib))).not.toStrictEqual([])
 
       expect(findWordingBreaches(row)).toStrictEqual([])
+    },
+  )
+})
+
+describe('derived flow-card wording', () => {
+  it.each(DERIVED_WORDINGS)(
+    'should embed homey-lib $lib.source $lib.path in $app.source $app.path',
+    (row) => {
+      expect.assertions(2)
+
+      // A mistyped homey-lib path would otherwise pin nothing.
+      expect(Object.keys(readLabels(row.lib))).not.toStrictEqual([])
+
+      expect(findTermBreaches(row)).toStrictEqual([])
     },
   )
 })


### PR DESCRIPTION
homey-lib 2.52.1 (adopted in #1629) re-worded three `thermostat_mode`
`$flow` titles. Only the CARDS moved — the capability headers were left
alone:

| locale | 2.51.4 | 2.52.1 |
| --- | --- | --- |
| nl | `De thermostaatmodus …` (trigger, condition, action) | `De thermostaatstand …` |
| ru | `Режим термостата …` | `Режим работы термостата …`, with a trailing `:` on the trigger and action |
| sv | action `Ställ in termostatläget på` | `Ställ in termostatläget till` |
| ko | condition `온도조절기 모드가 다음!{{이면\|이 아니면}}` | `온도조절기 모드가 다음!{{과 같으면\|이 아니면}}` |

The ATW drivers ship `thermostat_mode.zone2` beside Homey's own
`thermostat_mode`, so the app's zone-2 cards sit next to Homey's in one
flow-card list — and they kept the old nouns. In nl the same list read
"De thermostaatstand !{{is|is niet}}" on Homey's card and
"Thermostaatmodus !{{is|is niet}} in zone 2" on the app's.

`tests/unit/borrowed-labels.test.ts` (#1630) could not see it: it pins
VERBATIM copies, and these are derivatives that only embed homey-lib's
term inside a sentence of the app's own.

## Changed

Six strings, in `.homeycompose/**`, all `nl` and `ru` — the app's own
additions ("in zone 2", the `!{{…|…}}` inflection) kept as they were:

| site | locale | before | after |
| --- | --- | --- | --- |
| `flow/triggers/thermostat_mode.zone2_changed.json` `title` | nl | `Thermostaatmodus in zone 2 is veranderd` | `Thermostaatstand in zone 2 is veranderd` |
| ″ | ru | `Режим термостата в зоне 2 изменился` | `Режим работы термостата в зоне 2 изменился` |
| `flow/conditions/thermostat_mode.zone2_condition.json` `title` | nl | `Thermostaatmodus !{{is\|is niet}} in zone 2` | `Thermostaatstand !{{is\|is niet}} in zone 2` |
| ″ | ru | `Режим термостата !{{соответствует\|не соответствует}} в зоне 2` | `Режим работы термостата !{{соответствует\|не соответствует}} в зоне 2` |
| ″ `titleFormatted` | nl | `Thermostaatmodus !{{is\|is niet}} [[thermostat_mode]] in zone 2` | `Thermostaatstand !{{is\|is niet}} [[thermostat_mode]] in zone 2` |
| ″ | ru | `Режим термостата !{{соответствует\|не соответствует}} [[thermostat_mode]] в зоне 2` | `Режим работы термостата !{{соответствует\|не соответствует}} [[thermostat_mode]] в зоне 2` |

Russian is not a substring swap: upstream inserted "работы" into the
noun phrase ("режим термостата" → "режим работы термостата"), which is
what the app adopts. Upstream's other Russian change — a trailing colon
on `изменен на:` / `на:` — does NOT transfer: it introduces the dropdown
Homey renders after its card title, whereas the app's trigger ends on
`изменился` with no argument at all, and the app's action carries its
argument inline as `[[thermostat_mode]]`. A colon before an inline token
would be wrong Russian.

## Deliberately NOT changed

- **The trigger's token title** (`tokens[0].title`, all 13 locales —
  `Thermostaatmodus - zone 2`, `Режим термостата - зона 2`). A token is
  a tag name, and the label Homey names that concept with is the
  capability HEADER, which 2.52.1 left untouched (`Thermostaatmodus`,
  `Режим термостата`). Homey titles the zone-1 tag from that header, and
  the app's other zone-2 tags are built the same way
  (`Operational state - zone 2` = homey-lib's `operational_state` title
  + suffix). Re-wording it would have CREATED a divergence in the tag
  list rather than removed one.
- **The zone-2 action card** (`title` / `titleFormatted`, all 13
  locales). Every locale names "the mode in zone 2" — `Set the mode in
  zone 2`, `Stel de modus in zone 2 in`, `Установить режим в зоне 2` —
  never the thermostat mode. That is the app's own voice, and it embeds
  no homey-lib term, so there is nothing to follow; making it follow
  would be a rewrite, not an adoption.
- **Swedish, everywhere.** Upstream's only sv change is the action's
  preposition `på` → `till`, and the app's action already reads
  `Ställ in läget i zon 2 till [[thermostat_mode]]`. Its trigger and
  condition mirror sv cards upstream did not touch. Nothing to do.
- **Korean, everywhere.** Upstream's change is an inflection on its own
  `다음` ("the following") construction, which exists because Homey
  renders the dropdown after the title. The app's condition inlines the
  token and uses its own copula
  (`구역 2의 온도조절기 모드가 [[thermostat_mode]] !{{입니다|이(가) 아닙니다}}`)
  — it never writes `다음`. The term `온도조절기 모드` itself is unchanged.
- **The nine other locales.** Upstream did not re-word them.
- **Italian**, which reads `modalità termostato` where homey-lib's cards
  say `modalità del termostato`. Pre-existing, upstream asked for
  nothing here, and the app's form is homey-lib's own capability title —
  so it is pinned against that label rather than edited (below).

## Guard

`borrowed-labels.test.ts` now holds a table per shape, and the file and
`CLAUDE.md` say which is which.

`BORROWED_LABELS` is unchanged: byte-equal copies, compared whole.

`DERIVED_WORDINGS` is new, for strings that only EMBED homey-lib's
vocabulary. Per row and per locale it pins the TERM — a whole localized
noun phrase — asserted to sit inside **both** sides:

- against homey-lib, it is the tripwire: an upstream re-wording stops
  the term being found there, and the failure names the new wording;
- against the app, it holds the adoption, so a later edit cannot walk
  the app's sentence away from Homey's word.

A localized noun phrase cannot hold by accident the way a bare
`includes` of a common word would, which is what keeps the table from
crying wolf; and the row also fails if upstream gains or loses a locale,
because an untranslated app card is a real gap.

Which homey-lib label a row follows is the per-site judgement above,
recorded in its `lib` column: card titles follow the card of the same
kind, the token title follows the capability header. `libExceptions`
covers a locale whose app string speaks a different upstream label than
its row's default — today Italian alone.

Both directions were verified to bite before the fix landed: reverting
one app string fails the app assertion, and swapping homey-lib back to
2.51.4 fails the upstream assertion on all six nl/ru card sites — i.e.
this guard would have caught #1629 on the day.

## Gates

`format` 0 · `lint` 0 (no disables) · `typecheck` 0 · `test:coverage` 0
(937 tests, 100 % statements/branches/functions/lines) · `build` 0 ·
`homey:validate` 0. `app.json` is the CLI's own regeneration, committed
verbatim; `locales/*.json` are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKsbttD4wLTrZnZDwKK1Fn
