### PR TITLE
fix: write an inverted protection range as the range the user typed

### DIFF
--- a/settings/index.mts
+++ b/settings/index.mts
@@ -1715,8 +1715,9 @@ class ZoneSettingsManager {
   }
 
   // Field validation (each bound against its own input range, in the
-  // user's language) is the page's; the pair's clamping — the gap, an
-  // inverted pair — is the library clamp's verdict alone.
+  // user's language) is the page's, and so is the pair's ORDER; the
+  // clamping itself — the range and the gap — is the library clamp's
+  // verdict alone.
   #getMinAndMax(
     minElement: HTMLInputElement,
     maxElement: HTMLInputElement,
@@ -1736,7 +1737,12 @@ class ZoneSettingsManager {
     if (min === null || max === null) {
       throw new Error(errors.join('\n'))
     }
-    return clamp(min, max)
+    // An inverted pair is read as the range the user drew, not as a
+    // low bound of `max`: the library clamp has no notion of order, so
+    // it would answer `{ min, min + gap }` and silently write a range
+    // the user never typed. Ordering first reproduces what the page
+    // did before 46.7.2.
+    return min <= max ? clamp(min, max) : clamp(max, min)
   }
 
   // Read one panel's settings for the selected target. Every target kind

--- a/tests/unit/settings.test.ts
+++ b/tests/unit/settings.test.ts
@@ -1455,10 +1455,11 @@ describe('settings page', () => {
       ]).toStrictEqual(['33', '40'])
     })
 
-    // The pair goes to the library's clampFrostProtection verbatim —
-    // no app-side swap: an inverted pair keeps the typed min and lifts
-    // the max to min + gap, the same verdict a direct SDK call gets.
-    it('should clamp an inverted frost range like the library', async () => {
+    // An inverted pair is the range the user drew, so the page orders
+    // it before handing it to the library clamp. Without that, the
+    // clamp — which has no notion of order — would read 11 as the low
+    // bound and write 11..13, a range nobody typed.
+    it('should write an inverted frost range as the range typed', async () => {
       const harness = await bootPage()
       commit(getInput('min'), '11')
       commit(getInput('max'), '10')
@@ -1470,7 +1471,7 @@ describe('settings page', () => {
           harness,
           'PUT /targets/buildings_1/settings/frost-protection',
         ),
-      ).toStrictEqual({ isEnabled: true, max: 13, min: 11 })
+      ).toStrictEqual({ isEnabled: true, max: 12, min: 10 })
     })
 
     it('should alert an out-of-range frost temperature', async () => {


### PR DESCRIPTION
## What

A regression from the reshape, found by the regression hunt and confirmed by measurement.

`#getMinAndMax` used to order the pair before applying the range and the gap. #1641 replaced that with a raw call to the library's `clampFrostProtection` / `clampOverheatProtection`, which have no notion of order: they read the first argument as the low bound. So an inverted entry now writes a different range than it did through 46.7.1, silently, on a protection setpoint.

| typed | 46.7.1 wrote | 46.7.2 writes | this PR |
|---|---|---|---|
| frost min 12, max 8 | 8..12 | 12..14 | 8..12 |
| frost min 14, max 6 | 6..14 | 14..16 | 6..14 |
| overheat min 38, max 33 | 33..38 | 38..40 | 33..38 |

Measured against the shipped clamp, not inferred.

## The change

One line in `settings/index.mts`: the pair is ordered before it reaches the clamp. The division of labour is now stated where it was wrong: field validation and the pair's **order** are the page's, the range and the gap remain the library clamp's verdict alone.

The suite had pinned the reshape behaviour with a clause reading "no app-side swap"; it now pins what the user gets back.

## Gates

`format`, `lint`, `typecheck`, `test:coverage`, `build` — all exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMCysNQv5KFdV1LZmZaFQy