### PR TITLE
chore(release): 46.7.1

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -1918,5 +1918,20 @@
     "pl": "Wewnętrzna konserwacja i restrukturyzacja kodu.",
     "ru": "Внутреннее обслуживание и реструктуризация кода.",
     "sv": "Internt underhåll och omstrukturering av koden."
+  },
+  "46.7.1": {
+    "ar": "لم يعد تسجيل الدخول الناجح يُبلَّغ عنه كفشل: إذا تعذّر عرض أجهزتك على الفور، يخبرك التطبيق الآن بأن القائمة قديمة بدلاً من إعادتك إلى شاشة تسجيل الدخول. ولم يعد طراز جهاز لا يعرفه التطبيق بعد يُخفي بقية أجهزتك.",
+    "da": "Et vellykket login rapporteres ikke længere som en fejl: hvis dine enheder ikke kan vises med det samme, fortæller appen dig nu, at listen er forældet, i stedet for at sende dig tilbage til login-skærmen. Og en enhedsmodel, som appen endnu ikke kender, skjuler ikke længere alle dine andre enheder.",
+    "de": "Eine erfolgreiche Anmeldung wird nicht mehr als Fehler gemeldet: Wenn deine Geräte nicht sofort aufgelistet werden können, sagt dir die App jetzt, dass die Liste veraltet ist, statt dich zurück zum Anmeldebildschirm zu schicken. Und ein Gerätemodell, das die App noch nicht kennt, verbirgt nicht mehr alle deine anderen Geräte.",
+    "en": "A successful sign-in is no longer reported as a login failure: when your devices cannot be listed right away, the app now tells you the list is out of date instead of sending you back to the sign-in screen. And a device model the app does not recognise yet no longer hides all your other devices.",
+    "es": "Un inicio de sesión correcto ya no se notifica como un fallo: si tus dispositivos no se pueden listar de inmediato, la app ahora te indica que la lista está desactualizada en lugar de devolverte a la pantalla de inicio de sesión. Y un modelo de dispositivo que la app aún no reconoce ya no oculta el resto de tus dispositivos.",
+    "fr": "Une connexion réussie n’est plus signalée comme un échec : si vos appareils ne peuvent pas être listés tout de suite, l’app vous indique désormais que la liste n’est pas à jour au lieu de vous renvoyer à l’écran de connexion. Et un modèle d’appareil que l’app ne reconnaît pas encore ne masque plus tous vos autres appareils.",
+    "it": "Un accesso riuscito non viene più segnalato come un errore: se i tuoi dispositivi non possono essere elencati subito, l’app ora ti avvisa che l’elenco non è aggiornato invece di riportarti alla schermata di accesso. E un modello di dispositivo che l’app non riconosce ancora non nasconde più tutti gli altri dispositivi.",
+    "ko": "로그인에 성공했는데도 실패로 표시되던 문제를 해결했습니다. 기기 목록을 바로 가져오지 못하면 로그인 화면으로 되돌리는 대신 목록이 오래되었다고 알려 줍니다. 또한 앱이 아직 모르는 기기 모델이 있어도 나머지 기기가 모두 사라지지 않습니다.",
+    "nl": "Een geslaagde aanmelding wordt niet langer als een mislukking gemeld: als je apparaten niet meteen kunnen worden opgehaald, meldt de app nu dat de lijst verouderd is in plaats van je terug te sturen naar het aanmeldscherm. En een apparaatmodel dat de app nog niet kent, verbergt niet langer al je andere apparaten.",
+    "no": "En vellykket pålogging rapporteres ikke lenger som en feil: hvis enhetene dine ikke kan vises med én gang, forteller appen deg nå at listen er utdatert, i stedet for å sende deg tilbake til påloggingsskjermen. Og en enhetsmodell som appen ennå ikke kjenner, skjuler ikke lenger alle de andre enhetene dine.",
+    "pl": "Udane logowanie nie jest już zgłaszane jako błąd: jeśli lista urządzeń nie może zostać od razu pobrana, aplikacja informuje teraz, że jest nieaktualna, zamiast odsyłać Cię z powrotem do ekranu logowania. A model urządzenia, którego aplikacja jeszcze nie rozpoznaje, nie ukrywa już wszystkich pozostałych urządzeń.",
+    "ru": "Успешный вход больше не отображается как ошибка: если список устройств не удаётся получить сразу, приложение теперь сообщает, что список устарел, вместо того чтобы возвращать вас на экран входа. А модель устройства, которую приложение ещё не знает, больше не скрывает все остальные ваши устройства.",
+    "sv": "En lyckad inloggning rapporteras inte längre som ett fel: om dina enheter inte kan listas direkt berättar appen nu att listan är inaktuell i stället för att skicka tillbaka dig till inloggningsskärmen. Och en enhetsmodell som appen ännu inte känner till döljer inte längre alla dina andra enheter."
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -286,5 +286,5 @@
       "värmeåtervinning"
     ]
   },
-  "version": "46.7.0"
+  "version": "46.7.1"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -792,11 +792,17 @@ reader fails open with an empty map).
   2026-08 against the docs source). The workflows therefore declare no
   `merge_group` trigger: an event that cannot fire needs no handling.
 - The PR title IS the commit that lands: `squash_merge_commit_title` is
-  `PR_TITLE` on all five repos, so the title is the single source (under
-  the former `COMMIT_OR_PR_TITLE`, a one-commit PR silently took its
-  commit subject instead). It must follow Conventional Commits, which
+  `PR_TITLE` on SEVEN of the family's eight repos, so the title is the
+  single source (under the former `COMMIT_OR_PR_TITLE`, a one-commit PR
+  silently took its commit subject instead). `api-core` is the
+  exception and still sits on `COMMIT_OR_PR_TITLE` — read from the API
+  2026-08-30, not assumed; the count read five here until `api-core`
+  joined the family, and rounding it up to eight would have asserted a
+  setting that is not there. It must follow Conventional Commits, which
   the required `PR title` check enforces
-  (`.github/workflows/pr-title.yml`, byte-identical in the five). The
+  (`.github/workflows/pr-title.yml`, byte-identical in the seven repos
+  that call the family reusables — every repo but `configs`, which
+  hosts them and whose own copy differs; md5-verified the same day). The
   default type set is the convention's own — no custom list, no scope
   allowlist (house scopes are free-form), and deliberately no
   `subjectPattern`: subjects legitimately open on a proper noun

--- a/app.json
+++ b/app.json
@@ -287,7 +287,7 @@
       "värmeåtervinning"
     ]
   },
-  "version": "46.7.0",
+  "version": "46.7.1",
   "flow": {
     "triggers": [
       {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "com.melcloud",
-  "version": "46.7.0",
+  "version": "46.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "com.melcloud",
-      "version": "46.7.0",
+      "version": "46.7.1",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@olivierzal/homey-kit": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.melcloud",
-  "version": "46.7.0",
+  "version": "46.7.1",
   "description": "MELCloud for Homey",
   "homepage": "https://github.com/OlivierZal/com.melcloud/",
   "bugs": {


### PR DESCRIPTION
## What I found first

The task assumed 46.7.0 was still pending. **It is not** — it is released and submitted:

| evidence | value |
| --- | --- |
| git tag | `v46.7.0` on `main`, commit `b0ce7b32` |
| GitHub release | published 2026-08-27T16:14:09Z, `draft: false`, `prerelease: false` |
| `publish.yml` run | `33092159520` — **success**, 5m54s, fired 2 seconds after the release |

That workflow pushes the build to the Homey App Store via athombv's action, so the submission happened. (It cannot prove Athom has since *certified* it; nothing in the repo records certification state.)

The doctrine is explicit — a submitted version number is spent, bump the patch. So this PR is **46.7.1**, not a rewrite of 46.7.0's entry.

## The store entry

46.7.0's entry reads "Internal maintenance and code restructuring." That was true when written and no longer covers the window: twelve commits sit above the release tag, two of them user-visible.

**46.7.1**, in all 13 locales (`ar`, `da`, `de`, `en`, `es`, `fr`, `it`, `ko`, `nl`, `no`, `pl`, `ru`, `sv`):

> A successful sign-in is no longer reported as a login failure: when your devices cannot be listed right away, the app now tells you the list is out of date instead of sending you back to the sign-in screen. And a device model the app does not recognise yet no longer hides all your other devices.

The two fixes behind it:

- **#1632** — an accepted sign-in was read as a credential rejection and stranded the user on the login form, over credentials the server had just accepted; the next click re-hammered the endpoint MELCloud throttles hardest.
- **#1625** — adopting the SDK release where an unmodelled Classic device type stopped invalidating the whole account listing. An account owning one such device saw **zero** devices.

Written in the store's voice and addressed to the user: no internal vocabulary, no library names, no PR numbers, and deliberately non-exhaustive — the tooling, test and refactor work in the same window stays out, per `CONTRIBUTING.md`.

## Version bump

Per the release flow: `.homeycompose/app.json` → `46.7.1`, `package.json` aligned with `npm version --no-git-tag-version`, and `app.json` regenerated by `homey:validate` (its only diff is the version line).

## One count correction

`CLAUDE.md` claimed `squash_merge_commit_title` is `PR_TITLE` "on all five repos". Read from the API on 2026-08-30, it is `PR_TITLE` on **seven of eight** — `api-core` still sits on `COMMIT_OR_PR_TITLE`.

Worth flagging: the stale five could **not** simply be rounded up to eight. Doing so would have asserted a setting that is not there. The entry now names the exception. The neighbouring `pr-title.yml` byte-identity count is seven (md5-verified), `configs` being the one that differs.

## Gates

| gate | exit |
| --- | --- |
| `npm run format` | 0 |
| `npm run lint` | 0 |
| `npm run typecheck` | 0 |
| `npm run test:coverage` | 0 — 950 tests, 100% on all four axes |
| `npm run build` | 0 |
| `npm run homey:validate` | 0 (publish level) |

No lint disables added.

## Not done here

This PR does not tag or release. Once merged, `v46.7.1` needs its tag and a published GitHub release to reach the store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKsbttD4wLTrZnZDwKK1Fn