### PR TITLE
refactor: drop the caller-less chart hour surface and route-unification orphans

### DIFF
--- a/app.mts
+++ b/app.mts
@@ -22,7 +22,6 @@ import {
   type HolidayModeUpdate,
   type HomeBuildingZone,
   type HomeDeviceZone,
-  type Hour,
   type ProtectionUpdate,
   type ReportChartLineOptions,
   type ReportChartPieOptions,
@@ -573,15 +572,11 @@ export default class MELCloudApp extends App {
     )
   }
 
-  public async getTargetHourlyTemperatures({
-    hour,
-    targetId,
-  }: {
-    targetId: string
-    hour?: Hour | undefined
-  }): Promise<ReportChartLineOptions> {
+  public async getTargetHourlyTemperatures(
+    targetId: string,
+  ): Promise<ReportChartLineOptions> {
     return unwrapResult(
-      await this.#getFullReportTarget(targetId).getHourlyTemperatures(hour),
+      await this.#getFullReportTarget(targetId).getHourlyTemperatures(),
     )
   }
 
@@ -610,15 +605,11 @@ export default class MELCloudApp extends App {
       : unwrapResult(await target.getOverheatProtection())
   }
 
-  public async getTargetSignal({
-    hour,
-    targetId,
-  }: {
-    targetId: string
-    hour?: Hour | undefined
-  }): Promise<ReportChartLineOptions> {
+  public async getTargetSignal(
+    targetId: string,
+  ): Promise<ReportChartLineOptions> {
     return unwrapResult(
-      await this.#getReportTarget(targetId).getSignalStrength(hour),
+      await this.#getReportTarget(targetId).getSignalStrength(),
     )
   }
 

--- a/lib/validation.mts
+++ b/lib/validation.mts
@@ -1,15 +1,8 @@
-import type { Hour } from '@olivierzal/melcloud-api'
-
-import type { DeviceOrZoneData, ZoneData } from '../types/zone.mts'
-
-const HOUR_MAX = 23
+import type { DeviceOrZoneData } from '../types/zone.mts'
 
 const zoneTypes = new Set<string>(['areas', 'buildings', 'floors'])
 
 const deviceOrZoneTypes = new Set<string>([...zoneTypes, 'devices'])
-
-const isZoneType = (zoneType: string): zoneType is ZoneData['zoneType'] =>
-  zoneTypes.has(zoneType)
 
 const isDeviceOrZoneType = (
   zoneType: string,
@@ -62,45 +55,11 @@ export const toNonNegativeInt = (
 }
 
 /**
- * Parses `value` as an `Hour` (0-23). Throws on out-of-range or non-integer
- * input.
- * @param value - The candidate to parse as an hour of the day.
- * @param field - Field name prepended to error messages so callers can locate the invalid input.
- * @returns The parsed hour narrowed to the `Hour` union (0-23).
- */
-export const toHour = (value: unknown, field?: string): Hour => {
-  const parsed = toNonNegativeInt(value, { field, max: HOUR_MAX })
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- narrowing a [0..23] integer to the Hour union
-  return parsed as Hour
-}
-
-/**
  * Validates a raw `zoneType`/`zoneId` pair (from a request path or a parsed
- * option value) as `ZoneData`. `zoneType` is later used to index the zone
- * registry, so reject anything outside the known zone collections.
- * @param root0 - The raw zone coordinates to validate.
- * @param root0.zoneId - Identifier of the target zone within its collection.
- * @param root0.zoneType - Zone collection name, rejected unless it names a known collection.
- * @returns The validated pair narrowed to `ZoneData`.
- * @throws {@link RangeError} when zoneType is not a known zone collection.
- */
-export const toZoneData = ({
-  zoneId,
-  zoneType,
-}: {
-  readonly zoneId: string
-  readonly zoneType: string
-}): ZoneData => {
-  if (!isZoneType(zoneType)) {
-    throw new RangeError(`Invalid zone type: ${zoneType}`)
-  }
-  return { zoneId, zoneType }
-}
-
-/**
- * Same guard for endpoints that also accept a single device (frost
- * protection and holiday mode — the settings page lists devices in its
- * zone selector).
+ * option value), also accepting a single device (frost protection and
+ * holiday mode — the settings page lists devices in its zone selector).
+ * `zoneType` is later used to index the zone registry, so reject anything
+ * outside the known collections.
  * @param root0 - The raw coordinates to validate.
  * @param root0.zoneId - Identifier of the target device or zone.
  * @param root0.zoneType - Collection name, also accepting `devices`, rejected when unknown.

--- a/tests/unit/app.test.ts
+++ b/tests/unit/app.test.ts
@@ -1798,10 +1798,7 @@ describe('melCloudApp', () => {
       const mockData = mock<ReportChartLineOptions>()
       await initWithDeviceFacade(app, 'getHourlyTemperatures', mockData)
 
-      const temperatures = await app.getTargetHourlyTemperatures({
-        hour: 10,
-        targetId: 'devices_1',
-      })
+      const temperatures = await app.getTargetHourlyTemperatures('devices_1')
 
       expect(temperatures).toBe(mockData)
     })
@@ -1826,10 +1823,7 @@ describe('melCloudApp', () => {
       const mockData = mock<ReportChartLineOptions>()
       await initWithDeviceFacade(app, 'getSignalStrength', mockData)
 
-      const signal = await app.getTargetSignal({
-        hour: 5,
-        targetId: 'devices_1',
-      })
+      const signal = await app.getTargetSignal('devices_1')
 
       expect(signal).toBe(mockData)
     })
@@ -1837,9 +1831,9 @@ describe('melCloudApp', () => {
     it('should reject a classic zone target above the device leaves', async () => {
       await app.onInit()
 
-      await expect(
-        app.getTargetSignal({ targetId: 'buildings_1' }),
-      ).rejects.toThrow('errors.deviceNotFound')
+      await expect(app.getTargetSignal('buildings_1')).rejects.toThrow(
+        'errors.deviceNotFound',
+      )
     })
   })
 
@@ -1964,10 +1958,7 @@ describe('melCloudApp', () => {
         mockData,
       })
 
-      const signal = await app.getTargetSignal({
-        hour: 5,
-        targetId: 'homeDevices_guid-1',
-      })
+      const signal = await app.getTargetSignal('homeDevices_guid-1')
 
       expect(signal).toBe(mockData)
     })
@@ -1993,9 +1984,9 @@ describe('melCloudApp', () => {
       mockHomeFacadeManagerGetById.mockReturnValue(null)
       await app.onInit()
 
-      await expect(
-        app.getTargetSignal({ targetId: 'homeDevices_missing' }),
-      ).rejects.toThrow('errors.deviceNotFound')
+      await expect(app.getTargetSignal('homeDevices_missing')).rejects.toThrow(
+        'errors.deviceNotFound',
+      )
     })
 
     it('should delegate hourly temperatures to the ATW facade', async () => {
@@ -2007,10 +1998,8 @@ describe('melCloudApp', () => {
         type: Home.DeviceType.Atw,
       })
 
-      const temperatures = await app.getTargetHourlyTemperatures({
-        hour: 10,
-        targetId: 'homeDevices_guid-1',
-      })
+      const temperatures =
+        await app.getTargetHourlyTemperatures('homeDevices_guid-1')
 
       expect(temperatures).toBe(mockData)
     })

--- a/tests/unit/charts-api.test.ts
+++ b/tests/unit/charts-api.test.ts
@@ -62,39 +62,23 @@ describe('charts api', () => {
   })
 
   describe('hourly temperature retrieval', () => {
-    it('should call app.getTargetHourlyTemperatures with hour number', async () => {
-      const lineOptions = mock<ReportChartLineOptions>()
-      mockApp.getTargetHourlyTemperatures.mockResolvedValue(lineOptions)
+    it.each(['devices_1', 'homeDevices_guid-1'])(
+      'should delegate %s to app.getTargetHourlyTemperatures',
+      async (targetId) => {
+        const lineOptions = mock<ReportChartLineOptions>()
+        mockApp.getTargetHourlyTemperatures.mockResolvedValue(lineOptions)
 
-      const result = await api.getTargetHourlyTemperatures({
-        homey,
-        params: { targetId: 'devices_1' },
-        query: { hour: '10' },
-      })
+        const result = await api.getTargetHourlyTemperatures({
+          homey,
+          params: { targetId },
+        })
 
-      expect(result).toBe(lineOptions)
-      expect(mockApp.getTargetHourlyTemperatures).toHaveBeenCalledWith({
-        hour: 10,
-        targetId: 'devices_1',
-      })
-    })
-
-    it('should pass undefined when hour is undefined', async () => {
-      const lineOptions = mock<ReportChartLineOptions>()
-      mockApp.getTargetHourlyTemperatures.mockResolvedValue(lineOptions)
-
-      const result = await api.getTargetHourlyTemperatures({
-        homey,
-        params: { targetId: 'homeDevices_guid-1' },
-        query: {},
-      })
-
-      expect(result).toBe(lineOptions)
-      expect(mockApp.getTargetHourlyTemperatures).toHaveBeenCalledWith({
-        hour: undefined,
-        targetId: 'homeDevices_guid-1',
-      })
-    })
+        expect(result).toBe(lineOptions)
+        expect(mockApp.getTargetHourlyTemperatures).toHaveBeenCalledWith(
+          targetId,
+        )
+      },
+    )
   })
 
   describe('energy report retrieval', () => {
@@ -161,39 +145,21 @@ describe('charts api', () => {
   })
 
   describe('signal retrieval', () => {
-    it('should call app.getTargetSignal with hour number', async () => {
-      const lineOptions = mock<ReportChartLineOptions>()
-      mockApp.getTargetSignal.mockResolvedValue(lineOptions)
+    it.each(['devices_1', 'homeDevices_guid-1'])(
+      'should delegate %s to app.getTargetSignal',
+      async (targetId) => {
+        const lineOptions = mock<ReportChartLineOptions>()
+        mockApp.getTargetSignal.mockResolvedValue(lineOptions)
 
-      const result = await api.getTargetSignal({
-        homey,
-        params: { targetId: 'devices_1' },
-        query: { hour: '5' },
-      })
+        const result = await api.getTargetSignal({
+          homey,
+          params: { targetId },
+        })
 
-      expect(result).toBe(lineOptions)
-      expect(mockApp.getTargetSignal).toHaveBeenCalledWith({
-        hour: 5,
-        targetId: 'devices_1',
-      })
-    })
-
-    it('should pass undefined when hour is undefined', async () => {
-      const lineOptions = mock<ReportChartLineOptions>()
-      mockApp.getTargetSignal.mockResolvedValue(lineOptions)
-
-      const result = await api.getTargetSignal({
-        homey,
-        params: { targetId: 'homeDevices_guid-1' },
-        query: {},
-      })
-
-      expect(result).toBe(lineOptions)
-      expect(mockApp.getTargetSignal).toHaveBeenCalledWith({
-        hour: undefined,
-        targetId: 'homeDevices_guid-1',
-      })
-    })
+        expect(result).toBe(lineOptions)
+        expect(mockApp.getTargetSignal).toHaveBeenCalledWith(targetId)
+      },
+    )
   })
 
   describe('temperature retrieval', () => {

--- a/tests/unit/validation.test.ts
+++ b/tests/unit/validation.test.ts
@@ -2,9 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import {
   toDeviceOrZoneData,
-  toHour,
   toNonNegativeInt,
-  toZoneData,
   toZoneValueData,
 } from '../../lib/validation.mts'
 
@@ -47,41 +45,6 @@ describe(toNonNegativeInt, () => {
   it('includes the field name in error messages when provided', () => {
     expect(() => toNonNegativeInt('bad', { field: 'days' })).toThrow(/^days: /v)
   })
-})
-
-describe(toHour, () => {
-  it.each([0, 12, 23])('accepts %d', (input) => {
-    expect(toHour(input)).toBe(input)
-  })
-
-  it('accepts numeric strings', () => {
-    expect(toHour('5')).toBe(5)
-  })
-
-  it.each([24, -1, 1.5, 'abc'])('rejects %p', (input) => {
-    expect(() => toHour(input, 'hour')).toThrow(/^hour: /v)
-  })
-})
-
-describe(toZoneData, () => {
-  it.each(['areas', 'buildings', 'floors'] as const)(
-    'accepts %s',
-    (zoneType) => {
-      expect(toZoneData({ zoneId: '1', zoneType })).toStrictEqual({
-        zoneId: '1',
-        zoneType,
-      })
-    },
-  )
-
-  it.each(['devices', 'constructor', ''])(
-    'rejects %p coming from the URL',
-    (zoneType) => {
-      expect(() => toZoneData({ zoneId: '1', zoneType })).toThrow(
-        /Invalid zone type/v,
-      )
-    },
-  )
 })
 
 describe(toDeviceOrZoneData, () => {

--- a/types/widgets.mts
+++ b/types/widgets.mts
@@ -1,8 +1,4 @@
-import type {
-  HomeBuildingZone,
-  HomeDeviceZone,
-  Hour,
-} from '@olivierzal/melcloud-api'
+import type { HomeBuildingZone, HomeDeviceZone } from '@olivierzal/melcloud-api'
 import type * as Classic from '@olivierzal/melcloud-api/classic'
 
 import type { BaseSettings } from './bases.mts'
@@ -35,8 +31,4 @@ export interface ChartsWidgetSettings extends BaseSettings {
 
 export interface DaysQuery {
   readonly days?: string
-}
-
-export interface HourQuery {
-  readonly hour?: `${Hour}`
 }

--- a/widgets/charts/api.mts
+++ b/widgets/charts/api.mts
@@ -5,13 +5,9 @@ import type {
 import type { Homey } from 'homey/lib/Homey'
 
 import type { FlatDeviceZone } from '../../types/zone.mts'
-import { toHour, toNonNegativeInt } from '../../lib/validation.mts'
+import { toNonNegativeInt } from '../../lib/validation.mts'
 import { getWebviewHashes } from '../../lib/webview-hashes.mts'
-import {
-  type DaysQuery,
-  type HourQuery,
-  DAYS_MAX,
-} from '../../types/widgets.mts'
+import { type DaysQuery, DAYS_MAX } from '../../types/widgets.mts'
 
 const api = {
   getDevices: ({ homey: { app } }: { homey: Homey }): FlatDeviceZone[] =>
@@ -34,16 +30,11 @@ const api = {
   getTargetHourlyTemperatures: async ({
     homey: { app },
     params: { targetId },
-    query: { hour },
   }: {
     homey: Homey
     params: { targetId: string }
-    query: HourQuery
   }): Promise<ReportChartLineOptions> =>
-    app.getTargetHourlyTemperatures({
-      hour: hour === undefined ? undefined : toHour(hour, 'hour'),
-      targetId,
-    }),
+    app.getTargetHourlyTemperatures(targetId),
   getTargetOperationModes: async ({
     homey: { app },
     params: { targetId },
@@ -60,16 +51,10 @@ const api = {
   getTargetSignal: async ({
     homey: { app },
     params: { targetId },
-    query: { hour },
   }: {
     homey: Homey
     params: { targetId: string }
-    query: HourQuery
-  }): Promise<ReportChartLineOptions> =>
-    app.getTargetSignal({
-      hour: hour === undefined ? undefined : toHour(hour, 'hour'),
-      targetId,
-    }),
+  }): Promise<ReportChartLineOptions> => app.getTargetSignal(targetId),
   getTargetTemperatures: async ({
     homey: { app },
     params: { targetId },


### PR DESCRIPTION
Dead-surface sweep, three adversarially-confirmed items — deletions only, no behavior change on any called path.

## 1. The `?hour=` charts query surface — caller-less in the repo's entire history

The only query a charts webview ever sends is `?days=` (`fetchChartData` in `widgets/charts/public/index.mts`); `git log -S 'hour='` across all branches finds no commit that ever wrote an `hour=` caller. The surface dies end to end app-side:

- `widgets/charts/api.mts`: the `hour` query leaves both route handlers — `getTargetHourlyTemperatures` and `getTargetSignal` are now plain `targetId` delegations.
- `app.mts`: both getters take a bare `targetId` and call the library getters with no argument (the parameter is optional — the library keeps it). The `Hour` type import dies with them.
- `types/widgets.mts`: `HourQuery` existed only for that surface — deleted (and its `Hour` import).
- `lib/validation.mts`: `toHour` + `HOUR_MAX` existed only for that surface — deleted, taking one `eslint-disable` (`no-unsafe-type-assertion`) with them.
- Tests naming what dies: the `toHour` describe in `validation.test.ts`; the "with hour number" / "undefined hour" cases in `charts-api.test.ts` become plain delegation tests; the `app.test.ts` call sites drop the `hour` argument.

Contract pinning: both halves re-verified. `api-contract.test.ts` (manifest ids ↔ handlers) and `api-route-guards.test.ts` (call sites) are the kit's table-driven kernels — no table row changes because both handlers and both routes survive; only the optional query dies, which neither the manifest nor either table ever declared. The manifest (`widgets/charts/widget.compose.json`) declares method+path only — no query param anywhere in `.homeycompose` — so `homey:validate` regenerated nothing (clean tree after the run).

## 2. `toZoneData` + `isZoneType` — route-unification orphans

Orphaned by the target-neutral route unification, surviving only through their own test. Grep-verified: no importer outside `lib/validation.mts` and `tests/unit/validation.test.ts`. Both deleted; their describes dropped. `zoneTypes` stays — still spread into `deviceOrZoneTypes`. The `ZoneData` import specifier dies with the guard; `toDeviceOrZoneData`'s doc comment absorbs the context the deleted twin's comment carried.

## 3. `homey-apps-sdk-v3-types` devDependency — verified, and KEPT (condition failed)

Verification ran all three axes: no import of `homey-apps-sdk-v3-types` anywhere, no `types` array in any tsconfig, no triple-slash reference. But the trial `npm uninstall` failed the lint gate with 14 × `import-x/no-extraneous-dependencies` across the 14 test files that `import ... from 'homey'`: the resolver follows the `@types/homey` alias (`npm:homey-apps-sdk-v3-types`) to the real package and demands its **real name** be listed. The twin is load-bearing for the lint's dependency accounting, not dead — restored verbatim, `package.json`/`package-lock.json` untouched in this PR.

## Gates (all exit 0)

- `npm run format` — 0
- `npm run lint` — 0
- `npm run typecheck` — 0 (TS 7 via the explicit `@typescript/native` path)
- `npm run test:coverage` — 0: 939 tests passed, 100% statements/branches/functions/lines
- `npm run build` — 0
- `npm run homey:validate` — 0, publish level, no files rewritten

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKsbttD4wLTrZnZDwKK1Fn