### PR TITLE
build: adopt @olivierzal/configs 4.5.0

### DIFF
--- a/.github/actions/setup-node-and-install/action.yml
+++ b/.github/actions/setup-node-and-install/action.yml
@@ -1,4 +1,4 @@
-description: Set up Node.js for this @olivierzal-scoped GitHub Packages project and (optionally) install dependencies. Caller must run actions/checkout first — composite actions cannot reference local files before the repo is checked out.
+description: Set up Node.js (optionally against the @olivierzal GitHub Packages registry) and install dependencies with hardened flags. Caller must run actions/checkout first — composite actions cannot reference local files before the repo is checked out.
 inputs:
   cache:
     default: npm
@@ -6,19 +6,29 @@ inputs:
     required: false
   install:
     default: 'true'
-    description: Whether to run `npm ci --ignore-scripts`. Set to 'false' for jobs that only need a Node/.npmrc setup (audit, publish).
+    description: Whether to run `npm ci --ignore-scripts`. Set to 'false' only for jobs that need neither dependencies nor a helper script from the package — a job resolving `node_modules/@olivierzal/configs/scripts/…` must install, or it silently falls through to a path that exists only in this repo.
     required: false
   node-version:
-    default: '22'
-    description: Node.js version to install. Defaults to the Homey runtime version.
+    default: lts/*
+    description: Node.js version to install. Apps pin their runtime version, libs use 'lts/*' or 'latest'.
     required: false
   npm-token:
-    description: Token forwarded as NODE_AUTH_TOKEN. Required when `install` is true (GitHub Packages requires auth even for read).
+    description: Token forwarded as NODE_AUTH_TOKEN during install. Required by repos whose dependencies live on GitHub Packages (auth is needed even for read).
+    required: false
+  registry-url:
+    description: Optional registry URL forwarded to actions/setup-node (publish jobs, scoped-dependency installs).
+    required: false
+  require-npm-token:
+    default: 'false'
+    description: Fail fast when `install` is true and no npm-token was provided — for repos whose install cannot succeed anonymously.
+    required: false
+  scope:
+    description: Optional npm scope forwarded to actions/setup-node.
     required: false
 name: Setup Node and install
 runs:
   steps:
-    - if: inputs.install == 'true' && inputs.npm-token == ''
+    - if: inputs.require-npm-token == 'true' && inputs.install == 'true' && inputs.npm-token == ''
       run: |
         echo "::error::setup-node-and-install: 'npm-token' input is required when 'install' is 'true' (GitHub Packages auth)."
         exit 1
@@ -30,8 +40,8 @@ runs:
         # the falsy branch sits after `||`.
         cache: ${{ inputs.cache != 'none' && inputs.cache || '' }}
         node-version: ${{ inputs.node-version }}
-        registry-url: https://npm.pkg.github.com
-        scope: '@olivierzal'
+        registry-url: ${{ inputs.registry-url }}
+        scope: ${{ inputs.scope }}
     - env:
         NODE_AUTH_TOKEN: ${{ inputs.npm-token }}
       if: inputs.install == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
       packages: read
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/reusable-ci.yml@b6fc63379fae3634daf4dd9495295b6d95f6b7fe # v4.4.0
+    uses: OlivierZal/configs/.github/workflows/reusable-ci.yml@dc0a53bd2908cd5b8b6b6ef6d7fdbb83c869303d # v4.5.0
     with:
       check-node-version: '22'
       # The coverage/Sonar leg carries its own flag, and it runs on the

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -8,7 +8,7 @@ jobs:
       pull-requests: write
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/claude-code-review.yml@b6fc63379fae3634daf4dd9495295b6d95f6b7fe # v4.4.0
+    uses: OlivierZal/configs/.github/workflows/claude-code-review.yml@dc0a53bd2908cd5b8b6b6ef6d7fdbb83c869303d # v4.5.0
 name: claude-code-review
 on:
   pull_request:

--- a/.github/workflows/claude-dependabot-fix.yml
+++ b/.github/workflows/claude-dependabot-fix.yml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: read
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/reusable-claude-dependabot-fix.yml@b6fc63379fae3634daf4dd9495295b6d95f6b7fe # v4.4.0
+    uses: OlivierZal/configs/.github/workflows/reusable-claude-dependabot-fix.yml@dc0a53bd2908cd5b8b6b6ef6d7fdbb83c869303d # v4.5.0
     with:
       repo-guidance: 'API bugs surfacing through @olivierzal/melcloud-api are fixed in that library, never worked around in this app. When the bump is @olivierzal/configs, realign every `uses: OlivierZal/configs/...` ref in .github/workflows to the tag matching the new npm pin, comment included — one version covers both channels. Stop and leave the pull request failing for human review when that release changes lint policy: adopting it needs per-repository judgement no automated fix can make.'
       verify-commands: '`npm run format`, `npm run lint`, `npm run typecheck`, `npm test`, and `npm run build`'

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -6,7 +6,7 @@ jobs:
       issues: write
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/claude-issue-triage.yml@b6fc63379fae3634daf4dd9495295b6d95f6b7fe # v4.4.0
+    uses: OlivierZal/configs/.github/workflows/claude-issue-triage.yml@dc0a53bd2908cd5b8b6b6ef6d7fdbb83c869303d # v4.5.0
 name: claude-issue-triage
 on:
   issues:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -11,7 +11,7 @@ jobs:
       pull-requests: read
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/claude.yml@b6fc63379fae3634daf4dd9495295b6d95f6b7fe # v4.4.0
+    uses: OlivierZal/configs/.github/workflows/claude.yml@dc0a53bd2908cd5b8b6b6ef6d7fdbb83c869303d # v4.5.0
 name: claude
 on:
   # No pull_request_review(_comment): Copilot auto-review fires them as a

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -4,7 +4,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: OlivierZal/configs/.github/workflows/dependabot.yml@b6fc63379fae3634daf4dd9495295b6d95f6b7fe # v4.4.0
+    uses: OlivierZal/configs/.github/workflows/dependabot.yml@dc0a53bd2908cd5b8b6b6ef6d7fdbb83c869303d # v4.5.0
 name: dependabot
 on:
   pull_request: {}

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -3,7 +3,7 @@ jobs:
   dependency-review:
     permissions:
       contents: read
-    uses: OlivierZal/configs/.github/workflows/dependency-review.yml@b6fc63379fae3634daf4dd9495295b6d95f6b7fe # v4.4.0
+    uses: OlivierZal/configs/.github/workflows/dependency-review.yml@dc0a53bd2908cd5b8b6b6ef6d7fdbb83c869303d # v4.5.0
 name: Dependency review
 on:
   pull_request: {}

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -3,7 +3,7 @@ jobs:
   pr_title:
     permissions:
       pull-requests: read
-    uses: OlivierZal/configs/.github/workflows/pr-title.yml@b6fc63379fae3634daf4dd9495295b6d95f6b7fe # v4.4.0
+    uses: OlivierZal/configs/.github/workflows/pr-title.yml@dc0a53bd2908cd5b8b6b6ef6d7fdbb83c869303d # v4.5.0
 name: pr-title
 on:
   pull_request:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,14 @@ jobs:
       - uses: ./.github/actions/setup-node-and-install
         with:
           cache: none
+          node-version: '22'
           npm-token: ${{ secrets.GITHUB_TOKEN }}
+          # setup-node writes the registry auth to its user config only
+          # when given a registry — the `cp` below carries that file into
+          # the workspace for the publish action's container.
+          registry-url: https://npm.pkg.github.com
+          require-npm-token: 'true'
+          scope: '@olivierzal'
       - run: cp "$NPM_CONFIG_USERCONFIG" "$GITHUB_WORKSPACE/.npmrc"
       - id: publish
         name: Publish

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -14,7 +14,9 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/setup-node-and-install
         with:
+          node-version: '22'
           npm-token: ${{ secrets.GITHUB_TOKEN }}
+          require-npm-token: 'true'
       - name: Validate app
         uses: athombv/github-action-homey-app-validate@0f3b42c15d26aab79d7c48cde4d2805524da910e # untagged: master carries the `don't npm ci` fix the @typescript/native toolchain needs; v1 predates it
         with:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -5,7 +5,7 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    uses: OlivierZal/configs/.github/workflows/zizmor.yml@b6fc63379fae3634daf4dd9495295b6d95f6b7fe # v4.4.0
+    uses: OlivierZal/configs/.github/workflows/zizmor.yml@dc0a53bd2908cd5b8b6b6ef6d7fdbb83c869303d # v4.5.0
 name: zizmor
 on:
   pull_request: {}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -659,9 +659,15 @@ Dependabot alerts scan continuously and carry the named, reasoned
 dismissals (an exception lives on the advisory, so it cannot outlive
 it), while `dependency-review` judges what a PR introduces;
 `validate.yml` and `publish.yml` stay local
-(no reusable exists), so the composite action stays too — and installs
-pass `npm-token` (the configs dependency lives on GitHub Packages,
-where even reads need auth).
+(no reusable exists), so the composite action stays too — a verbatim
+copy of the pinned configs version, re-synced with every pin bump.
+Its callers pin `node-version: '22'` (the action's own default,
+`lts/*`, is the libs' choice) and pass `npm-token` with
+`require-npm-token` (the configs dependency lives on GitHub Packages,
+where even reads need auth); the publish job also forwards
+`registry-url`/`scope`, since setup-node writes the registry user
+config its `cp` step carries into the publish container only when
+given a registry.
 
 ## Runtime boundary (@olivierzal/homey-kit)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "temporal-polyfill": "^1.0.4"
       },
       "devDependencies": {
-        "@olivierzal/configs": "4.4.0",
+        "@olivierzal/configs": "4.5.0",
         "@types/homey": "npm:homey-apps-sdk-v3-types@^0.3.12",
         "@types/node": "^26.4.0",
         "@typescript/native": "npm:typescript@^7.0.2",
@@ -1083,9 +1083,9 @@
       }
     },
     "node_modules/@olivierzal/configs": {
-      "version": "4.4.0",
-      "resolved": "https://npm.pkg.github.com/download/@olivierzal/configs/4.4.0/802d5ef7d61f29e7d7473aeaa43a255e77467376",
-      "integrity": "sha512-QTinEvdHe0Z4pKKw5uQI1BYBMyFPM9v+HxYzt+tMI+mnm5SVcFutDFu4bD24BV9fMFr7ConXnOrEQuibh599+Q==",
+      "version": "4.5.0",
+      "resolved": "https://npm.pkg.github.com/download/@olivierzal/configs/4.5.0/142bff44ae36a4be80eec88694901f8ee42c21b7",
+      "integrity": "sha512-Kqb9hSeY0bpVGObKL/SDEL4QDHL5J3tgB47vuPBVGav/OYM75J02wD/ib4SMQ/G2QeItIQQDyXUCxstRmcFR4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1106,7 +1106,7 @@
         "eslint-plugin-yml": "^3.6.0",
         "jsonc-eslint-parser": "^3.3.0",
         "prettier-plugin-packagejson": "^3.0.2",
-        "typescript-eslint": "^8.67.0",
+        "typescript-eslint": "^8.68.0",
         "unplugin-swc": "^1.5.11"
       },
       "engines": {
@@ -2011,17 +2011,17 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.67.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.67.0.tgz",
-      "integrity": "sha512-Un7Heoyj65NREbKAyIrFxeM143NZpExWmy1Nep4DLeQOeLlTeumPjoNKnBrU5D5moWXbPJgRa5Uwcdu0faVNGQ==",
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.69.0.tgz",
+      "integrity": "sha512-t5jQTKPIgVW1PE6dR6H6Qz5gm8zjMlX5/2gRaOGd9eO6V7J+tQc6iWKukEe7dY8u9HyYasQ0yfF0/FSSTEO2gA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.67.0",
-        "@typescript-eslint/type-utils": "8.67.0",
-        "@typescript-eslint/utils": "8.67.0",
-        "@typescript-eslint/visitor-keys": "8.67.0",
+        "@typescript-eslint/scope-manager": "8.69.0",
+        "@typescript-eslint/type-utils": "8.69.0",
+        "@typescript-eslint/utils": "8.69.0",
+        "@typescript-eslint/visitor-keys": "8.69.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -2034,7 +2034,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.67.0",
+        "@typescript-eslint/parser": "^8.69.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
@@ -2050,16 +2050,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.67.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.67.0.tgz",
-      "integrity": "sha512-fUBfTuuEulWqX6V8+O3PtScV01tzYYRUDTAirHFKoRAt7nOzoGiPt0M/bB47wWNy0coOOcgEwAMUtBpykMxl6w==",
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.69.0.tgz",
+      "integrity": "sha512-l4b0DhWioGg6Gt2ebGlvfkFMOjRsauxtsnDRwUSRX1qHq3HdTfQHV8wW9zEXeciai6HfeaKOedQn2Zoofx3WBw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.67.0",
-        "@typescript-eslint/types": "8.67.0",
-        "@typescript-eslint/typescript-estree": "8.67.0",
-        "@typescript-eslint/visitor-keys": "8.67.0",
+        "@typescript-eslint/scope-manager": "8.69.0",
+        "@typescript-eslint/types": "8.69.0",
+        "@typescript-eslint/typescript-estree": "8.69.0",
+        "@typescript-eslint/visitor-keys": "8.69.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -2075,14 +2075,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.67.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.67.0.tgz",
-      "integrity": "sha512-cvE8c7ulYeXN9fYuszhCeCsbzyVEXuhrRCybnBre7TUmqb5nRmBfQAwCj0O3WJFDeyAZt4VYv51vMCC9LHSdYw==",
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.69.0.tgz",
+      "integrity": "sha512-yi4obFrHMmnsesWehHbkg9zMA7Jt8cXT+mKM08G999pH1yT6nqgsHx7MYm0uY1wAj8CqiBXYRJ7WAT0QdQHQXg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.67.0",
-        "@typescript-eslint/types": "^8.67.0",
+        "@typescript-eslint/tsconfig-utils": "^8.69.0",
+        "@typescript-eslint/types": "^8.69.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -2097,14 +2097,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.67.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.67.0.tgz",
-      "integrity": "sha512-EgvsleTwS4E+WzzSvem8fAUubLwatMNF1B5hHSLQxcvs7q2dtRhGyujHwLJSYlG41niJ7GP24Aha2+0mb1b2kg==",
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.69.0.tgz",
+      "integrity": "sha512-ewfspqWvSxKSOaplqAUNbaSFO0eB6w1EtQ+esfYFRm3614Ty4uNtExkcbgd6nWsXphbqKyf9ZYdbZdv2xEoWEQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.67.0",
-        "@typescript-eslint/visitor-keys": "8.67.0"
+        "@typescript-eslint/types": "8.69.0",
+        "@typescript-eslint/visitor-keys": "8.69.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2115,9 +2115,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.67.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.67.0.tgz",
-      "integrity": "sha512-vV+LUSv5njUWsknE71fqKTlXUva+R76SaeORd6Zojcunk/6DvKFXONU3BrAs2H49mbygUXt6gbYunzwqNwlhdg==",
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.69.0.tgz",
+      "integrity": "sha512-xNqK7YTDZsLniQMV/4rpFR8Z5JlqeRvVjuG1YgF/mdPVH84HSD19L8CczMA0qg2RfwEV231GHH3VnToJDo4MfQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2132,15 +2132,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.67.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.67.0.tgz",
-      "integrity": "sha512-aVWDXbRmdXO9siTfX4ditQI1T9+zVcNazT48EJCD0v40/9RIFoUgZ05CmGEq9H2gixRpjUn/iplwvlcvutJW/Q==",
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.69.0.tgz",
+      "integrity": "sha512-ZfoJAVg3JZndQEpEl9petVlxau3lRuElc4HRMuAlLCf8to04/iHz692RUSNmXKDjEuJmIL+KZ2/BsOcBc16dsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.67.0",
-        "@typescript-eslint/typescript-estree": "8.67.0",
-        "@typescript-eslint/utils": "8.67.0",
+        "@typescript-eslint/types": "8.69.0",
+        "@typescript-eslint/typescript-estree": "8.69.0",
+        "@typescript-eslint/utils": "8.69.0",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -2157,9 +2157,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.67.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.67.0.tgz",
-      "integrity": "sha512-sBtgslww8nsMYUjhdPBiSyUqSzT8uR6g93A2QXnQC8+cGdjz0CyaOdqHDRJb1AtORbZCNUJBBeFA/tNR2uQmww==",
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.69.0.tgz",
+      "integrity": "sha512-K3VrubUPhlo9VDBS6QdI8YB5j7ClpqLRdefcz6PFrhnwicehBweqQ9Evhl4l+FYz0HdDmMqIiSX0aldGRYtDCA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2171,16 +2171,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.67.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.67.0.tgz",
-      "integrity": "sha512-EKQBCE9yNlRJYm7jdTW5AhDacDUmSwQb0FAJAmK2EKYrNXIsa2vxcSZx6PvJ/dEdI6lS+Y9W+EXckLj0iPFGcw==",
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.69.0.tgz",
+      "integrity": "sha512-AdFkgqck3Vudb/kWnxlyafU/4aBhHrbQ9locP2N4psXTy5mOBg0SHJumnLvx7r6g1gV4DKvUFwV2nJZBoqOD8w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.67.0",
-        "@typescript-eslint/tsconfig-utils": "8.67.0",
-        "@typescript-eslint/types": "8.67.0",
-        "@typescript-eslint/visitor-keys": "8.67.0",
+        "@typescript-eslint/project-service": "8.69.0",
+        "@typescript-eslint/tsconfig-utils": "8.69.0",
+        "@typescript-eslint/types": "8.69.0",
+        "@typescript-eslint/visitor-keys": "8.69.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -2199,16 +2199,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.67.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.67.0.tgz",
-      "integrity": "sha512-U9D1FdwEWBwok3hxxSdhclMb0twvt9QnjIQ0VfQ1AiX2epnpSgv2ubVDsayOFyY8K6FX+AQ7E0FKWVG3iKsj1A==",
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.69.0.tgz",
+      "integrity": "sha512-tUbx60BBqQa31kXF5MCsOOLL5E/WzUuxIn7YpAvq+eaUlqvk8/NXnXMBNAdLCr0icjkzem7iUA5QqWHe/hJ1aw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.67.0",
-        "@typescript-eslint/types": "8.67.0",
-        "@typescript-eslint/typescript-estree": "8.67.0"
+        "@typescript-eslint/scope-manager": "8.69.0",
+        "@typescript-eslint/types": "8.69.0",
+        "@typescript-eslint/typescript-estree": "8.69.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2223,13 +2223,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.67.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.67.0.tgz",
-      "integrity": "sha512-fkv8dHRDqfGtTHuJeebdrQ7cX6Ad4WAS00rgHh9UGvMycF1mjBfsxry1XsLIFhWZ6Judlh6UdzK+TYlbpCXgnA==",
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.69.0.tgz",
+      "integrity": "sha512-+rmdgPA+EXkNgKYvHvFfhrs35utXbwaC5PGpDquSXcoXQDKUA5UjV0LmTucG/4JXkM31BTu4TilHtrN8IVBe8w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.67.0",
+        "@typescript-eslint/types": "8.69.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -7342,16 +7342,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.67.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.67.0.tgz",
-      "integrity": "sha512-S2udFs8tCKEKffuJ4TB1idGUZiXdCPGi3IPBGWXarbLQ5UPXORV8QEVzJ4gCRduURMb5EkpNCdjbk0eDIuI8Yg==",
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.69.0.tgz",
+      "integrity": "sha512-B3MltX0VqjUBNEe3b3sSuiRbfa6XrfHFtBiPamjT5AsW/dfq+y+bc0wyuS9DxAS1LyzCxRp2+rxzpLUvqM2BvA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.67.0",
-        "@typescript-eslint/parser": "8.67.0",
-        "@typescript-eslint/typescript-estree": "8.67.0",
-        "@typescript-eslint/utils": "8.67.0"
+        "@typescript-eslint/eslint-plugin": "8.69.0",
+        "@typescript-eslint/parser": "8.69.0",
+        "@typescript-eslint/typescript-estree": "8.69.0",
+        "@typescript-eslint/utils": "8.69.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "temporal-polyfill": "^1.0.4"
   },
   "devDependencies": {
-    "@olivierzal/configs": "4.4.0",
+    "@olivierzal/configs": "4.5.0",
     "@types/homey": "npm:homey-apps-sdk-v3-types@^0.3.12",
     "@types/node": "^26.4.0",
     "@typescript/native": "npm:typescript@^7.0.2",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,18 +1,13 @@
+import { coverageDefaults } from '@olivierzal/configs/vitest-coverage'
 import { swcPlugin } from '@olivierzal/configs/vitest-swc'
 import { type ViteUserConfig, defineConfig } from 'vitest/config'
 
 const config: ViteUserConfig = defineConfig({
   test: {
     coverage: {
+      ...coverageDefaults,
       exclude: ['.homeybuild/**'],
       include: ['**/*.mts'],
-      reporter: ['text', 'lcov'],
-      thresholds: {
-        branches: 100,
-        functions: 100,
-        lines: 100,
-        statements: 100,
-      },
     },
     projects: [
       {


### PR DESCRIPTION
Adopts `@olivierzal/configs` 4.5.0 across both delivery channels the family's two-channel gate requires to agree, in two commits.

## npm channel (commit 1, `build: adopt @olivierzal/configs 4.5.0`)

- `package.json`: `@olivierzal/configs` `4.4.0` → `4.5.0` (exact pin, devDependencies).
- `package-lock.json` follows; root `version` and `packages[""].version` both read `46.7.1`, equal to `package.json`.
- `vitest.config.ts`: the hand-written `reporter: ['text', 'lcov']` and 100/100/100/100 `thresholds` carried exactly the values `coverageDefaults` ships (confirmed against `node_modules/@olivierzal/configs/dist/vitest/coverage.js`), so they are replaced by `...coverageDefaults` from `@olivierzal/configs/vitest-coverage`; `include` and `exclude` stay as they were.

## workflow channel (commit 2, `build: re-point the workflow stubs to configs v4.5.0`)

- All 9 stubs under `.github/workflows/` move from `@b6fc63379fae3634daf4dd9495295b6d95f6b7fe # v4.4.0` to `@dc0a53bd2908cd5b8b6b6ef6d7fdbb83c869303d # v4.5.0` (`ci`, `claude`, `claude-code-review`, `claude-dependabot-fix`, `claude-issue-triage`, `dependabot`, `dependency-review`, `pr-title`, `zizmor`); no v4.4.0 reference remains.
- `.github/actions/setup-node-and-install/action.yml` is now the byte-identical v4.5.0 copy. The action itself did not change between configs v4.4.0 and v4.5.0 — this repo's copy had never been synced, so the swap closes a pre-existing drift: the family copy defaults `node-version` to `lts/*` (the old local copy said `'22'`), makes `registry-url`/`scope` optional inputs (the old copy hard-coded the GitHub Packages registry) and gates the missing-token fail-fast behind `require-npm-token`.
- Both local callers are adapted so behavior is preserved under the family copy: `validate.yml` and `publish.yml` pin `node-version: '22'` and pass `require-npm-token: 'true'`; `publish.yml` additionally forwards `registry-url: https://npm.pkg.github.com` and `scope: '@olivierzal'`, because its `cp "$NPM_CONFIG_USERCONFIG"` step depends on setup-node writing the registry user config, which only happens when it is given a registry (the same shape the four library repos' publish jobs use). `validate.yml` needs no registry input: the committed `.npmrc` already routes `@olivierzal` to GitHub Packages, and `NODE_AUTH_TOKEN` carries the auth.
- CLAUDE.md's tooling-boundary paragraph records that caller contract.

## Gates (local, exit codes, final tree)

| Gate | Exit |
| --- | --- |
| `check-pins.sh` (configs' two-channel gate, run locally from `node_modules`) | 0 — 14 pinned references across 12 files |
| `npm run format` | 0 |
| `npm run lint` | 0 |
| `npm run typecheck` | 0 |
| `npm run test:coverage` | 0 — 52 files, 942 tests, 100 % thresholds held |
| `npm run build` | 0 |
| `npm run homey:validate` (level `publish`) | 0 — rewrote nothing |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BenMGhoj97mp21GNirfUHD
