### PR TITLE
fix: attribute a zone panel request to the zone it targeted

### DIFF
--- a/settings/index.mts
+++ b/settings/index.mts
@@ -1696,12 +1696,19 @@ class ZoneSettingsManager {
     path,
   }: ZoneSettingDescriptor): Promise<void> {
     await this.#gateFor(id).runBusy(async () => {
+      const target = this.#zone.value
+      let data: MixableZoneSettings
       try {
-        this.#updateZoneMapping(await this.#getZoneSettingData(id, path))
-        display()
+        data = await this.#getZoneSettingData(target, id, path)
       } catch {
         // Non-critical: UI falls back to default values
+        return
       }
+      if (this.#zone.value !== target) {
+        return
+      }
+      this.#updateZoneMapping(target, data)
+      display()
     })
   }
 
@@ -1752,21 +1759,16 @@ class ZoneSettingsManager {
   // Home device all land in the panel's own cache slot. A `null` payload
   // (nothing configured) reads as empty, i.e. default values.
   async #getZoneSettingData(
+    target: string,
     id: ZoneSettingDescriptor['id'],
     path: ZoneSettingDescriptor['path'],
   ): Promise<MixableZoneSettings> {
     return {
       [id]: await homeyApiGet<Mixable<ProtectionState> | null>(
         this.#homey,
-        `${this.#getZoneSettingsBase()}/settings/${path}`,
+        `/targets/${target}/settings/${path}`,
       ),
     }
-  }
-
-  // The picker value IS the targetId of the neutral settings routes:
-  // addressing needs no family branch.
-  #getZoneSettingsBase(): string {
-    return `/targets/${this.#zone.value}`
   }
 
   // PUT one zone-setting panel: refresh the cached zone mapping and
@@ -1777,18 +1779,30 @@ class ZoneSettingsManager {
     zoneSettings: MixableZoneSettings,
   ): Promise<void> {
     await this.#gateFor(id).runBusy(async () => {
+      // The picker stays live across the request, so the zone moves
+      // under it. The target is pinned once, addresses the route, and
+      // everything after the await is dropped when the user has moved
+      // on: the new zone's panel was already repainted by its own
+      // fetch, and rebaselining it against this zone's values would
+      // make a pristine form read as dirty and the wrong values as
+      // saved.
+      const target = this.#zone.value
       try {
         await homeyApiPut<unknown>(
           this.#homey,
-          `${this.#getZoneSettingsBase()}/settings/${path}`,
+          `/targets/${target}/settings/${path}`,
           query,
         )
-        this.#updateZoneMapping(zoneSettings)
-        display()
-        await this.#homey.alert(this.#homey.__('settings.success'))
       } catch (error) {
         await this.#homey.alert(getErrorMessage(error))
+        return
       }
+      if (this.#zone.value !== target) {
+        return
+      }
+      this.#updateZoneMapping(target, zoneSettings)
+      display()
+      await this.#homey.alert(this.#homey.__('settings.success'))
     })
   }
 
@@ -1856,9 +1870,12 @@ class ZoneSettingsManager {
     return false
   }
 
-  #updateZoneMapping(data: MixableZoneSettings): void {
-    const { value } = this.#zone
-    this.#zoneMapping[value] = { ...this.#zoneMapping[value], ...data }
+  // The target is passed in, never re-read: both callers write it after
+  // an await and the picker stays live throughout, so reading it here
+  // would file the answer under whichever zone the user has since
+  // selected.
+  #updateZoneMapping(target: string, data: MixableZoneSettings): void {
+    this.#zoneMapping[target] = { ...this.#zoneMapping[target], ...data }
   }
 }
 

--- a/tests/unit/settings.test.ts
+++ b/tests/unit/settings.test.ts
@@ -1340,6 +1340,87 @@ describe('settings page', () => {
       ])
     })
 
+    // The zone picker is NOT inside the panel fieldset the dirty gate
+    // freezes, so it stays live across a panel request and the zone
+    // moves under it. Anything the landing writes must belong to the
+    // zone the request targeted: cached under the live one it would
+    // hold another zone's values, and rebaselining there would make a
+    // pristine form read as dirty.
+    it('should drop a panel write the user has navigated away from', async () => {
+      const harness = await bootPage()
+      const pending: ApiCallback[] = []
+      const passThrough = apiImplementation({}, defaultRoutes())
+      harness.api.mockImplementation((...callArgs: ApiCallArgs) => {
+        const [method] = callArgs
+        const callback = callArgs.findLast(
+          (argument): argument is ApiCallback => typeof argument === 'function',
+        )
+        if (method === 'PUT' && callback !== undefined) {
+          pending.push(callback)
+          return
+        }
+        passThrough(...callArgs)
+      })
+      commit(getInput('min'), '6')
+      commit(getInput('max'), '10')
+      getButton('apply_frost_protection').click()
+      await settleDetached()
+      commit(getSelect('zones'), 'devices_11')
+      await settleDetached()
+
+      expect(pending).toHaveLength(1)
+
+      for (const landing of pending) {
+        landing(null, undefined)
+      }
+      await settleDetached()
+
+      expect(harness.alert).not.toHaveBeenCalledWith('settings.success')
+    })
+
+    it('should drop a panel read the user has navigated away from', async () => {
+      const harness = await bootPage()
+      const pending: ApiCallback[] = []
+      const passThrough = apiImplementation(
+        {},
+        {
+          ...defaultRoutes(),
+          'GET /targets/devices_11/settings/frost-protection': {
+            isEnabled: true,
+            max: 30,
+            min: 29,
+          },
+        },
+      )
+      harness.api.mockImplementation((...callArgs: ApiCallArgs) => {
+        const [, path] = callArgs
+        const callback = callArgs.findLast(
+          (argument): argument is ApiCallback => typeof argument === 'function',
+        )
+        if (
+          path === '/targets/devices_11/settings/frost-protection' &&
+          callback !== undefined
+        ) {
+          pending.push(callback)
+          return
+        }
+        passThrough(...callArgs)
+      })
+      commit(getSelect('zones'), 'devices_11')
+      await settleDetached()
+      commit(getSelect('zones'), 'buildings_1')
+      await settleDetached()
+
+      expect(pending).toHaveLength(1)
+
+      for (const landing of pending) {
+        landing(null, { isEnabled: true, max: 30, min: 29 })
+      }
+      await settleDetached()
+
+      expect(getInput('min').value).toBe('8')
+    })
+
     it('should fall back to defaults when the panel fetch fails', async () => {
       await bootPage({
         failures: {


### PR DESCRIPTION
## What

A frost-protection / holiday-mode / overheat panel request could be attributed to the wrong zone.

The dirty gate freezes the **panel** fieldset (`fieldsetElements: [getFieldset(`${prefix}_panel`)]`), not the zone picker — so the picker stays live for the whole round trip and the user can move it while a write or a read is in flight. Everything after the await read `this.#zone.value` fresh:

- `#updateZoneMapping` cached the answer under whichever zone was **then** selected;
- `display()` repainted that panel with another zone's values;
- `markSaved()` re-baselined it, so a pristine form reads as dirty afterwards;
- and the URL itself was built by `#getZoneSettingsBase()`, a helper that read the live picker at build time.

MELCloud's settings calls are slow enough for this to be an ordinary interaction, not a stress case: nothing visible happens on Apply, so the user moves on.

## How

The target is pinned once, inside the gated callback, and used for everything: the route, the cache key, the repaint decision. When the picker has moved by the time the request lands, the whole tail is dropped — the new zone's panel was already repainted by its own fetch, and rebaselining it against this zone's values is exactly the damage.

`#getZoneSettingsBase()` is deleted; `#getZoneSettingData` takes the target instead. A live read at URL-build time was the root of the defect, so the shape that allowed it is gone rather than guarded.

The `try` blocks stay at complexity 1 (`unicorn/try-complexity`): the staleness check sits after the block, and each `catch` returns.

## Verification

`format`, `lint`, `typecheck` and `test:coverage` all green by exit code; 929 tests across 48 files, coverage thresholds held.

Two new clauses drive the real race through the page: the API callback is captured rather than answered, the picker is moved, then the callback fires. One covers the write (no success alert, no rebaseline), one the read (the panel keeps the live zone's values).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMCysNQv5KFdV1LZmZaFQy