### PR TITLE
build: adopt @olivierzal/configs 5.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
       packages: read
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/reusable-ci.yml@dc0a53bd2908cd5b8b6b6ef6d7fdbb83c869303d # v4.5.0
+    uses: OlivierZal/configs/.github/workflows/reusable-ci.yml@9656fb8009b6b4c344dbdda62c99b95ed64bfe8f # v5.0.0
     with:
       check-node-version: '22'
       # The coverage/Sonar leg carries its own flag, and it runs on the

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -8,7 +8,7 @@ jobs:
       pull-requests: write
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/claude-code-review.yml@dc0a53bd2908cd5b8b6b6ef6d7fdbb83c869303d # v4.5.0
+    uses: OlivierZal/configs/.github/workflows/claude-code-review.yml@9656fb8009b6b4c344dbdda62c99b95ed64bfe8f # v5.0.0
 name: claude-code-review
 on:
   pull_request:

--- a/.github/workflows/claude-dependabot-fix.yml
+++ b/.github/workflows/claude-dependabot-fix.yml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: read
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/reusable-claude-dependabot-fix.yml@dc0a53bd2908cd5b8b6b6ef6d7fdbb83c869303d # v4.5.0
+    uses: OlivierZal/configs/.github/workflows/reusable-claude-dependabot-fix.yml@9656fb8009b6b4c344dbdda62c99b95ed64bfe8f # v5.0.0
     with:
       repo-guidance: 'API bugs surfacing through @olivierzal/melcloud-api are fixed in that library, never worked around in this app. When the bump is @olivierzal/configs, realign every `uses: OlivierZal/configs/...` ref in .github/workflows to the tag matching the new npm pin, comment included — one version covers both channels. Stop and leave the pull request failing for human review when that release changes lint policy: adopting it needs per-repository judgement no automated fix can make.'
       verify-commands: '`npm run format`, `npm run lint`, `npm run typecheck`, `npm test`, and `npm run build`'

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -6,7 +6,7 @@ jobs:
       issues: write
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/claude-issue-triage.yml@dc0a53bd2908cd5b8b6b6ef6d7fdbb83c869303d # v4.5.0
+    uses: OlivierZal/configs/.github/workflows/claude-issue-triage.yml@9656fb8009b6b4c344dbdda62c99b95ed64bfe8f # v5.0.0
 name: claude-issue-triage
 on:
   issues:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -11,7 +11,7 @@ jobs:
       pull-requests: read
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/claude.yml@dc0a53bd2908cd5b8b6b6ef6d7fdbb83c869303d # v4.5.0
+    uses: OlivierZal/configs/.github/workflows/claude.yml@9656fb8009b6b4c344dbdda62c99b95ed64bfe8f # v5.0.0
 name: claude
 on:
   # No pull_request_review(_comment): Copilot auto-review fires them as a

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -4,7 +4,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: OlivierZal/configs/.github/workflows/dependabot.yml@dc0a53bd2908cd5b8b6b6ef6d7fdbb83c869303d # v4.5.0
+    uses: OlivierZal/configs/.github/workflows/dependabot.yml@9656fb8009b6b4c344dbdda62c99b95ed64bfe8f # v5.0.0
 name: dependabot
 on:
   pull_request: {}

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -3,7 +3,7 @@ jobs:
   dependency-review:
     permissions:
       contents: read
-    uses: OlivierZal/configs/.github/workflows/dependency-review.yml@dc0a53bd2908cd5b8b6b6ef6d7fdbb83c869303d # v4.5.0
+    uses: OlivierZal/configs/.github/workflows/dependency-review.yml@9656fb8009b6b4c344dbdda62c99b95ed64bfe8f # v5.0.0
 name: Dependency review
 on:
   pull_request: {}

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -3,7 +3,7 @@ jobs:
   pr_title:
     permissions:
       pull-requests: read
-    uses: OlivierZal/configs/.github/workflows/pr-title.yml@dc0a53bd2908cd5b8b6b6ef6d7fdbb83c869303d # v4.5.0
+    uses: OlivierZal/configs/.github/workflows/pr-title.yml@9656fb8009b6b4c344dbdda62c99b95ed64bfe8f # v5.0.0
 name: pr-title
 on:
   pull_request:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -5,7 +5,7 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    uses: OlivierZal/configs/.github/workflows/zizmor.yml@dc0a53bd2908cd5b8b6b6ef6d7fdbb83c869303d # v4.5.0
+    uses: OlivierZal/configs/.github/workflows/zizmor.yml@9656fb8009b6b4c344dbdda62c99b95ed64bfe8f # v5.0.0
 name: zizmor
 on:
   pull_request: {}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -645,6 +645,24 @@ coverage.
   literal verbatim; the ban is the same either way. The **node-side**
   floor is the Homey's own Node, held by the manifest's
   `compatibility` declaration, NOT by a check.
+- The CSS half of the webview floor is `css/use-baseline`, bound in
+  the configs preset (5.0.0) to the same iOS 16.4 WebKit through the
+  one knob the rule has — Baseline year 2022, the last year every
+  entry of which sits inside that engine — plus an exact-name
+  allowlist of what WebKit shipped BEFORE the floor and Baseline dated
+  later, by its last core browser (`color-mix`, Safari 16.2;
+  `mask-image`, 15.4; `outline`, dated by 16.4 itself). Measured over
+  this app's ten stylesheets at adoption (2026-09-07): seven
+  rejections under the bare year — `color-mix` ×3, `outline` ×3,
+  `mask-image` ×1 — every one on the allowlist, zero under the bound
+  rule, and `eslint --print-config` identical across the bump on every
+  non-CSS file. A future rejection is settled against MDN's
+  browser-compat data, never locally: a feature Safari 16.4 or older
+  ships re-enters the allowlist in configs with its release (a configs
+  release, adopted by pin bump); anything newer is rewritten. No
+  `css/use-baseline` override lives in the overlay or inline, and the
+  year and the list move only with the App Store minimum configs'
+  `ios-floor-watch.yml` records.
 - A floor is declared from WHERE THE CODE RUNS, never from what a
   dependency happens to require. `compatibility: ">=12.9.0"` is
   Athom's own documented Node 22 boundary ("as of Homey v12.9.0, all
@@ -714,9 +732,12 @@ stubs calling the family reusables in OlivierZal/configs, pinned
 Dependabot alerts scan continuously and carry the named, reasoned
 dismissals (an exception lives on the advisory, so it cannot outlive
 it), while `dependency-review` judges what a PR introduces;
-`validate.yml` and `publish.yml` stay local
-(no reusable exists), so the composite action stays too — a verbatim
-copy of the pinned configs version, re-synced with every pin bump.
+`validate.yml` and `publish.yml` stay local: the app's release path is
+the Homey App Store through athombv's actions, which no configs
+reusable covers (`reusable-publish.yml` and `reusable-docs.yml`, since
+configs 5.0.0, are the LIBRARIES' GitHub Packages and Pages path), so
+the composite action stays too — a verbatim copy of the pinned configs
+version, re-synced with every pin bump.
 Its callers pin `node-version: '22'` (the action's own default,
 `lts/*`, is the libs' choice) and pass `npm-token` with
 `require-npm-token` (the configs dependency lives on GitHub Packages,

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "temporal-polyfill": "^1.0.4"
       },
       "devDependencies": {
-        "@olivierzal/configs": "4.5.0",
+        "@olivierzal/configs": "5.0.0",
         "@types/homey": "npm:homey-apps-sdk-v3-types@^0.3.12",
         "@types/node": "^26.4.0",
         "@typescript/native": "npm:typescript@^7.0.2",
@@ -804,21 +804,6 @@
         "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
-    "node_modules/@gerrit0/mini-shiki": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.23.0.tgz",
-      "integrity": "sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@shikijs/engine-oniguruma": "^3.23.0",
-        "@shikijs/langs": "^3.23.0",
-        "@shikijs/themes": "^3.23.0",
-        "@shikijs/types": "^3.23.0",
-        "@shikijs/vscode-textmate": "^10.0.2"
-      }
-    },
     "node_modules/@html-eslint/core": {
       "version": "0.65.0",
       "resolved": "https://registry.npmjs.org/@html-eslint/core/-/core-0.65.0.tgz",
@@ -1083,9 +1068,9 @@
       }
     },
     "node_modules/@olivierzal/configs": {
-      "version": "4.5.0",
-      "resolved": "https://npm.pkg.github.com/download/@olivierzal/configs/4.5.0/142bff44ae36a4be80eec88694901f8ee42c21b7",
-      "integrity": "sha512-Kqb9hSeY0bpVGObKL/SDEL4QDHL5J3tgB47vuPBVGav/OYM75J02wD/ib4SMQ/G2QeItIQQDyXUCxstRmcFR4A==",
+      "version": "5.0.0",
+      "resolved": "https://npm.pkg.github.com/download/@olivierzal/configs/5.0.0/f35b0f14c1f5d6b9952bc73cba55673e5cb04dd5",
+      "integrity": "sha512-ySdivucxdB5ROb3JD8YRrohBXxXldlUAyLk4X8ib6Br84jIWLuiRgIhD+zmEctVWi/D8BiU+dX0F7hPfCHOnqQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1104,7 +1089,6 @@
         "eslint-plugin-perfectionist": "^5.10.0",
         "eslint-plugin-unicorn": "^74.0.0",
         "eslint-plugin-yml": "^3.6.0",
-        "jsonc-eslint-parser": "^3.3.0",
         "prettier-plugin-packagejson": "^3.0.2",
         "typescript-eslint": "^8.68.0",
         "unplugin-swc": "^1.5.11"
@@ -1115,7 +1099,6 @@
       "peerDependencies": {
         "eslint": ">=10",
         "prettier": ">=3.5",
-        "typedoc": ">=0.28",
         "vitest": ">=4"
       }
     },
@@ -1466,60 +1449,6 @@
       "integrity": "sha512-qY3QRtKdq//Z8jDENSUCAaSE76sUwHgN6pzoRXj6e5cSwQqxFLjm8B+GDkbtUr/WGWJRzoAMtz0I60TM1KrOBg==",
       "dev": true,
       "license": "Apache-2.0"
-    },
-    "node_modules/@shikijs/engine-oniguruma": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.23.0.tgz",
-      "integrity": "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@shikijs/types": "3.23.0",
-        "@shikijs/vscode-textmate": "^10.0.2"
-      }
-    },
-    "node_modules/@shikijs/langs": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.23.0.tgz",
-      "integrity": "sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@shikijs/types": "3.23.0"
-      }
-    },
-    "node_modules/@shikijs/themes": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.23.0.tgz",
-      "integrity": "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@shikijs/types": "3.23.0"
-      }
-    },
-    "node_modules/@shikijs/types": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.23.0.tgz",
-      "integrity": "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@shikijs/vscode-textmate": "^10.0.2",
-        "@types/hast": "^3.0.4"
-      }
-    },
-    "node_modules/@shikijs/vscode-textmate": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
-      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/@sindresorhus/base62": {
       "version": "1.0.0",
@@ -3223,14 +3152,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
-      "license": "Python-2.0",
-      "peer": true
-    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -3698,20 +3619,6 @@
       "integrity": "sha512-K6bvB2BjnNrugtIih6ewlbBI9DXa976jIdiIlRLHhBoEI9a4JaQjjHyF+A1IQI543aQYR4LnmOrT/K5fZj0aPA==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "peer": true,
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
     },
     "node_modules/es-html-parser": {
       "version": "0.3.1",
@@ -5326,27 +5233,6 @@
         "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/linkify-it": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
-      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/markdown-it"
-        }
-      ],
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "uc.micro": "^2.0.0"
-      }
-    },
     "node_modules/load-tsconfig": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/load-tsconfig/-/load-tsconfig-0.2.5.tgz",
@@ -5393,14 +5279,6 @@
       "engines": {
         "node": "20 || >=22"
       }
-    },
-    "node_modules/lunr": {
-      "version": "2.3.9",
-      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
-      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
@@ -5456,35 +5334,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/markdown-it": {
-      "version": "14.3.0",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.3.0.tgz",
-      "integrity": "sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/markdown-it"
-        }
-      ],
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "argparse": "^2.0.1",
-        "entities": "^4.5.0",
-        "linkify-it": "^5.0.2",
-        "mdurl": "^2.0.0",
-        "punycode.js": "^2.3.1",
-        "uc.micro": "^2.1.0"
-      },
-      "bin": {
-        "markdown-it": "bin/markdown-it.mjs"
       }
     },
     "node_modules/markdown-table": {
@@ -5769,14 +5618,6 @@
       "integrity": "sha512-pVxQFCcaYUEAH853+v7yoI/qzhxXSq1bTb9obMYGYAN1c3Hen+XDCEvr296XhstrwlSTNgOR7mCSD4JPjbJe5A==",
       "dev": true,
       "license": "CC0-1.0"
-    },
-    "node_modules/mdurl": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.1.0.tgz",
-      "integrity": "sha512-1+HBaOx0zi/dQWht8rNv9MYf9qqpqL/kxI0hXImU6Y547zM6Sni8BQibt7ifgMcYtQg41ao3Ivd6cnSM86inpg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/micromark": {
       "version": "4.0.2",
@@ -6809,17 +6650,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/punycode.js": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
-      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/quote-js-string": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/quote-js-string/-/quote-js-string-0.1.0.tgz",
@@ -7302,31 +7132,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/typedoc": {
-      "version": "0.28.20",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.20.tgz",
-      "integrity": "sha512-uSKqkh8Cr48vllnEy+jdaAgOeR6Y+QCBW7usgUsKj7gJEfR7stw9U/fE49LBnj2tPRKPY0c0EBJSWe9Appmplg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@gerrit0/mini-shiki": "^3.23.0",
-        "lunr": "^2.3.9",
-        "markdown-it": "^14.3.0",
-        "minimatch": "^10.2.5",
-        "yaml": "^2.9.0"
-      },
-      "bin": {
-        "typedoc": "bin/typedoc"
-      },
-      "engines": {
-        "node": ">= 18",
-        "pnpm": ">= 10"
-      },
-      "peerDependencies": {
-        "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x || 6.0.x"
-      }
-    },
     "node_modules/typescript": {
       "name": "@typescript/typescript6",
       "version": "6.0.2",
@@ -7364,14 +7169,6 @@
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
-    },
-    "node_modules/uc.micro": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
-      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/undici": {
       "version": "8.10.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "temporal-polyfill": "^1.0.4"
   },
   "devDependencies": {
-    "@olivierzal/configs": "4.5.0",
+    "@olivierzal/configs": "5.0.0",
     "@types/homey": "npm:homey-apps-sdk-v3-types@^0.3.12",
     "@types/node": "^26.4.0",
     "@typescript/native": "npm:typescript@^7.0.2",


### PR DESCRIPTION
## What

Adopt `@olivierzal/configs` 5.0.0 ([release notes](https://github.com/OlivierZal/configs/releases/tag/v5.0.0)) on both channels: the npm pin (exact 5.0.0, resolved from GitHub Packages with its integrity hash) and every workflow stub at `@9656fb8009b6b4c344dbdda62c99b95ed64bfe8f # v5.0.0`.

Worktree reused from the earlier round and hard-reset to origin/main (6cab7f74) before starting. Adoption: (1) package.json `@olivierzal/configs` → `file:` reference to the 5.0.0 pack (npm install: "changed 1 package"; the owner re-pins to `5.0.0` exact after publishing); (2) the nine workflow stubs (ci, claude, claude-code-review, claude-dependabot-fix, claude-issue-triage, dependabot, dependency-review, pr-title, zizmor) re-pointed from `@dc0a53bd… # v4.5.0` to `@release/configs-next # v5.0.0` (owner re-pins to the release SHA, same tag comment); (3) `.github/actions/setup-node-and-install/action.yml` left as is — measured byte-identical between v4.5.0, PR head 9461fe5 and the consumer's copy; (4) package-lock.json committed exactly as `npm install` wrote it, no overrides, no --legacy-peer-deps — typedoc and its 14-package subtree gone, matching the guide's simulation; (5) CLAUDE.md: a new bullet under the floor doctrine records the CSS half of the webview floor (css/use-baseline bound to 2022 + the three allowlisted names, the 7/0 measurement, the MDN-compat classification rule for a future rejection: Safari ≤16.4 → allowlist entry in configs, newer → rewrite; no override in overlay or inline), and the "validate.yml and publish.yml stay local (no reusable exists)" sentence reworded — the app's release path is the Homey App Store through athombv's actions, which no configs reusable covers; reusable-publish/reusable-docs are the libraries' GitHub Packages/Pages path. Nothing else needed: tsconfig.json extends `tsconfig/app` and tsconfig.build.json extends ./tsconfig.json (no -build alias anywhere, no -build sentence in this CLAUDE.md), eslint.config.ts imports only `homeyApp` from `eslint/homey-app` (untouched by the barrel trim), vitest.config.ts takes `coverageDefaults` from `vitest-coverage`, .nvmrc already 22.22.2 with engines `^22.22.2 || >=24.15.0`, README/CONTRIBUTING/SECURITY mention configs nowhere, no CHANGELOG file exists (store changelog is release-only). The reusables the stubs call changed only by action bumps between v4.5.0 and the PR head (claude-code-action 1.0.208→1.0.211, zizmor-action 0.6.2→0.6.3; reusable-ci, dependabot, dependency-review, pr-title unchanged), so no `with:` input of the stubs moves. Observation, not a seam problem: npm 12 lists `@olivierzal/configs@5.0.0 (prepare: npm run build)` among blocked install scripts for the file: install — prepare never runs for a tarball and dist/ ships in it, so it is noise. Post-release verification for the owner, as the guide states: `npm view @olivierzal/configs@5.0.0 peerDependencies --json` must list exactly eslint, prettier, vitest, and this re-pin's lock must lose node_modules/typedoc as the file: install did.

## Process

Built and gated against the unreleased `npm pack` of configs BEFORE the release (family rule — the dry adoptions are where the GitHub Packages `peerDependenciesMeta` leak was found and fixed in configs before 5.0.0 shipped), then re-pinned to the published 5.0.0 and the release commit; the composite action is the release's bytes.

## Gates (dry run against the pack)

GREEN (real exit codes): npm run format (0) · npm run lint (0, 8 GB heap, css/html included) · npm run typecheck (0, TS 7 explicit path) · npm run test:coverage (0: 50 files, 933 tests, 100 % statements/branches/functions/lines) · npm run build (0, both IIFE+ESM bundles emitted and stamped) · npm run homey:validate (0 at level publish, touched no file) · pack scripts/check-pins.sh (0: 5 SHA pins verified; the branch refs are non-SHA and skipped by design) · pack scripts/check-coverage-leg.sh (0: coverage on the 22.20 leg). Iso-behaviour: `eslint --print-config` byte-identical 4.5.0→5.0.0 on app.mts, settings/index.mts, tests/unit/app.test.ts, settings/index.html, package.json; on settings/index.css the only diff is css/use-baseline `newly` → `{available: 2022, allowFunctions: [color-mix], allowProperties: [mask-image, outline]}` (deliberate). CSS classification: bare year 2022 without the allowlist raises 7 rejections over the 10 stylesheets (settings/index.css mask-image ×1; ata-group-setting layout.css outline+color-mix; ata-group-setting and charts zone-select.css color-mix+outline each), all three names on the allowlist, 0 under the shipped rule. Lock: 15 packages removed (node_modules/typedoc + 14-package subtree: @gerrit0/mini-shiki, @shikijs/*, argparse, entities, linkify-it, lunr, markdown-it, mdurl, punycode.js, uc.micro), 0 added, eslint 10.9.1 / prettier 3.9.6 / vitest 4.1.11 untouched, −203 lines net; lock entry peerDependencies = exactly {eslint >=10, prettier >=3.5, vitest >=4}. RED (pin-only): zizmor 1.29.0 offline with the consumer's .github/zizmor.yml → 9 × unpinned-uses (High), one per stub on `@release/configs-next # v5.0.0`, nothing else; the same run on origin/main's .github reports 0 findings.

Re-run on the published pin by the owner's session: every gate in package.json (format, lint, typecheck, test:coverage, build, docs, lint:package where present) — all exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMCysNQv5KFdV1LZmZaFQy
