### PR TITLE
build!: adopt @olivierzal/melcloud-api 55.0.0 and classify sign-ins by type

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -352,26 +352,31 @@ coverage.
   to offer. Anything deriving a name or email from `getUser()` must
   handle the `null`.
 - A rejection from `authenticate()` is NOT necessarily a credential
-  rejection, and the SESSION is the arbiter. Since melcloud-api 54.0.0
-  the library ENFORCES a registry sync after the server accepted the
-  sign-in, and that sync throws on its own — over a session that is
-  already live, with the credentials already persisted. So both entry
-  points classify by consulting `isAuthenticated()` when the error is
-  not an `AuthenticationError`: reading `true` means only the device
-  refresh failed, and the app-API handler (`api.mts`) answers
-  `{ isDeviceListStale: true }` rather than rejecting, while the
-  pairing handler (`drivers/base-driver.mts`) continues to the device
-  list. Reading `false` is the real login failure. Degrading is not
-  the same as going silent: the settings page still ALERTS the failed
-  refresh from its post-login re-check (`#onLogin`), where that
-  warning outranks the device check's own "add a device" — an
-  unrefreshed list is WHY the list came back empty. Treating every
-  rejection as a credential failure (46.7.0 and earlier) stranded a
-  signed-in user on the login form, and their next click re-hammered
-  `/Login/ClientLogin3`, the endpoint MELCloud throttles hardest
-  (`ErrorId 6`) — the library's login backoff arms around the sign-in
-  itself, NOT around the enforced sync, so nothing local slowed the
-  retries.
+  rejection, and the TYPE is the arbiter. The library ENFORCES a
+  registry sync after the server accepted the sign-in, and since
+  melcloud-api 55.0.0 that failure arrives wrapped as
+  `RegistrySyncError` (the sync's own error on `cause`); a refused
+  credential is never wrapped — it stays `AuthenticationError`. So
+  both entry points classify by `instanceof RegistrySyncError`: the
+  app-API handler (`api.mts`) answers `{ isDeviceListStale: true }`
+  rather than rejecting, the pairing handler
+  (`drivers/base-driver.mts`) continues to the device list, and
+  ANYTHING else is a login failure. Neither consults
+  `isAuthenticated()` — the retired judge-by-the-session heuristic
+  (54.0.0's era) had a CONFIRMED false positive: a transport failure
+  during the sign-in round-trip over a PRE-EXISTING live session (a
+  user switching accounts; `ClientLogin3` answering 500 over a stale
+  key) read "signed in, stale list" while the new credentials were
+  never accepted. Degrading is not the same as going silent: the
+  settings page still ALERTS the failed refresh from its post-login
+  re-check (`#onLogin`), where that warning outranks the device
+  check's own "add a device" — an unrefreshed list is WHY the list
+  came back empty. Treating every rejection as a credential failure
+  (46.7.0 and earlier) stranded a signed-in user on the login form,
+  and their next click re-hammered `/Login/ClientLogin3`, the endpoint
+  MELCloud throttles hardest (`ErrorId 6`) — the library's login
+  backoff arms around the sign-in itself, NOT around the enforced
+  sync, so nothing local slowed the retries.
 - Home drivers compute capabilities per device from the facade — at
   pairing (`toDeviceDetails`) and again at device init
   (`getRequiredCapabilities`). `isOwner` gates NOTHING, on any driver:

--- a/api.mts
+++ b/api.mts
@@ -11,6 +11,7 @@ import {
   type ProtectionUpdate,
   AuthenticationError,
   AuthenticationThrottledError,
+  RegistrySyncError,
 } from '@olivierzal/melcloud-api'
 
 import type {
@@ -134,13 +135,16 @@ const api = {
     } catch (error) {
       // A rejection is not proof the credentials were refused: the
       // library enforces a registry sync AFTER the server accepted the
-      // sign-in, and that sync throws on its own. The session is the
-      // arbiter — a live one means the account is in, and only the
-      // device list is stale.
-      if (error instanceof AuthenticationError || !client.isAuthenticated()) {
-        throw toLoginFailure(homey, service, error)
+      // sign-in, and that failure arrives wrapped as its own TYPE —
+      // `RegistrySyncError` means the account is in and only the device
+      // list is stale. The type is the arbiter; re-deriving the verdict
+      // from the session read "signed in" on a transport failure over a
+      // PRE-EXISTING live session while the new credentials were never
+      // accepted.
+      if (error instanceof RegistrySyncError) {
+        return { isDeviceListStale: true }
       }
-      return { isDeviceListStale: true }
+      throw toLoginFailure(homey, service, error)
     }
     return { isDeviceListStale: false }
   },

--- a/drivers/base-driver.mts
+++ b/drivers/base-driver.mts
@@ -3,6 +3,7 @@ import {
   type DeviceType,
   type LoginCredentials,
   AuthenticationError,
+  RegistrySyncError,
 } from '@olivierzal/melcloud-api'
 
 import type { AuthenticationAPI } from '../types/api.mts'
@@ -135,14 +136,16 @@ export abstract class BaseMELCloudDriver extends Driver {
           return false
         }
         // The library enforces a registry sync AFTER the server
-        // accepted the sign-in, so a non-credential rejection can leave
-        // a perfectly live session behind. Pairing follows the session,
-        // not the rejection: an account that IS signed in continues to
-        // the device list instead of failing the wizard.
-        if (!this.api.isAuthenticated()) {
-          throw error
+        // accepted the sign-in and wraps that failure as its own TYPE:
+        // a `RegistrySyncError` means the account IS signed in, so
+        // pairing continues to the device list instead of failing the
+        // wizard. Anything else is a login failure — consulting the
+        // session here read "signed in" on a transport failure over a
+        // pre-existing live session.
+        if (error instanceof RegistrySyncError) {
+          return true
         }
-        return true
+        throw error
       }
     })
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "GPL-3.0-only",
       "dependencies": {
         "@olivierzal/homey-kit": "5.0.0",
-        "@olivierzal/melcloud-api": "54.0.0",
+        "@olivierzal/melcloud-api": "55.0.0",
         "source-map-support": "^0.5.21",
         "temporal-polyfill": "^1.0.4"
       },
@@ -1129,9 +1129,9 @@
       }
     },
     "node_modules/@olivierzal/melcloud-api": {
-      "version": "54.0.0",
-      "resolved": "https://npm.pkg.github.com/download/@olivierzal/melcloud-api/54.0.0/dc360af9e5b0ef08f561d556f6985ed3e5b90df8",
-      "integrity": "sha512-Xv2weql7ix6aIti+vRE/W6tmZctkrrL7/E8TZGApwXRO72hp4ANEqZJPyawGQ/W6m6x9spjINGEKSfUvT4vaEQ==",
+      "version": "55.0.0",
+      "resolved": "https://npm.pkg.github.com/download/@olivierzal/melcloud-api/55.0.0/36b3d26cf5ac0853e637dca838d52578aecfb0ae",
+      "integrity": "sha512-CtHxptCHOKV+O9z4Wh6m+LQPAIYTGRPB2ToG480h1NNkRaHGlv/vTx2ejbtwF6SItGve11znwxjZPgug14DQcA==",
       "license": "MIT",
       "dependencies": {
         "@olivierzal/api-core": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "prettier": "@olivierzal/configs/prettier",
   "dependencies": {
     "@olivierzal/homey-kit": "5.0.0",
-    "@olivierzal/melcloud-api": "54.0.0",
+    "@olivierzal/melcloud-api": "55.0.0",
     "source-map-support": "^0.5.21",
     "temporal-polyfill": "^1.0.4"
   },

--- a/tests/driver-descriptors.ts
+++ b/tests/driver-descriptors.ts
@@ -1,5 +1,8 @@
 import type PairSession from 'homey/lib/PairSession'
-import { AuthenticationError } from '@olivierzal/melcloud-api'
+import {
+  AuthenticationError,
+  RegistrySyncError,
+} from '@olivierzal/melcloud-api'
 import { describe, expect, it, vi } from 'vitest'
 
 import { mock } from './helpers.ts'
@@ -209,7 +212,6 @@ export const testPairing = (
     it('should rethrow non-authentication errors from the login handler', async () => {
       const error = new Error('network down')
       authenticateMock.mockRejectedValue(error)
-      isAuthenticatedMock.mockReturnValue(false)
       const { reference, session } = createLoginSession(showViewMock)
       await getDriver().onPair(session)
 
@@ -219,18 +221,40 @@ export const testPairing = (
     })
 
     // The library enforces a registry sync AFTER the server accepted
-    // the credentials, so `authenticate()` can reject over a session
-    // that is live. Pairing follows the session, not the rejection —
-    // an account that IS signed in reaches its device list.
-    it('should pair through a registry failure that left the session live', async () => {
-      authenticateMock.mockRejectedValue(new Error('registry sync down'))
-      isAuthenticatedMock.mockReturnValue(true)
+    // the credentials and wraps that failure as `RegistrySyncError`.
+    // Pairing follows the TYPE, not the session — an account that IS
+    // signed in reaches its device list.
+    it('should pair through a registry sync failure on an accepted sign-in', async () => {
+      authenticateMock.mockRejectedValue(
+        new RegistrySyncError(
+          'Signed in, but the registry could not be verified',
+          { cause: new Error('registry sync down') },
+        ),
+      )
       const { reference, session } = createLoginSession(showViewMock)
       await getDriver().onPair(session)
 
       await expect(
         reference.loginHandler({ password: 'pass', username: 'user' }),
       ).resolves.toBe(true)
+    })
+
+    // The retired heuristic's confirmed false positive: a transport
+    // failure during the sign-in round-trip over a PRE-EXISTING live
+    // session read "signed in, stale list" while the new credentials
+    // were never accepted. It is a LOGIN FAILURE, and the session is
+    // never consulted.
+    it('should fail the login on a transport failure over a pre-existing live session', async () => {
+      const error = new Error('transport down')
+      authenticateMock.mockRejectedValue(error)
+      isAuthenticatedMock.mockReturnValue(true)
+      const { reference, session } = createLoginSession(showViewMock)
+      await getDriver().onPair(session)
+
+      await expect(
+        reference.loginHandler({ password: 'pass', username: 'user' }),
+      ).rejects.toThrow(error)
+      expect(isAuthenticatedMock).not.toHaveBeenCalled()
     })
 
     it('should never pair through a credential rejection', async () => {

--- a/tests/unit/api.test.ts
+++ b/tests/unit/api.test.ts
@@ -11,6 +11,7 @@ import {
   type ProtectionState,
   AuthenticationError,
   AuthenticationThrottledError,
+  RegistrySyncError,
 } from '@olivierzal/melcloud-api'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -361,10 +362,9 @@ describe('api', () => {
       expect(mockClassicAuthenticate).not.toHaveBeenCalled()
     })
 
-    it('should propagate authenticate errors when no session survived', async () => {
+    it('should propagate authenticate errors that carry no registry-sync wrap', async () => {
       const error = new Error('invalid credentials')
       mockClassicAuthenticate.mockRejectedValue(error)
-      mockClassicIsAuthenticated.mockReturnValue(false)
 
       await expect(
         api.authenticate({
@@ -427,26 +427,23 @@ describe('api', () => {
   })
 
   // The library enforces a registry sync AFTER the server accepted the
-  // credentials, so `authenticate()` rejects over a session that is
-  // live. The session is the arbiter: such a rejection reports a stale
-  // device list, never a login failure.
+  // credentials and wraps that failure as `RegistrySyncError`: the TYPE
+  // is the arbiter, and such a rejection reports a stale device list,
+  // never a login failure. The session is never consulted — it reads
+  // "signed in" on a transport failure over a pre-existing live one.
   describe('accepted sign-in whose registry sync failed', () => {
     it.each([
-      {
-        authenticateMock: mockClassicAuthenticate,
-        isAuthenticatedMock: mockClassicIsAuthenticated,
-        service: 'classic',
-      },
-      {
-        authenticateMock: mockHomeAuthenticate,
-        isAuthenticatedMock: mockHomeIsAuthenticated,
-        service: 'home',
-      },
+      { authenticateMock: mockClassicAuthenticate, service: 'classic' },
+      { authenticateMock: mockHomeAuthenticate, service: 'home' },
     ])(
       'should answer a stale device list on $service rather than reject',
-      async ({ authenticateMock, isAuthenticatedMock, service }) => {
-        authenticateMock.mockRejectedValueOnce(new Error('registry sync down'))
-        isAuthenticatedMock.mockReturnValue(true)
+      async ({ authenticateMock, service }) => {
+        authenticateMock.mockRejectedValueOnce(
+          new RegistrySyncError(
+            'Signed in, but the registry could not be verified',
+            { cause: new Error('registry sync down') },
+          ),
+        )
 
         await expect(
           api.authenticate({
@@ -459,9 +456,9 @@ describe('api', () => {
       },
     )
 
-    it('should still report a login failure when no session survived', async () => {
+    it('should report a login failure on a transport failure over a pre-existing live session', async () => {
       mockClassicAuthenticate.mockRejectedValueOnce(new Error('transport down'))
-      mockClassicIsAuthenticated.mockReturnValue(false)
+      mockClassicIsAuthenticated.mockReturnValue(true)
 
       await expect(
         api.authenticate({
@@ -470,6 +467,7 @@ describe('api', () => {
           params: { api: 'classic' },
         }),
       ).rejects.toThrow('transport down')
+      expect(mockClassicIsAuthenticated).not.toHaveBeenCalled()
     })
 
     it('should never rescue a credential rejection over a live session', async () => {


### PR DESCRIPTION
## Adoption

Bumps the exact pin `@olivierzal/melcloud-api` 54.0.0 → 55.0.0 and carries the code change this release exists to enable: sign-in failures are now classified **by type**, never by re-reading the session.

## The classification change

Both sign-in entry points used the judge-by-the-session heuristic — `error instanceof AuthenticationError || !client.isAuthenticated()` — with a confirmed false positive: a transport failure during `doAuthenticate` over a **pre-existing live session** (a user switching accounts; `ClientLogin3` answering 500 over a stale key) read "signed in, stale list" while the new credentials were never accepted.

55.0.0 wraps the enforced post-auth sync failure as `RegistrySyncError` (its own error preserved as `cause`); a refused credential stays `AuthenticationError`. So:

- `api.mts` `authenticate` handler: `error instanceof RegistrySyncError` → `{ isDeviceListStale: true }`; anything else → login failure. The `isAuthenticated()` consultation is deleted.
- `drivers/base-driver.mts` pairing `login` handler: `AuthenticationError` → `false`, `RegistrySyncError` → proceed to the device list, anything else → rethrow. Same deletion.
- The CLAUDE.md rule recorded 2026-08-30 is re-worded: the arbiter is the TYPE, not the session.

## Loss-event flow (verified, no code change needed)

A definitively-refused stored credential now surfaces (`ensureAuthenticated()` answers `false`; `onAuthenticationLost` fires once per episode). Both flow through the existing surfaces unchanged: `onAuthenticationLost` → `#notifySessionLost` → timeline notification (with the paired-device gate), and `GET /sessions/:api` serves `ensureAuthenticated`'s answer, so the settings page renders its normal signed-out state over a dead credential.

## Tests

- Re-pointed the "stale answer" rows: the api.test.ts `.each` and the shared pairing descriptor now reject with `RegistrySyncError` (cause preserved) instead of a bare error plus an `isAuthenticated` stub.
- New false-positive clauses on both entry points: a transport failure over a pre-existing live session is a **login failure**, and the session is never consulted (asserted).
- Coverage stays 100 % on all four axes; no lint disables.

## Gates

`format` / `lint` / `typecheck` / `test:coverage` (953 passed) / `build` / `homey:validate` — all exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKsbttD4wLTrZnZDwKK1Fn