### PR TITLE
fix: log a write that never reached the wire

### DIFF
--- a/drivers/base-device.mts
+++ b/drivers/base-device.mts
@@ -392,19 +392,21 @@ export abstract class BaseMELCloudDevice<
     return this.thermostatMode !== null && 'off' in this.thermostatMode
   }
 
-  // A write the library folds away leaves no trace on the wire, so it
-  // must leave one in the log: without it a report of "the setting does
-  // not hold" is indistinguishable from a report of "the command never
-  // left Homey", which is exactly the question the 2026-09 reports
-  // could not answer. The refusal stays non-fatal — the user asked for
-  // a state the app already believes the unit holds.
+  // A write that LANDS is already logged by the library's observability
+  // seam (`dataType: 'API request'`, with the full body and
+  // `EffectiveFlags`), so nothing is added here for that case. A write
+  // the library FOLDS AWAY makes no request at all, so that seam has
+  // nothing to log and the only trace left would be the absence of a
+  // request after `Requested data:` — and an absence proves nothing in
+  // a truncated diagnostic report, which is exactly how the 2026-09
+  // reports arrived. The refusal stays non-fatal: the user asked for a
+  // state the app already believes the unit holds.
   async #pushUpdate(
     device: TFacade,
     updateData: Record<string, unknown>,
   ): Promise<void> {
     try {
       await device.updateValues(updateData)
-      this.log('Sent data:', updateData)
     } catch (error) {
       if (error instanceof NoChangesError) {
         this.log('Not sent, identical to the last synced state:', updateData)

--- a/drivers/base-device.mts
+++ b/drivers/base-device.mts
@@ -392,16 +392,25 @@ export abstract class BaseMELCloudDevice<
     return this.thermostatMode !== null && 'off' in this.thermostatMode
   }
 
+  // A write the library folds away leaves no trace on the wire, so it
+  // must leave one in the log: without it a report of "the setting does
+  // not hold" is indistinguishable from a report of "the command never
+  // left Homey", which is exactly the question the 2026-09 reports
+  // could not answer. The refusal stays non-fatal — the user asked for
+  // a state the app already believes the unit holds.
   async #pushUpdate(
     device: TFacade,
     updateData: Record<string, unknown>,
   ): Promise<void> {
     try {
       await device.updateValues(updateData)
+      this.log('Sent data:', updateData)
     } catch (error) {
-      if (!(error instanceof NoChangesError)) {
-        await this.setWarning(error)
+      if (error instanceof NoChangesError) {
+        this.log('Not sent, identical to the last synced state:', updateData)
+        return
       }
+      await this.setWarning(error)
     }
   }
 

--- a/tests/device-descriptors.ts
+++ b/tests/device-descriptors.ts
@@ -86,14 +86,41 @@ export const testSetValuesErrorHandling = (
       expect(superSetWarningMock).toHaveBeenCalledWith('API error')
     })
 
-    it('should ignore NoChangesError', async () => {
+    // A folded-away write must stay non-fatal AND leave a trace: a
+    // command that never reached the wire is otherwise invisible in a
+    // diagnostic report, which is what made the 2026-09 "it does not
+    // hold the setting" reports undiagnosable.
+    it('should log NoChangesError instead of warning', async () => {
       setValuesMock.mockRejectedValue(new NoChangesError(1))
-      await (getDevice() as { onInit: () => Promise<void> }).onInit()
+      const device = getDevice() as {
+        log: (...args: unknown[]) => void
+        onInit: () => Promise<void>
+      }
+      await device.onInit()
       superSetWarningMock.mockClear()
+      const log = vi.spyOn(device, 'log')
       const callback = getCapabilityListenerCallback()
       await callback({ onoff: true })
 
       expect(superSetWarningMock).not.toHaveBeenCalled()
+      expect(log).toHaveBeenCalledWith(
+        'Not sent, identical to the last synced state:',
+        expect.any(Object),
+      )
+    })
+
+    it('should log a write that reached the wire', async () => {
+      setValuesMock.mockResolvedValue({})
+      const device = getDevice() as {
+        log: (...args: unknown[]) => void
+        onInit: () => Promise<void>
+      }
+      await device.onInit()
+      const log = vi.spyOn(device, 'log')
+      const callback = getCapabilityListenerCallback()
+      await callback({ onoff: true })
+
+      expect(log).toHaveBeenCalledWith('Sent data:', expect.any(Object))
     })
 
     it('should set warning for non-Error thrown values', async () => {

--- a/tests/device-descriptors.ts
+++ b/tests/device-descriptors.ts
@@ -86,10 +86,11 @@ export const testSetValuesErrorHandling = (
       expect(superSetWarningMock).toHaveBeenCalledWith('API error')
     })
 
-    // A folded-away write must stay non-fatal AND leave a trace: a
-    // command that never reached the wire is otherwise invisible in a
-    // diagnostic report, which is what made the 2026-09 "it does not
-    // hold the setting" reports undiagnosable.
+    // A folded-away write must stay non-fatal AND leave a trace. A
+    // write that lands needs none: the library's observability seam
+    // logs the request. A folded-away one makes no request, so without
+    // this line the only evidence is an absence — worthless in a
+    // truncated report, which is how the 2026-09 reports arrived.
     it('should log NoChangesError instead of warning', async () => {
       setValuesMock.mockRejectedValue(new NoChangesError(1))
       const device = getDevice() as {
@@ -107,20 +108,6 @@ export const testSetValuesErrorHandling = (
         'Not sent, identical to the last synced state:',
         expect.any(Object),
       )
-    })
-
-    it('should log a write that reached the wire', async () => {
-      setValuesMock.mockResolvedValue({})
-      const device = getDevice() as {
-        log: (...args: unknown[]) => void
-        onInit: () => Promise<void>
-      }
-      await device.onInit()
-      const log = vi.spyOn(device, 'log')
-      const callback = getCapabilityListenerCallback()
-      await callback({ onoff: true })
-
-      expect(log).toHaveBeenCalledWith('Sent data:', expect.any(Object))
     })
 
     it('should set warning for non-Error thrown values', async () => {


### PR DESCRIPTION
## Why

Two reports this week (2026-09-08 on 46.7.2, 2026-09-10 on 46.7.3) say a Classic ATA does not hold the mode it is given. Neither diagnostic log can answer the first question about them — did the command reach the unit? — because one outcome leaves **no trace at all**.

A write that lands is fully logged already: the library's observability seam emits `dataType: 'API request'` with the body and `EffectiveFlags`, then the response. Nothing is added here for that case.

A write the library **folds away** is different. `facade.updateValues` throws `NoChangesError` when the change set matches the last synced state, no request is made, so that seam has nothing to emit — and `#pushUpdate` swallowed the refusal with no log and no warning. The only remaining evidence would be the *absence* of a request after the existing `Requested data:` line, and an absence proves nothing in a truncated report, which is how both reports arrived.

This matters because the refusal is judged against the **snapshot**, which can be up to a sync interval stale: right after a mode change the app believes the unit holds what was asked, so a second attempt inside that window is folded away silently. "It goes back to auto and setting it again does nothing" is what that feels like.

## What

One line, in the one case nothing else can report:

```
Not sent, identical to the last synced state: { … }
```

The refusal stays non-fatal — the user asked for a state the app already believes the unit holds. The shared device descriptor pins the line for all four device suites.

## What this does not claim

It does not fix the reported symptom and does not identify its cause. A code audit of every write path found no autonomous mode writer in the app: the only funnel is the capability listener, plus the group widget's explicit Apply. The reverting actor is still unidentified and most likely MELCloud or the unit. This change is what lets the next report say so.

## Gates

`format`, `lint`, `typecheck`, `test:coverage` (925 tests, 100 % on all four axes), `build` — all exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMCysNQv5KFdV1LZmZaFQy