### PR TITLE
docs: tighten the merge rule's wording

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -943,13 +943,14 @@ reader fails open with an empty map).
   before acting either way (Copilot has been wrong about library
   semantics). Resolve the thread once settled; none left dangling.
 - Auto-merge is never armed on an authored PR (verdict 2026-09-07:
-  api-core #12 had it armed and merged 13 s before Copilot's review
-  landed, leaving two threads on a merged PR, one of them real). A PR
-  merges by hand, on its FINAL head, once three things hold at once:
-  every check SUCCESS or SKIPPED, the Sonar PR window at zero open
-  issues with the gate OK, and every review thread settled. The
-  Dependabot lane (`dependabot.yml` arming `gh pr merge --auto` once CI
-  passes) is the one deliberate exception and stays as documented.
+  api-core#12 had it armed and merged 13 s before Copilot's review
+  landed, leaving two threads on a merged PR, one of them real). A PR is
+  merged by hand, on its FINAL head, once three things hold at once:
+  every check is SUCCESS or SKIPPED, the Sonar PR window is at zero open
+  issues with the gate OK, and every review thread is settled. The
+  Dependabot lane (`.github/workflows/dependabot.yml` arming `gh pr
+merge --auto` once CI passes) is the one deliberate exception and
+  stays as documented.
 - SonarCloud must be spotless for a PR to merge — and the quality gate
   passing is necessary, NOT sufficient: the free-tier gate tolerates
   3 % duplication on new code, lets code smells through, and cannot be

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -948,9 +948,9 @@ reader fails open with an empty map).
   merged by hand, on its FINAL head, once three things hold at once:
   every check is SUCCESS or SKIPPED, the Sonar PR window is at zero open
   issues with the gate OK, and every review thread is settled. The
-  Dependabot lane (`.github/workflows/dependabot.yml` arming `gh pr
-merge --auto` once CI passes) is the one deliberate exception and
-  stays as documented.
+  Dependabot lane (`.github/workflows/dependabot.yml` arming
+  `gh pr merge --auto` once CI passes) is the one deliberate exception
+  and stays as documented.
 - SonarCloud must be spotless for a PR to merge — and the quality gate
   passing is necessary, NOT sufficient: the free-tier gate tolerates
   3 % duplication on new code, lets code smells through, and cannot be


### PR DESCRIPTION
## What

Brings the merge rule written today to the family's final wording, the one Copilot's three points across the eight copies asked for: the Dependabot workflow named by its path (`.github/workflows/dependabot.yml` — `.github/dependabot.yml` also exists), verbs in the three conditions, and `api-core#12` in the document's cross-repo reference style. Same text in the eight repos; doc-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMCysNQv5KFdV1LZmZaFQy