### PR TITLE
build: adopt @olivierzal/melcloud-api 56.0.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -209,7 +209,9 @@ coverage.
   the LIBRARY's business: every melcloud-api `updateGroupState` leg
   resolves an already-matching delta as success, so the app-side
   handlers are plain delegations (verdict 2026-08, recorded on
-  `updateTargetAtaState`). Overheat stays Home-only: a Classic target
+  `updateTargetAtaState`); the one write failure the Classic device leg
+  can newly raise there, `StateReadError` (below), propagates to the
+  widget like any other. Overheat stays Home-only: a Classic target
   reads `null` and refuses the write. The
   inter-app grouping route is `GET /devices/groups` (the extension
   degrades to "no grouping" when it is absent).
@@ -401,6 +403,29 @@ coverage.
   MELCloud throttles hardest (`ErrorId 6`) — the library's login
   backoff arms around the sign-in itself, NOT around the enforced
   sync, so nothing local slowed the retries.
+- A Classic DEVICE write merges its delta onto a LIVE read of the
+  unit, never onto the last sync's snapshot (melcloud-api ≥ 56.0.0:
+  `updateValues` GETs `/Device/Get` first — `EffectiveFlags` is
+  decorative and an omitted field zero-fills, so the merge base is the
+  only thing a write can get wrong; the "vane resets to Auto" and
+  "setpoint reverts" reports, #1408, were the stale base). Two
+  consequences the app takes AS-IS, by decision: a read that fails
+  REFUSES the write with `StateReadError` (extends `APIError`;
+  `failure.kind` classifies the read), which `#pushUpdate`
+  (`drivers/base-device.mts`) surfaces through its generic catch as the
+  device warning — no branch on `failure.kind`, no retry policy — and
+  `NoChangesError` is judged against the unit's live state, so a value
+  the unit already holds is refused even when the last-synced Homey
+  value disagreed; `#pushUpdate` still swallows it, and no
+  `onSyncComplete` fires for a refused write (the library announces a
+  resolved write only), so the capability catches up on the next sync
+  tick, as before. Budget one extra GET per Classic device write
+  against the rate-limit window: a zone `updateGroupState` /
+  `updatePower` spends none, the device-facade fan-out one per member.
+  Home is untouched (its PUT is a delta). The API-level sync callback
+  keeps its defaulted parameter (`#onSync = async ({ ids, type } = {})`,
+  `app.mts`): a bare `@syncDevices()` cycle now notifies `undefined`
+  where it used to pass `{ type: undefined }`.
 - Home drivers compute capabilities per device from the facade — at
   pairing (`toDeviceDetails`) and again at device init
   (`getRequiredCapabilities`). `isOwner` gates NOTHING, on any driver:

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "GPL-3.0-only",
       "dependencies": {
         "@olivierzal/homey-kit": "5.2.0",
-        "@olivierzal/melcloud-api": "55.2.0",
+        "@olivierzal/melcloud-api": "56.0.0",
         "source-map-support": "^0.5.21",
         "temporal-polyfill": "^1.0.4"
       },
@@ -1056,9 +1056,9 @@
       }
     },
     "node_modules/@olivierzal/api-core": {
-      "version": "1.2.0",
-      "resolved": "https://npm.pkg.github.com/download/@olivierzal/api-core/1.2.0/da8a47ce951d1cee42dcb0c01985bf7daee2afae",
-      "integrity": "sha512-DIgvlS74UEykWos1t9ZiFDhI9F1qruedO9lJNoU3s+menpOSFRP0CI92mIj/CqYJLkBAa0B+p7hxOkxXLEMYig==",
+      "version": "1.3.0",
+      "resolved": "https://npm.pkg.github.com/download/@olivierzal/api-core/1.3.0/347653b589e5c4811a0e8fa8c733c7e93a408be0",
+      "integrity": "sha512-IAGyQ8JCVF+ecY0UvAhLvKszY2r5zq/0XcvaRVcoyRlQRyLukg6DAeQK0uxVGHYuuvCCST8oirLB5wuULrSyNg==",
       "license": "MIT",
       "dependencies": {
         "temporal-polyfill": "^1.0.3"
@@ -1112,12 +1112,12 @@
       }
     },
     "node_modules/@olivierzal/melcloud-api": {
-      "version": "55.2.0",
-      "resolved": "https://npm.pkg.github.com/download/@olivierzal/melcloud-api/55.2.0/93d55dcd5e261ba4fd49d9e0e058ef1df82c3cb4",
-      "integrity": "sha512-UYyubSKpp2Oddar+UXV7aibloC+cCF1mBdvzSMhyaxy8HGd4qYBTJE0CexZuw3C8UOIuI5XFNQREqBmFEsin/A==",
+      "version": "56.0.0",
+      "resolved": "https://npm.pkg.github.com/download/@olivierzal/melcloud-api/56.0.0/142c91869a113283c7a84a679f9ba429a4698fae",
+      "integrity": "sha512-ErSQozqRZDyphqrnTHaGsxEuhS9vCk3ATfVsqi9JubFwH623fnSwI4tW8Q5BoX4BKyQWcPw+jSIIwPSZ6GTBsA==",
       "license": "MIT",
       "dependencies": {
-        "@olivierzal/api-core": "1.2.0",
+        "@olivierzal/api-core": "1.3.0",
         "tough-cookie": "^6.0.2",
         "undici": "^8.9.0",
         "zod": "^4.4.3"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "prettier": "@olivierzal/configs/prettier",
   "dependencies": {
     "@olivierzal/homey-kit": "5.2.0",
-    "@olivierzal/melcloud-api": "55.2.0",
+    "@olivierzal/melcloud-api": "56.0.0",
     "source-map-support": "^0.5.21",
     "temporal-polyfill": "^1.0.4"
   },

--- a/tests/device-descriptors.ts
+++ b/tests/device-descriptors.ts
@@ -1,5 +1,5 @@
 import { getMockCallArg } from '@olivierzal/homey-kit/testing'
-import { NoChangesError } from '@olivierzal/melcloud-api'
+import { NoChangesError, StateReadError } from '@olivierzal/melcloud-api'
 import { describe, expect, it, vi } from 'vitest'
 
 const getConverter = (
@@ -94,6 +94,19 @@ export const testSetValuesErrorHandling = (
       await callback({ onoff: true })
 
       expect(superSetWarningMock).not.toHaveBeenCalled()
+    })
+
+    it('should surface a refused live read as the device warning', async () => {
+      setValuesMock.mockRejectedValue(
+        new StateReadError(1, { failure: { kind: 'network' } }),
+      )
+      await (getDevice() as { onInit: () => Promise<void> }).onInit()
+      const callback = getCapabilityListenerCallback()
+      await callback({ onoff: true })
+
+      expect(superSetWarningMock).toHaveBeenCalledWith(
+        'Could not read the live state of device with id 1 before writing',
+      )
     })
 
     it('should set warning for non-Error thrown values', async () => {


### PR DESCRIPTION
## Summary

Adopts `@olivierzal/melcloud-api` **56.0.0** ([release](https://github.com/OlivierZal/melcloud-api/releases/tag/v56.0.0)) — the major that merges every Classic device write onto a LIVE `/Device/Get` read instead of the last sync's snapshot (`EffectiveFlags` is decorative and an omitted field zero-fills, live-probed 2026-09-05), which is the mechanism behind the "vertical vane keeps resetting to Auto" / "cooling reverts to 24°" field reports (#1408). Exact pin, no caret; `@olivierzal/api-core` follows to 1.3.0 through it.

## Adoption points (from the SDK PR's consumer notes)

| # | Point | What this PR does |
|---|-------|-------------------|
| 1 | New throw `StateReadError` (extends `APIError`) from a Classic `updateValues` whose pre-write read failed | No code change: `#pushUpdate` (`drivers/base-device.mts`) already surfaces every non-`NoChangesError` rejection as the device warning. Pinned by a new shared descriptor case (`tests/device-descriptors.ts`, runs in the 4 device suites): the warning reads `Could not read the live state of device with id 1 before writing`. No branch on `failure.kind` — no retry policy, by decision. |
| 2 | Cost: one extra `/Device/Get` per Classic DEVICE write; zone `updateGroupState`/`updatePower` spend none | Recorded in CLAUDE.md (driver conventions). |
| 3 | `NoChangesError` now judged against the unit's live state; no `onSyncComplete` after that refusal | No code change (already swallowed); recorded in CLAUDE.md. |
| 4 | Removed exports (`classicUpdateDevice(s)`, `fetchDevices`, `syncDevices` and their `/classic`, `/home` aliases) | Grep confirms zero importers here. |
| 5 | `ValidationError` is now the core's class re-exported | `instanceof` through melcloud-api unchanged; the app holds no direct api-core dependency. |
| 6 | Bare `@syncDevices()` cycle notifies `undefined` instead of `{ type: undefined }` | No change: `#onSync = async ({ ids, type } = {})` already defaults the parameter, and `tests/unit/app.test.ts` already exercises the bare `getSyncCallback()()` call. Recorded in CLAUDE.md. |
| 7 | Run typecheck/lint/test/build | Full suite below. |

Companion docs: CLAUDE.md gains the live-read ledger bullet (driver conventions) and a clause on the app-API bullet that the Classic device leg's `StateReadError` propagates through `updateTargetAtaState` to the ATA group widget like any other write failure (its no-change tolerance still holds — `ClassicDeviceAtaFacade.updateGroupState` still wraps each member write in `tolerateNoChanges`, verified in the 56.0.0 source).

## Consumer-visible effects

- **Fix inherited:** a Classic write no longer re-imposes stale fields another writer (the MELCloud app, an IR remote once reported) changed since the last sync — #1408's vane/setpoint reversions.
- **New failure mode:** when the pre-write read fails, the write is REFUSED (nothing posted, registry untouched) and the device shows the warning above; the ATA group widget's Update surfaces the same error. Previously such a write would have gone out against the snapshot.
- **Rate-limit budget:** one more Classic request per device write.
- `NoChangesError` may now fire for a value the unit already holds even when Homey's last-synced value disagreed — silent, capability catches up at the next sync tick.

## App version / `.homeychangelog.json`

Neither moves, following the precedent of #1637 and #1641 (the 55.2.0 adoption also carried user-visible fixes without a store entry): adoption PRs are the pin; the store release PR (bump + all-locale changelog + `homey:validate`) carries the wording. The next release's entry should mention the vane/setpoint fix and the new "could not read the live state" warning.

## Dependency guard

Exactly one `@olivierzal/api-core` copy; lock resolved from `https://npm.pkg.github.com` with an integrity hash, zero `file:`:

```text
com.melcloud@46.7.1
└─┬ @olivierzal/melcloud-api@56.0.0
  └── @olivierzal/api-core@1.3.0
```

## Gates (explicit exit codes, Node 22.22.2 = `.nvmrc`)

| Gate | Exit |
| --- | --- |
| `npm run format` | 0 |
| `npm run lint` | 0 |
| `npm run typecheck` | 0 |
| `npm run test:coverage` (927 tests / 48 files, +4 from the shared descriptor case; 100 % stmts 2561/2561, branches 1035/1035, funcs 858/858, lines 2530/2530) | 0 |
| `npm run build` | 0 |
| `npm run homey:validate` (level `publish`, no file rewritten) | 0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMCysNQv5KFdV1LZmZaFQy
