### PR TITLE
build: adopt @olivierzal/melcloud-api 55.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "GPL-3.0-only",
       "dependencies": {
         "@olivierzal/homey-kit": "5.0.0",
-        "@olivierzal/melcloud-api": "55.0.0",
+        "@olivierzal/melcloud-api": "55.1.0",
         "source-map-support": "^0.5.21",
         "temporal-polyfill": "^1.0.4"
       },
@@ -1071,9 +1071,9 @@
       }
     },
     "node_modules/@olivierzal/api-core": {
-      "version": "1.0.0",
-      "resolved": "https://npm.pkg.github.com/download/@olivierzal/api-core/1.0.0/f28c1f81a327f0825b720da6362364304fcce17d",
-      "integrity": "sha512-XngO74CE1GMBkpr/Byww5UGsPi+eWoM588+rWAAUepDj4b21DjVseQ+CZKdb7jjxfXvF4jIMtWxtyZTO08qAXg==",
+      "version": "1.1.0",
+      "resolved": "https://npm.pkg.github.com/download/@olivierzal/api-core/1.1.0/67c6f8f3528037eaf77f962cfc1ed8fb3bd695c7",
+      "integrity": "sha512-TJEiNPDTC8KXvzkVwrBemaxb+B2KaQH81cLTDZNbr+lmKCBvJ1CiVnAsaNM7d3tBh5HrGpm9k1Vh+CFWVGOfgg==",
       "license": "MIT",
       "dependencies": {
         "temporal-polyfill": "^1.0.3"
@@ -1129,12 +1129,12 @@
       }
     },
     "node_modules/@olivierzal/melcloud-api": {
-      "version": "55.0.0",
-      "resolved": "https://npm.pkg.github.com/download/@olivierzal/melcloud-api/55.0.0/36b3d26cf5ac0853e637dca838d52578aecfb0ae",
-      "integrity": "sha512-CtHxptCHOKV+O9z4Wh6m+LQPAIYTGRPB2ToG480h1NNkRaHGlv/vTx2ejbtwF6SItGve11znwxjZPgug14DQcA==",
+      "version": "55.1.0",
+      "resolved": "https://npm.pkg.github.com/download/@olivierzal/melcloud-api/55.1.0/8585e484114d88537afbcc978bb6cacf4aed6f03",
+      "integrity": "sha512-2VLQFvg+3BAB+YMD7vGSl5/4tcif2qiw/HEUY74WKrPuTTqYY/pDrfX5XaaoxyS6kfWz/zCwmNs4UM+7gAmXfg==",
       "license": "MIT",
       "dependencies": {
-        "@olivierzal/api-core": "1.0.0",
+        "@olivierzal/api-core": "1.1.0",
         "tough-cookie": "^6.0.2",
         "undici": "^8.9.0",
         "zod": "^4.4.3"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "prettier": "@olivierzal/configs/prettier",
   "dependencies": {
     "@olivierzal/homey-kit": "5.0.0",
-    "@olivierzal/melcloud-api": "55.0.0",
+    "@olivierzal/melcloud-api": "55.1.0",
     "source-map-support": "^0.5.21",
     "temporal-polyfill": "^1.0.4"
   },


### PR DESCRIPTION
## Summary

Adopts `@olivierzal/melcloud-api` **55.1.0** — the SessionAPI extraction's mechanism crossing. The session mechanics (login/token lifecycle) moved into the shared `SessionAPI` layer of `@olivierzal/api-core`; 55.1.0 carries **zero public surface delta** (proven on the library side), so no app code changes are required or included. This PR is the pin bump and lockfile only.

## api-core single-copy guard

The app branches on `instanceof AuthenticationError` / `RegistrySyncError` (`api.mts`, `drivers/base-driver.mts`); a duplicated `@olivierzal/api-core` in the tree would silently break those checks. Guard output — exactly one resolved copy:

```
com.melcloud@46.7.1 /Users/olivierzalmanski/github/com.melcloud
└─┬ @olivierzal/melcloud-api@55.1.0
  └── @olivierzal/api-core@1.1.0
```

## Gates (explicit exit codes)

| Gate | Exit |
| --- | --- |
| `npm run format` | 0 |
| `npm run lint` | 0 |
| `npm run typecheck` | 0 |
| `npm run test:coverage` (100% stmts/branch/funcs/lines, 953 tests / 53 files) | 0 |
| `npm run build` | 0 |
| `npm run homey:validate` (level `publish`) | 0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKsbttD4wLTrZnZDwKK1Fn
