### PR TITLE
docs: merge by hand, never auto-merge an authored PR

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -942,6 +942,14 @@ reader fails open with an empty map).
   reasoned reply when it does not — verify claims against sources
   before acting either way (Copilot has been wrong about library
   semantics). Resolve the thread once settled; none left dangling.
+- Auto-merge is never armed on an authored PR (verdict 2026-09-07:
+  api-core #12 had it armed and merged 13 s before Copilot's review
+  landed, leaving two threads on a merged PR, one of them real). A PR
+  merges by hand, on its FINAL head, once three things hold at once:
+  every check SUCCESS or SKIPPED, the Sonar PR window at zero open
+  issues with the gate OK, and every review thread settled. The
+  Dependabot lane (`dependabot.yml` arming `gh pr merge --auto` once CI
+  passes) is the one deliberate exception and stays as documented.
 - SonarCloud must be spotless for a PR to merge — and the quality gate
   passing is necessary, NOT sufficient: the free-tier gate tolerates
   3 % duplication on new code, lets code smells through, and cannot be


### PR DESCRIPTION
## What

Writes the merge rule approved on 2026-09-07 into the process section: auto-merge is never armed on an authored PR (api-core #12 had it armed and merged 13 s before Copilot's review landed, leaving two threads on a merged PR, one of them real). A PR merges by hand, on its final head, once every check is SUCCESS or SKIPPED, the Sonar PR window is at zero open issues with the gate OK, and every review thread is settled. The Dependabot lane (`dependabot.yml` arming `gh pr merge --auto` once CI passes) is named as the one deliberate exception and stays as documented.

Doc-only; the same wording lands in the eight family repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMCysNQv5KFdV1LZmZaFQy