### PR TITLE
build: adopt @olivierzal/homey-kit 5.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "46.7.1",
       "license": "GPL-3.0-only",
       "dependencies": {
-        "@olivierzal/homey-kit": "5.2.0",
+        "@olivierzal/homey-kit": "5.2.1",
         "@olivierzal/melcloud-api": "56.0.0",
         "source-map-support": "^0.5.21",
         "temporal-polyfill": "^1.0.4"
@@ -1117,9 +1117,9 @@
       }
     },
     "node_modules/@olivierzal/homey-kit": {
-      "version": "5.2.0",
-      "resolved": "https://npm.pkg.github.com/download/@olivierzal/homey-kit/5.2.0/b04e290d4604f6e7dbdfa4637601a0ea93646343",
-      "integrity": "sha512-gAusr4R2NF7W7tO9hArGENjJC766RCJT6uorvzSWTHpZwLU+RhCaeqw+Er98Iv9PIO+wasgyx2+PwNzeugsBPQ==",
+      "version": "5.2.1",
+      "resolved": "https://npm.pkg.github.com/download/@olivierzal/homey-kit/5.2.1/821c7925dc47d27a263aab079a480e33bf9842e2",
+      "integrity": "sha512-lwvTQGHcQXPjfsVuotxcHEu6i1IR4AMqT90zA/TYPMHhXbyPUZ9Vj9wLS7W53V94MNPPdGpZUUiu7Md7RbiJoQ==",
       "license": "MIT",
       "engines": {
         "node": ">=22.20.0"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "prettier": "@olivierzal/configs/prettier",
   "dependencies": {
-    "@olivierzal/homey-kit": "5.2.0",
+    "@olivierzal/homey-kit": "5.2.1",
     "@olivierzal/melcloud-api": "56.0.0",
     "source-map-support": "^0.5.21",
     "temporal-polyfill": "^1.0.4"


### PR DESCRIPTION
## What

Pin `@olivierzal/homey-kit` 5.2.1 ([release notes](https://github.com/OlivierZal/homey-kit/releases/tag/v5.2.1)): `ManifestDriver.name` admits the plain string the manifest carries. Type-only change in the kit; this app was type-checked against the `npm pack` of the fix before the release (exit 0). The lock resolves 5.2.1 from GitHub Packages with its integrity hash, no `file:` reference.

## Gates

format, lint, typecheck, test:coverage, build — all exit 0 on the published pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMCysNQv5KFdV1LZmZaFQy