### PR TITLE
fix: offer on the ATW cool-flow cards exactly what the capability allows

### DIFF
--- a/.homeycompose/flow/actions/target_temperature.flow_cool_action.json
+++ b/.homeycompose/flow/actions/target_temperature.flow_cool_action.json
@@ -6,8 +6,8 @@
       "type": "device"
     },
     {
-      "max": 30,
-      "min": 10,
+      "max": 25,
+      "min": 5,
       "name": "target_temperature",
       "step": 1,
       "type": "range"

--- a/.homeycompose/flow/actions/target_temperature.flow_cool_zone2_action.json
+++ b/.homeycompose/flow/actions/target_temperature.flow_cool_zone2_action.json
@@ -6,8 +6,8 @@
       "type": "device"
     },
     {
-      "max": 30,
-      "min": 10,
+      "max": 25,
+      "min": 5,
       "name": "target_temperature",
       "step": 1,
       "type": "range"

--- a/app.json
+++ b/app.json
@@ -2686,8 +2686,8 @@
             "type": "device"
           },
           {
-            "max": 30,
-            "min": 10,
+            "max": 25,
+            "min": 5,
             "name": "target_temperature",
             "step": 1,
             "type": "range"
@@ -2733,8 +2733,8 @@
             "type": "device"
           },
           {
-            "max": 30,
-            "min": 10,
+            "max": 25,
+            "min": 5,
             "name": "target_temperature",
             "step": 1,
             "type": "range"

--- a/tests/unit/driver-compose.test.ts
+++ b/tests/unit/driver-compose.test.ts
@@ -40,3 +40,54 @@ describe('ata driver compose twins', () => {
     expect(classic).toBe(home)
   })
 })
+
+// A range flow card offers a slider the user picks from, and the
+// generic run listener forwards that value verbatim to the capability.
+// A card wider than its capability therefore lets a Flow apply a value
+// the tile cannot render and the library silently clamps; a narrower
+// one forbids what the capability allows. Neither the manifest nor
+// homey-lib relates the two, so the agreement is pinned here.
+describe('flow card ranges', () => {
+  it('should offer exactly what the capability declares', async () => {
+    const manifest = JSON.parse(await readFile('app.json', 'utf8')) as {
+      drivers: {
+        id: string
+        capabilitiesOptions?: Record<string, { max?: number; min?: number }>
+      }[]
+      flow?: {
+        actions?: {
+          args?: { type: string; filter?: string; max?: number; min?: number }[]
+        }[]
+      }
+    }
+    const boundsFor = (driverId: string, capability: string): unknown =>
+      manifest.drivers.find(({ id }) => id === driverId)?.capabilitiesOptions?.[
+        capability
+      ]
+    const mismatches = (manifest.flow?.actions ?? []).flatMap((action) => {
+      const range = action.args?.find(({ type }) => type === 'range')
+      const filter = action.args?.find(({ type }) => type === 'device')?.filter
+      if (range === undefined || filter === undefined) {
+        return []
+      }
+      const parameters = new URLSearchParams(filter)
+      const capability = parameters.get('capabilities')
+      if (capability === null) {
+        return []
+      }
+      const driverIds = parameters.get('driver_id')?.split('|') ?? []
+      return driverIds.flatMap((driverId) => {
+        const bounds = boundsFor(driverId, capability) as
+          { max?: number; min?: number } | undefined
+        return bounds === undefined ||
+          (bounds.min === range.min && bounds.max === range.max)
+          ? []
+          : [
+              `${driverId}/${capability}: card ${String(range.min)}-${String(range.max)}, capability ${String(bounds.min)}-${String(bounds.max)}`,
+            ]
+      })
+    })
+
+    expect(mismatches).toStrictEqual([])
+  })
+})


### PR DESCRIPTION
## What

`target_temperature.flow_cool_action` and its zone-2 twin declare a range of **10-30**, while the capability they target declares **5-25** on `melcloud_atw`.

The run listener in `drivers/base-driver.mts` is capability-generic and forwards the card's argument verbatim to `triggerCapabilityListener`, so:

- a Flow built with 26-30 applies a value the device tile cannot render, which Homey paints optimistically and logs to Insights before melcloud-api clamps it to 25;
- and 5-9, which the capability allows, was offered nowhere.

The heat-flow cards (25-60) were already aligned with theirs, and `tank_water` and `zone2` match the defaults template. These two were the only mismatch — I swept all six range cards.

## How

Both cards move to `5`/`25`; `app.json` regenerated through `homey:validate`.

Then the agreement is pinned. Neither the manifest nor homey-lib relates a card's range to its capability's bounds, so this drift had no way of surfacing — which is why it survived. The new clause walks every range card, resolves its capability and owning drivers from the `filter`, and reports each mismatch as `driver/capability: card A-B, capability C-D`.

**The clause was verified to fail before it was kept**: restoring 10-30 makes it report both cards with their exact ranges.

## Not done here

Flows already saved with 26-30 keep their stored argument — Homey does not re-validate them against a narrowed card. Guarding the forwarder against its capability's options would cover that, but it puts a per-call manifest read in a generic listener for a case that self-corrects the next time the user edits the Flow. Worth its own decision rather than riding this one.

## Verification

`format`, `lint`, `typecheck`, `test:coverage` and `homey:validate` all green by exit code; 928 tests across 48 files, coverage thresholds held.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMCysNQv5KFdV1LZmZaFQy