### PR TITLE
fix: log a write that fails off the HTTP path

### DIFF
--- a/drivers/base-device.mts
+++ b/drivers/base-device.mts
@@ -392,15 +392,19 @@ export abstract class BaseMELCloudDevice<
     return this.thermostatMode !== null && 'off' in this.thermostatMode
   }
 
-  // A write that LANDS is already logged by the library's observability
-  // seam (`dataType: 'API request'`, with the full body and
-  // `EffectiveFlags`), so nothing is added here for that case. A write
-  // the library FOLDS AWAY makes no request at all, so that seam has
-  // nothing to log and the only trace left would be the absence of a
-  // request after `Requested data:` — and an absence proves nothing in
-  // a truncated diagnostic report, which is exactly how the 2026-09
-  // reports arrived. The refusal stays non-fatal: the user asked for a
-  // state the app already believes the unit holds.
+  // The library's observability seam logs a write that LANDS
+  // (`dataType: 'API request'`, full body and `EffectiveFlags`). The two
+  // cases it cannot reach are logged here. A FOLDED write makes no
+  // request, so that seam has nothing to log and the only trace would be
+  // an absence, which proves nothing in a truncated diagnostic report;
+  // the refusal stays non-fatal, the user asked for a state the app
+  // already believes the unit holds. A write that fails OFF the HTTP
+  // path — a timeout, an abort, a DNS failure — reaches no seam either:
+  // the library serialises only an `HttpError`, its transient-retry rung
+  // is installed for GET alone, and `setWarning` is a toast that clears
+  // itself in the same call. Without this line such a write is invisible
+  // everywhere at once — the flow reports success, the tile keeps the
+  // new value, and the unit never moved.
   async #pushUpdate(
     device: TFacade,
     updateData: Record<string, unknown>,
@@ -412,6 +416,7 @@ export abstract class BaseMELCloudDevice<
         this.log('Not sent, identical to the last synced state:', updateData)
         return
       }
+      this.error('Write failed:', updateData, error)
       await this.setWarning(error)
     }
   }

--- a/drivers/base-device.mts
+++ b/drivers/base-device.mts
@@ -393,18 +393,21 @@ export abstract class BaseMELCloudDevice<
   }
 
   // The library's observability seam logs a write that LANDS
-  // (`dataType: 'API request'`, full body and `EffectiveFlags`). The two
-  // cases it cannot reach are logged here. A FOLDED write makes no
-  // request, so that seam has nothing to log and the only trace would be
-  // an absence, which proves nothing in a truncated diagnostic report;
-  // the refusal stays non-fatal, the user asked for a state the app
-  // already believes the unit holds. A write that fails OFF the HTTP
-  // path — a timeout, an abort, a DNS failure — reaches no seam either:
-  // the library serialises only an `HttpError`, its transient-retry rung
+  // (`dataType: 'API request'`, full body and `EffectiveFlags`), and its
+  // error seam logs an `HttpError`. Neither covers the two failures
+  // that matter here. A FOLDED write makes no request at all, so the
+  // only trace would be an absence — worthless in a truncated
+  // diagnostic report; the refusal stays non-fatal, the user asked for
+  // a state the app already believes the unit holds. A failure OFF the
+  // HTTP path — a timeout, an abort, a DNS failure — reaches no seam
+  // either: only an `HttpError` is serialised, the transient-retry rung
   // is installed for GET alone, and `setWarning` is a toast that clears
-  // itself in the same call. Without this line such a write is invisible
+  // its own message in the same call, so such a write is invisible
   // everywhere at once — the flow reports success, the tile keeps the
-  // new value, and the unit never moved.
+  // new value, and the unit never moved. Every failed write is logged
+  // rather than only the two uncovered ones: sorting them would mean
+  // re-deriving the seam's own predicate here, and a duplicated line
+  // for an HTTP failure costs nothing beside a silent one.
   async #pushUpdate(
     device: TFacade,
     updateData: Record<string, unknown>,

--- a/tests/device-descriptors.ts
+++ b/tests/device-descriptors.ts
@@ -119,13 +119,28 @@ export const testSetValuesErrorHandling = (
       expect(superSetWarningMock).toHaveBeenCalledWith('string error')
     })
 
+    // A write that fails off the HTTP path reaches no observability
+    // seam: the library serialises only an `HttpError`, and `setWarning`
+    // clears its own toast in the same call. The error line is the only
+    // trace a diagnostic report can carry, so it is pinned beside the
+    // warning.
     it('should warn when the update rejects with a transport error', async () => {
       setValuesMock.mockRejectedValueOnce(new Error('update failed'))
-      await (getDevice() as { onInit: () => Promise<void> }).onInit()
+      const device = getDevice() as {
+        error: (...args: unknown[]) => void
+        onInit: () => Promise<void>
+      }
+      await device.onInit()
+      const error = vi.spyOn(device, 'error')
       const callback = getCapabilityListenerCallback()
       await callback({ onoff: true })
 
       expect(superSetWarningMock).toHaveBeenCalledWith('update failed')
+      expect(error).toHaveBeenCalledWith(
+        'Write failed:',
+        expect.any(Object),
+        expect.any(Error),
+      )
     })
   })
 }


### PR DESCRIPTION
## What

A device write that rejects with anything other than a non-2xx currently leaves no trace anywhere a diagnostic report can carry.

`#pushUpdate` routes every non-`NoChangesError` failure to `setWarning`, and the override sets the message then clears it in the same call — deliberately, it is a transient toast. The library's own error seam (`SessionAPI.logError`) serialises only an `HttpError`, the transient-retry rung is installed for `GET` alone, and the app subscribes no `onRequestError`. So a timeout, an abort or a DNS failure reaches no sink at all: the Flow reports success, the tile keeps the new value, and the unit never moved.

This is the third case of the same class, after the folded-away write of #1659. The comment above `#pushUpdate` is extended to name both cases the observability seam cannot reach.

## How

One line in the catch, before the warning:

```ts
this.error('Write failed:', updateData, error)
```

`updateData` is wire tags with no credential, and any `HttpError` inside is redacted at construction, so nothing unredacted is added to the log.

## Twin

The same shape exists in `com.heatzy` (`drivers/heatzy/device.mts` `#sendUpdate`) and crosses in the same wave — OlivierZal/com.heatzy#1159. `com.melcloud.extension` does not share it: it writes through homey-api, not through api-core.

## Verification

`format`, `lint`, `typecheck` and `test:coverage` all green by exit code; 925 tests across 48 files, coverage thresholds held. The shared device descriptor's transport-error clause now pins the error line beside the warning, so all four device suites assert it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMCysNQv5KFdV1LZmZaFQy