### PR TITLE
fix: never rewind the energy watermark, and commit it before the total

### DIFF
--- a/drivers/home-report.mts
+++ b/drivers/home-report.mts
@@ -182,9 +182,25 @@ export abstract class HomeEnergyReport<
       cursor !== null && Temporal.Instant.compare(cursor, upTo) < 0
         ? await this.#fetchAccrual(facade, { cursor, measure, upTo })
         : 0
+    // The watermark only ever moves FORWARD. A Homey booting with a
+    // clock still behind — a power cut, an NTP step — computes an
+    // `upTo` in the past, and rewinding to it would have the next run
+    // re-accrue a window already counted. A lifetime meter cannot
+    // unlearn that.
+    const nextCursor =
+      cursor !== null && Temporal.Instant.compare(cursor, upTo) > 0
+        ? cursor
+        : upTo
+    // The watermark is committed BEFORE the total. The two writes
+    // cannot be atomic, and an interruption between them is PERMANENT
+    // either way: this order undercounts by one window, the reverse
+    // overcounts by one. Neither self-heals, so the choice is which
+    // error to prefer — and a meter that invents energy misreports
+    // consumption upward forever, taking Insights and every cost figure
+    // built on it along. Losing a window is the failure worth choosing.
+    await this.#device.setStoreValue(cursorKey(measure), nextCursor.toString())
     const total = storedTotal + accrued
     await this.#device.setStoreValue(totalKey(measure), total)
-    await this.#device.setStoreValue(cursorKey(measure), upTo.toString())
     return total
   }
 

--- a/tests/unit/home-report.test.ts
+++ b/tests/unit/home-report.test.ts
@@ -313,7 +313,38 @@ describe('home energy reports', () => {
         'energy_cursor_consumed',
         '2026-03-18T10:45:00Z',
       )
+      // The watermark is committed BEFORE the total: an interruption
+      // between the two writes is permanent either way, and this order
+      // undercounts by one window where the reverse overcounts.
+      expect(setStoreValueMock.mock.calls.map(([key]) => key)).toStrictEqual([
+        'energy_cursor_consumed',
+        'energy_total_consumed',
+      ])
       expect(setCapabilityValueMock).toHaveBeenCalledWith('meter_power', 1.7)
+    })
+
+    // A Homey booting after a power cut can run with a clock still
+    // behind, which puts `upTo` in the past. Rewinding the watermark
+    // there would have the next run re-accrue a window already counted,
+    // and a lifetime meter cannot unlearn invented energy.
+    it('should keep the watermark when the clock has stepped back', async () => {
+      cleanMappingMock.mockReturnValue({ meter_power: ['consumed'] })
+      getStoreValueMock.mockImplementation((key: string) =>
+        key === 'energy_cursor_consumed' ? '2026-03-18T12:00:00Z' : 1.5,
+      )
+      const getEnergySeriesMock = mockAtaFetch([])
+      const report = new HomeEnergyReportAta(mockDevice(), totalConfig)
+      await report.start()
+
+      expect(getEnergySeriesMock).not.toHaveBeenCalled()
+      expect(setStoreValueMock).toHaveBeenCalledWith(
+        'energy_cursor_consumed',
+        '2026-03-18T12:00:00Z',
+      )
+      expect(setStoreValueMock).toHaveBeenCalledWith(
+        'energy_total_consumed',
+        1.5,
+      )
     })
 
     it('should re-anchor a garbage cursor without accruing', async () => {


### PR DESCRIPTION
## What

Two ways `#accrueTotal` could count a window twice into a lifetime meter.

**The watermark could rewind.** It was written unconditionally from `upTo`, so a Homey booting with a clock still behind — a power cut, an NTP step — moved it to a past instant. The accrual itself was correct in that pass (`compare(cursor, upTo) < 0` is false, nothing is fetched), but the rewound watermark made the *next* run re-accrue from there, over a window already counted. A lifetime meter cannot unlearn that.

**The two writes were in the wrong order.** The total was committed before the watermark, so an interruption between them left the window counted with the watermark still at its start — the next run adds it again.

## How

- `nextCursor` keeps the stored cursor whenever it is already ahead of `upTo`, so the watermark is monotonic.
- The watermark is committed **first**.

On that second point, to be precise about what it buys: the two `setStoreValue` calls cannot be atomic, and an interruption between them is **permanent either way**. This order undercounts by one window; the reverse overcounts by one. Neither self-heals. The choice is which error to prefer, and a meter that invents energy misreports consumption upward forever — Insights and every cost figure built on it inherit that. Losing a window is the failure worth choosing.

## Verification

`format`, `lint`, `typecheck` and `test:coverage` all green by exit code; 928 tests across 48 files, coverage thresholds held.

One new clause: a stored cursor ahead of `upTo` fetches nothing and leaves the watermark where it was. The canonical accrual clause additionally pins the exact key sequence of the `setStoreValue` calls, so swapping the two writes back fails there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMCysNQv5KFdV1LZmZaFQy