### PR TITLE
fix: leave a Home capability alone when the wire value has no mapping

### DIFF
--- a/drivers/home-device.mts
+++ b/drivers/home-device.mts
@@ -63,15 +63,33 @@ export abstract class HomeMELCloudDevice<
       : this.driver.getRequiredCapabilities(facade)
   }
 
+  // The library types the Home enums as closed vocabularies but
+  // deliberately passes the wire through unenforced, so a member the
+  // BFF adds or renames reaches a converter that has no entry for it
+  // and yields `undefined`. Writing that into an enum capability is
+  // what the Classic leg's `?? data[tag]` fallback prevents; Home has
+  // no raw tag to fall back on, so the write is skipped and the last
+  // known value stands. `null` is deliberately NOT skipped — it is
+  // Homey's own "unknown", and the ATW zone-2 reads rely on it to
+  // clear a capability on a single-zone unit.
   protected override async syncCapabilityValues(
     device: HomeDeviceFacade<T>,
   ): Promise<void> {
     await Promise.all(
       typedEntries(this.deviceToCapability).map(
         async ([capability, convert]) => {
-          if (this.hasCapability(capability)) {
-            await this.setCapabilityValue(capability, convert(device))
+          if (!this.hasCapability(capability)) {
+            return
           }
+          const value = convert(device)
+          if (value === undefined) {
+            this.error(
+              'Unmapped device value, capability left as is:',
+              capability,
+            )
+            return
+          }
+          await this.setCapabilityValue(capability, value)
         },
       ),
     )

--- a/tests/unit/home-base-device.test.ts
+++ b/tests/unit/home-base-device.test.ts
@@ -288,6 +288,42 @@ describe(BaseMELCloudDevice, () => {
         42,
       )
     })
+
+    // The library types the Home enums as closed vocabularies but passes
+    // the wire through unenforced, so a member the BFF adds or renames
+    // reaches a converter that has no entry for it. `undefined` must
+    // leave the capability alone — Home has no raw tag to fall back on,
+    // unlike the Classic leg.
+    it('should skip the write and report a value it cannot map', async () => {
+      const customDevice = createTestHomeDevice()
+      Object.defineProperty(customDevice, 'deviceToCapability', {
+        value: { measure_temperature: (): undefined => undefined },
+      })
+      const error = vi.spyOn(customDevice, 'error')
+      await customDevice.syncFromDevice()
+
+      expect(customDevice.setCapabilityValue).not.toHaveBeenCalled()
+      expect(error).toHaveBeenCalledWith(
+        'Unmapped device value, capability left as is:',
+        'measure_temperature',
+      )
+    })
+
+    // `null` is Homey's own "unknown" and must keep landing: the ATW
+    // zone-2 reads rely on it to clear a capability on a single-zone
+    // unit, so the skip above tests `undefined` and never nullish.
+    it('should still write a null, which clears the capability', async () => {
+      const customDevice = createTestHomeDevice()
+      Object.defineProperty(customDevice, 'deviceToCapability', {
+        value: { measure_temperature: (): null => null },
+      })
+      await customDevice.syncFromDevice()
+
+      expect(customDevice.setCapabilityValue).toHaveBeenCalledWith(
+        'measure_temperature',
+        null,
+      )
+    })
   })
 
   describe('capability change handling', () => {


### PR DESCRIPTION
## What

The Home read path writes `undefined` into a capability whenever a converter meets a wire value it has no entry for.

`HomeDeviceAtaFacade` types `operationMode`, `vaneHorizontalDirection` and `vaneVerticalDirection` as the closed vocabularies but deliberately does not enforce them — `#enumSetting` is a pass-through, and its comment says so. So a member MELCloud adds or renames reaches `operationModeToClassic[…]`, misses, and the composed read yields `undefined`, which `syncCapabilityValues` hands straight to `setCapabilityValue` on an enum capability.

The Classic leg is guarded twice for exactly this: a presence test (`Object.hasOwn(data, tag)`) and a raw-tag fallback (`?? data[tag]`). Home has neither, and no raw tag to fall back on.

This is the consumer half of the library's own "new vocabulary must never crash a sync" contract, which melcloud-api documents and implements on its side.

## How

`syncCapabilityValues` skips the write when the converter returns `undefined`, and reports the capability so the drift is visible in a diagnostic report. The last known value stands.

The test is `=== undefined`, deliberately **not** nullish: `null` is Homey's own "unknown" and the ATW zone-2 reads rely on it to clear a capability on a single-zone unit. Both halves are pinned.

## Verification

`format`, `lint`, `typecheck` and `test:coverage` all green by exit code; 927 tests across 48 files, coverage thresholds held.

Two new clauses on the Home base device: one asserts the skip plus the report, the other asserts that a `null` still lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMCysNQv5KFdV1LZmZaFQy